### PR TITLE
feat: Add comprehensive pagination support for Canvas API

### DIFF
--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -12,6 +12,7 @@ use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Exceptions\MissingApiKeyException;
 use CanvasLMS\Exceptions\MissingBaseUrlException;
+use CanvasLMS\Pagination\PaginatedResponse;
 
 /**
  *
@@ -106,6 +107,37 @@ class HttpClient implements HttpClientInterface
     public function delete(string $url, array $options = []): ResponseInterface
     {
         return $this->request('DELETE', $url, $options);
+    }
+
+    /**
+     * Get request with pagination support
+     * @param string $url
+     * @param mixed[] $options
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     * @throws MissingApiKeyException
+     * @throws MissingBaseUrlException
+     */
+    public function getPaginated(string $url, array $options = []): PaginatedResponse
+    {
+        $response = $this->get($url, $options);
+        return new PaginatedResponse($response, $this);
+    }
+
+    /**
+     * Make an HTTP request with pagination support
+     * @param string $method
+     * @param string $url
+     * @param mixed[] $options
+     * @return PaginatedResponse
+     * @throws MissingApiKeyException
+     * @throws MissingBaseUrlException
+     * @throws CanvasApiException
+     */
+    public function requestPaginated(string $method, string $url, array $options = []): PaginatedResponse
+    {
+        $response = $this->request($method, $url, $options);
+        return new PaginatedResponse($response, $this);
     }
 
     /**

--- a/src/Interfaces/HttpClientInterface.php
+++ b/src/Interfaces/HttpClientInterface.php
@@ -3,6 +3,7 @@
 namespace CanvasLMS\Interfaces;
 
 use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginatedResponse;
 use Psr\Http\Message\ResponseInterface;
 
 interface HttpClientInterface
@@ -61,4 +62,23 @@ interface HttpClientInterface
      * @return ResponseInterface
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface;
+
+    /**
+     * Get request with pagination support
+     * @param string $url
+     * @param mixed[] $options
+     * @throws CanvasApiException
+     * @return PaginatedResponse
+     */
+    public function getPaginated(string $url, array $options = []): PaginatedResponse;
+
+    /**
+     * Make a request with pagination support
+     * @param string $method
+     * @param string $url
+     * @param mixed[] $options
+     * @throws CanvasApiException
+     * @return PaginatedResponse
+     */
+    public function requestPaginated(string $method, string $url, array $options = []): PaginatedResponse;
 }

--- a/src/Pagination/LinkHeaderParser.php
+++ b/src/Pagination/LinkHeaderParser.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace CanvasLMS\Pagination;
+
+/**
+ * LinkHeaderParser Class
+ *
+ * Utility class for parsing RFC 5988 Link headers from Canvas API responses.
+ * Canvas API uses Link headers to provide pagination information in the format:
+ *
+ * Link: <https://canvas.example.com/api/v1/courses?page=1&per_page=50>; rel="current",
+ *       <https://canvas.example.com/api/v1/courses?page=2&per_page=50>; rel="next",
+ *       <https://canvas.example.com/api/v1/courses?page=1&per_page=50>; rel="first",
+ *       <https://canvas.example.com/api/v1/courses?page=10&per_page=50>; rel="last"
+ *
+ * Usage:
+ * ```php
+ * $parser = new LinkHeaderParser();
+ * $links = $parser->parse($response->getHeader('Link')[0]);
+ * $nextUrl = $links['next'] ?? null;
+ * ```
+ *
+ * @package CanvasLMS\Pagination
+ */
+class LinkHeaderParser
+{
+    /**
+     * Parse Link header string into associative array
+     *
+     * @param string $linkHeader The Link header string from HTTP response
+     * @return string[] Associative array with rel values as keys and URLs as values
+     */
+    public function parse(string $linkHeader): array
+    {
+        $links = [];
+
+        if (empty($linkHeader)) {
+            return $links;
+        }
+
+        // Split by comma to get individual link entries
+        $linkEntries = explode(',', $linkHeader);
+
+        foreach ($linkEntries as $linkEntry) {
+            $linkEntry = trim($linkEntry);
+
+            // Parse each link entry: <URL>; rel="relation"
+            if (preg_match('/<([^>]+)>;\s*rel="([^"]+)"/', $linkEntry, $matches)) {
+                $url = trim($matches[1]);
+                $rel = trim($matches[2]);
+
+                if (!empty($url) && !empty($rel)) {
+                    $links[$rel] = $url;
+                }
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * Extract specific relation URL from Link header
+     *
+     * @param string $linkHeader The Link header string
+     * @param string $relation The relation to extract (next, prev, first, last, current)
+     * @return string|null The URL for the relation or null if not found
+     */
+    public function extractRelation(string $linkHeader, string $relation): ?string
+    {
+        $links = $this->parse($linkHeader);
+        return $links[$relation] ?? null;
+    }
+
+    /**
+     * Check if Link header contains a specific relation
+     *
+     * @param string $linkHeader The Link header string
+     * @param string $relation The relation to check for
+     * @return bool True if relation exists, false otherwise
+     */
+    public function hasRelation(string $linkHeader, string $relation): bool
+    {
+        $links = $this->parse($linkHeader);
+        return isset($links[$relation]);
+    }
+
+    /**
+     * Get all available relations from Link header
+     *
+     * @param string $linkHeader The Link header string
+     * @return string[] Array of relation names
+     */
+    public function getRelations(string $linkHeader): array
+    {
+        $links = $this->parse($linkHeader);
+        return array_keys($links);
+    }
+
+    /**
+     * Extract page number from a paginated URL
+     *
+     * @param string $url The paginated URL
+     * @return int|null The page number or null if not found
+     */
+    public function extractPageNumber(string $url): ?int
+    {
+        $parsedUrl = parse_url($url);
+
+        if (!isset($parsedUrl['query'])) {
+            return null;
+        }
+
+        parse_str($parsedUrl['query'], $queryParams);
+
+        if (isset($queryParams['page']) && is_numeric($queryParams['page'])) {
+            return (int) $queryParams['page'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract per_page parameter from a paginated URL
+     *
+     * @param string $url The paginated URL
+     * @return int|null The per_page value or null if not found
+     */
+    public function extractPerPage(string $url): ?int
+    {
+        $parsedUrl = parse_url($url);
+
+        if (!isset($parsedUrl['query'])) {
+            return null;
+        }
+
+        parse_str($parsedUrl['query'], $queryParams);
+
+        if (isset($queryParams['per_page']) && is_numeric($queryParams['per_page'])) {
+            return (int) $queryParams['per_page'];
+        }
+
+        return null;
+    }
+}

--- a/src/Pagination/PaginatedResponse.php
+++ b/src/Pagination/PaginatedResponse.php
@@ -1,0 +1,421 @@
+<?php
+
+namespace CanvasLMS\Pagination;
+
+use Psr\Http\Message\ResponseInterface;
+use CanvasLMS\Interfaces\HttpClientInterface;
+
+/**
+ * PaginatedResponse Class
+ *
+ * Wrapper class for HTTP responses that provides pagination functionality.
+ * This class encapsulates an HTTP response and provides methods to navigate
+ * through paginated results using Canvas API Link headers.
+ *
+ * Usage:
+ * ```php
+ * $response = $httpClient->get('/api/v1/courses');
+ * $paginatedResponse = new PaginatedResponse($response, $httpClient);
+ *
+ * $result = $paginatedResponse->toPaginationResult($courses);
+ *
+ * if ($paginatedResponse->hasNext()) {
+ *     $nextResponse = $paginatedResponse->getNext();
+ * }
+ * ```
+ *
+ * @package CanvasLMS\Pagination
+ */
+class PaginatedResponse
+{
+    /**
+     * The HTTP response
+     * @var ResponseInterface
+     */
+    private ResponseInterface $response;
+
+    /**
+     * HTTP client for making additional requests
+     * @var HttpClientInterface
+     */
+    private HttpClientInterface $httpClient;
+
+    /**
+     * Link header parser instance
+     * @var LinkHeaderParser
+     */
+    private LinkHeaderParser $linkParser;
+
+    /**
+     * Parsed Link header navigation URLs
+     * @var string[]
+     */
+    private array $navigationUrls;
+
+    /**
+     * Cached Link header string
+     * @var string|null
+     */
+    private ?string $linkHeader = null;
+
+    /**
+     * PaginatedResponse constructor
+     *
+     * @param ResponseInterface $response The HTTP response
+     * @param HttpClientInterface $httpClient HTTP client for additional requests
+     */
+    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient)
+    {
+        $this->response = $response;
+        $this->httpClient = $httpClient;
+        $this->linkParser = new LinkHeaderParser();
+        $this->navigationUrls = $this->parseLinkHeader();
+    }
+
+    /**
+     * Get the underlying HTTP response
+     *
+     * @return ResponseInterface
+     */
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
+
+    /**
+     * Get the response body as string
+     *
+     * @return string
+     */
+    public function getBody(): string
+    {
+        return $this->response->getBody()->getContents();
+    }
+
+    /**
+     * Get the response body as decoded JSON array
+     *
+     * @return mixed[]
+     */
+    public function getJsonData(): array
+    {
+        $body = $this->getBody();
+        $data = json_decode($body, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * Get the Link header from the response
+     *
+     * @return string
+     */
+    public function getLinkHeader(): string
+    {
+        if ($this->linkHeader === null) {
+            $linkHeaders = $this->response->getHeader('Link');
+            $this->linkHeader = $linkHeaders[0] ?? '';
+        }
+
+        return $this->linkHeader;
+    }
+
+    /**
+     * Parse Link header and extract navigation URLs
+     *
+     * @return string[]
+     */
+    private function parseLinkHeader(): array
+    {
+        $linkHeader = $this->getLinkHeader();
+        return $this->linkParser->parse($linkHeader);
+    }
+
+    /**
+     * Get all navigation URLs
+     *
+     * @return string[]
+     */
+    public function getNavigationUrls(): array
+    {
+        return $this->navigationUrls;
+    }
+
+    /**
+     * Get URL for specific relation
+     *
+     * @param string $relation The relation (next, prev, first, last, current)
+     * @return string|null
+     */
+    public function getUrl(string $relation): ?string
+    {
+        return $this->navigationUrls[$relation] ?? null;
+    }
+
+    /**
+     * Get the next page URL
+     *
+     * @return string|null
+     */
+    public function getNextUrl(): ?string
+    {
+        return $this->getUrl('next');
+    }
+
+    /**
+     * Get the previous page URL
+     *
+     * @return string|null
+     */
+    public function getPrevUrl(): ?string
+    {
+        return $this->getUrl('prev');
+    }
+
+    /**
+     * Get the first page URL
+     *
+     * @return string|null
+     */
+    public function getFirstUrl(): ?string
+    {
+        return $this->getUrl('first');
+    }
+
+    /**
+     * Get the last page URL
+     *
+     * @return string|null
+     */
+    public function getLastUrl(): ?string
+    {
+        return $this->getUrl('last');
+    }
+
+    /**
+     * Get the current page URL
+     *
+     * @return string|null
+     */
+    public function getCurrentUrl(): ?string
+    {
+        return $this->getUrl('current');
+    }
+
+    /**
+     * Check if there is a next page
+     *
+     * @return bool
+     */
+    public function hasNext(): bool
+    {
+        return $this->getNextUrl() !== null;
+    }
+
+    /**
+     * Check if there is a previous page
+     *
+     * @return bool
+     */
+    public function hasPrev(): bool
+    {
+        return $this->getPrevUrl() !== null;
+    }
+
+    /**
+     * Check if relation exists in Link header
+     *
+     * @param string $relation The relation to check
+     * @return bool
+     */
+    public function hasRelation(string $relation): bool
+    {
+        return isset($this->navigationUrls[$relation]);
+    }
+
+    /**
+     * Get the current page number
+     *
+     * @return int
+     */
+    public function getCurrentPage(): int
+    {
+        $currentUrl = $this->getCurrentUrl();
+        if ($currentUrl) {
+            return $this->linkParser->extractPageNumber($currentUrl) ?? 1;
+        }
+
+        return 1;
+    }
+
+    /**
+     * Get the total number of pages
+     *
+     * @return int|null
+     */
+    public function getTotalPages(): ?int
+    {
+        $lastUrl = $this->getLastUrl();
+        if ($lastUrl) {
+            return $this->linkParser->extractPageNumber($lastUrl);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the per_page parameter
+     *
+     * @return int|null
+     */
+    public function getPerPage(): ?int
+    {
+        // Try to extract from any available URL
+        foreach ($this->navigationUrls as $url) {
+            $perPage = $this->linkParser->extractPerPage($url);
+            if ($perPage !== null) {
+                return $perPage;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Fetch the next page
+     *
+     * @return self|null
+     */
+    public function getNext(): ?self
+    {
+        $nextUrl = $this->getNextUrl();
+        if (!$nextUrl) {
+            return null;
+        }
+
+        return $this->fetchUrl($nextUrl);
+    }
+
+    /**
+     * Fetch the previous page
+     *
+     * @return self|null
+     */
+    public function getPrev(): ?self
+    {
+        $prevUrl = $this->getPrevUrl();
+        if (!$prevUrl) {
+            return null;
+        }
+
+        return $this->fetchUrl($prevUrl);
+    }
+
+    /**
+     * Fetch the first page
+     *
+     * @return self|null
+     */
+    public function getFirst(): ?self
+    {
+        $firstUrl = $this->getFirstUrl();
+        if (!$firstUrl) {
+            return null;
+        }
+
+        return $this->fetchUrl($firstUrl);
+    }
+
+    /**
+     * Fetch the last page
+     *
+     * @return self|null
+     */
+    public function getLast(): ?self
+    {
+        $lastUrl = $this->getLastUrl();
+        if (!$lastUrl) {
+            return null;
+        }
+
+        return $this->fetchUrl($lastUrl);
+    }
+
+    /**
+     * Fetch a specific page by URL
+     *
+     * @param string $url The URL to fetch
+     * @return self|null
+     */
+    private function fetchUrl(string $url): ?self
+    {
+        try {
+            // Extract path from full URL for the HTTP client
+            $parsedUrl = parse_url($url);
+            $path = $parsedUrl['path'] ?? '';
+
+            // Remove API base path if present
+            $path = preg_replace('/^\/api\/v\d+/', '', $path);
+
+            // Add query parameters
+            $options = [];
+            if (isset($parsedUrl['query'])) {
+                parse_str($parsedUrl['query'], $queryParams);
+                $options['query'] = $queryParams;
+            }
+
+            $response = $this->httpClient->get($path, $options);
+            return new self($response, $this->httpClient);
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Convert to PaginationResult
+     *
+     * @param mixed[] $data The decoded response data
+     * @return PaginationResult
+     */
+    public function toPaginationResult(array $data): PaginationResult
+    {
+        return PaginationResult::fromLinkHeader($data, $this->getLinkHeader());
+    }
+
+    /**
+     * Fetch all pages starting from current page
+     *
+     * @return mixed[] Array containing all data from all pages
+     */
+    public function fetchAllPages(): array
+    {
+        $allData = [];
+        $currentResponse = $this;
+
+        do {
+            $data = $currentResponse->getJsonData();
+            $allData = array_merge($allData, $data);
+
+            $currentResponse = $currentResponse->getNext();
+        } while ($currentResponse !== null);
+
+        return $allData;
+    }
+
+    /**
+     * Get pagination summary information
+     *
+     * @return mixed[]
+     */
+    public function getPaginationInfo(): array
+    {
+        return [
+            'current_page' => $this->getCurrentPage(),
+            'total_pages' => $this->getTotalPages(),
+            'per_page' => $this->getPerPage(),
+            'has_next' => $this->hasNext(),
+            'has_prev' => $this->hasPrev(),
+            'navigation_urls' => $this->getNavigationUrls(),
+        ];
+    }
+}

--- a/src/Pagination/PaginationResult.php
+++ b/src/Pagination/PaginationResult.php
@@ -1,0 +1,365 @@
+<?php
+
+namespace CanvasLMS\Pagination;
+
+/**
+ * PaginationResult Class
+ *
+ * Wrapper class for paginated API responses that provides access to data and pagination metadata.
+ * This class encapsulates the results of a paginated API call along with navigation links and
+ * metadata extracted from Canvas API Link headers.
+ *
+ * Usage:
+ * ```php
+ * $result = Course::fetchAllPaginated(['per_page' => 50]);
+ * $courses = $result->getData();
+ *
+ * if ($result->hasNext()) {
+ *     $nextResult = $result->getNext();
+ * }
+ *
+ * echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
+ * ```
+ *
+ * @package CanvasLMS\Pagination
+ */
+class PaginationResult
+{
+    /**
+     * The actual data from the API response
+     * @var mixed[]
+     */
+    private array $data;
+
+    /**
+     * URL for the next page of results
+     * @var string|null
+     */
+    private ?string $nextUrl;
+
+    /**
+     * URL for the previous page of results
+     * @var string|null
+     */
+    private ?string $prevUrl;
+
+    /**
+     * URL for the first page of results
+     * @var string|null
+     */
+    private ?string $firstUrl;
+
+    /**
+     * URL for the last page of results
+     * @var string|null
+     */
+    private ?string $lastUrl;
+
+    /**
+     * URL for the current page of results
+     * @var string|null
+     */
+    private ?string $currentUrl;
+
+    /**
+     * Current page number
+     * @var int
+     */
+    private int $currentPage;
+
+    /**
+     * Total number of pages (if determinable)
+     * @var int|null
+     */
+    private ?int $totalPages;
+
+    /**
+     * Number of items per page
+     * @var int|null
+     */
+    private ?int $perPage;
+
+
+    /**
+     * PaginationResult constructor
+     *
+     * @param mixed[] $data The API response data
+     * @param string[] $navigationLinks Associative array of navigation URLs
+     * @param int $currentPage Current page number
+     * @param int|null $totalPages Total number of pages
+     * @param int|null $perPage Items per page
+     */
+    public function __construct(
+        array $data,
+        array $navigationLinks = [],
+        int $currentPage = 1,
+        ?int $totalPages = null,
+        ?int $perPage = null
+    ) {
+        $this->data = $data;
+        $this->nextUrl = $navigationLinks['next'] ?? null;
+        $this->prevUrl = $navigationLinks['prev'] ?? null;
+        $this->firstUrl = $navigationLinks['first'] ?? null;
+        $this->lastUrl = $navigationLinks['last'] ?? null;
+        $this->currentUrl = $navigationLinks['current'] ?? null;
+        $this->currentPage = $currentPage;
+        $this->totalPages = $totalPages;
+        $this->perPage = $perPage;
+    }
+
+    /**
+     * Create PaginationResult from Link header
+     *
+     * @param mixed[] $data The API response data
+     * @param string $linkHeader The Link header string
+     * @return self
+     */
+    public static function fromLinkHeader(array $data, string $linkHeader): self
+    {
+        $parser = new LinkHeaderParser();
+        $links = $parser->parse($linkHeader);
+
+        // Extract current page from current URL or default to 1
+        $currentPage = 1;
+        if (isset($links['current'])) {
+            $currentPage = $parser->extractPageNumber($links['current']) ?? 1;
+        }
+
+        // Extract total pages from last URL if available
+        $totalPages = null;
+        if (isset($links['last'])) {
+            $totalPages = $parser->extractPageNumber($links['last']);
+        }
+
+        // Extract per_page from any available URL
+        $perPage = null;
+        foreach ($links as $url) {
+            $perPage = $parser->extractPerPage($url);
+            if ($perPage !== null) {
+                break;
+            }
+        }
+
+        return new self($data, $links, $currentPage, $totalPages, $perPage);
+    }
+
+    /**
+     * Get the data from the API response
+     *
+     * @return mixed[]
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * Get the URL for the next page
+     *
+     * @return string|null
+     */
+    public function getNextUrl(): ?string
+    {
+        return $this->nextUrl;
+    }
+
+    /**
+     * Get the URL for the previous page
+     *
+     * @return string|null
+     */
+    public function getPrevUrl(): ?string
+    {
+        return $this->prevUrl;
+    }
+
+    /**
+     * Get the URL for the first page
+     *
+     * @return string|null
+     */
+    public function getFirstUrl(): ?string
+    {
+        return $this->firstUrl;
+    }
+
+    /**
+     * Get the URL for the last page
+     *
+     * @return string|null
+     */
+    public function getLastUrl(): ?string
+    {
+        return $this->lastUrl;
+    }
+
+    /**
+     * Get the URL for the current page
+     *
+     * @return string|null
+     */
+    public function getCurrentUrl(): ?string
+    {
+        return $this->currentUrl;
+    }
+
+    /**
+     * Get the current page number
+     *
+     * @return int
+     */
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * Get the total number of pages
+     *
+     * @return int|null
+     */
+    public function getTotalPages(): ?int
+    {
+        return $this->totalPages;
+    }
+
+    /**
+     * Get the number of items per page
+     *
+     * @return int|null
+     */
+    public function getPerPage(): ?int
+    {
+        return $this->perPage;
+    }
+
+    /**
+     * Check if there are more pages available
+     *
+     * @return bool
+     */
+    public function hasMore(): bool
+    {
+        return $this->hasNext();
+    }
+
+    /**
+     * Check if there is a next page
+     *
+     * @return bool
+     */
+    public function hasNext(): bool
+    {
+        return $this->nextUrl !== null;
+    }
+
+    /**
+     * Check if there is a previous page
+     *
+     * @return bool
+     */
+    public function hasPrev(): bool
+    {
+        return $this->prevUrl !== null;
+    }
+
+    /**
+     * Check if this is the first page
+     *
+     * @return bool
+     */
+    public function isFirstPage(): bool
+    {
+        return $this->currentPage === 1;
+    }
+
+    /**
+     * Check if this is the last page
+     *
+     * @return bool
+     */
+    public function isLastPage(): bool
+    {
+        if ($this->totalPages === null) {
+            return !$this->hasNext();
+        }
+
+        return $this->currentPage === $this->totalPages;
+    }
+
+    /**
+     * Get the number of items in the current page
+     *
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return count($this->data);
+    }
+
+    /**
+     * Check if the current page is empty
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->data);
+    }
+
+    /**
+     * Get pagination summary string
+     *
+     * @return string
+     */
+    public function getSummary(): string
+    {
+        $count = $this->getCount();
+        $page = $this->getCurrentPage();
+
+        if ($this->totalPages !== null) {
+            return "Page {$page} of {$this->totalPages} ({$count} items)";
+        }
+
+        return "Page {$page} ({$count} items)";
+    }
+
+    /**
+     * Get all navigation URLs
+     *
+     * @return string[]
+     */
+    public function getNavigationUrls(): array
+    {
+        return array_filter([
+            'first' => $this->firstUrl,
+            'prev' => $this->prevUrl,
+            'current' => $this->currentUrl,
+            'next' => $this->nextUrl,
+            'last' => $this->lastUrl,
+        ]);
+    }
+
+    /**
+     * Convert to array representation
+     *
+     * @return mixed[]
+     */
+    public function toArray(): array
+    {
+        return [
+            'data' => $this->data,
+            'pagination' => [
+                'current_page' => $this->currentPage,
+                'total_pages' => $this->totalPages,
+                'per_page' => $this->perPage,
+                'count' => $this->getCount(),
+                'has_next' => $this->hasNext(),
+                'has_prev' => $this->hasPrev(),
+                'is_first_page' => $this->isFirstPage(),
+                'is_last_page' => $this->isLastPage(),
+                'navigation_urls' => $this->getNavigationUrls(),
+            ],
+        ];
+    }
+}

--- a/tests/Api/AbstractBaseApiTest.php
+++ b/tests/Api/AbstractBaseApiTest.php
@@ -1,0 +1,390 @@
+<?php
+
+namespace Tests\Api;
+
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * AbstractBaseApiTest Class
+ *
+ * Test cases for AbstractBaseApi pagination functionality including:
+ * - Helper methods for pagination
+ * - PaginatedResponse integration
+ * - Model conversion from paginated responses
+ * - Backward compatibility with existing methods
+ */
+class AbstractBaseApiTest extends TestCase
+{
+    /**
+     * Concrete implementation of AbstractBaseApi for testing
+     */
+    private string $testApiClass;
+
+    /**
+     * Mock HTTP client
+     */
+    private HttpClientInterface $mockHttpClient;
+
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        // Create a concrete test class that extends AbstractBaseApi
+        $this->testApiClass = $this->createTestApiClass();
+        
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $this->testApiClass::setApiClient($this->mockHttpClient);
+    }
+
+    /**
+     * Create a concrete test class that extends AbstractBaseApi
+     */
+    private function createTestApiClass(): string
+    {
+        $className = 'TestApi' . uniqid();
+        
+        eval("
+            class {$className} extends \\CanvasLMS\\Api\\AbstractBaseApi
+            {
+                public \$id;
+                public \$name;
+                
+                public static function find(int \$id): self
+                {
+                    return new self(['id' => \$id, 'name' => 'Test Item']);
+                }
+                
+                public static function fetchAll(array \$params = []): array
+                {
+                    return [
+                        new self(['id' => 1, 'name' => 'Test Item 1']),
+                        new self(['id' => 2, 'name' => 'Test Item 2']),
+                    ];
+                }
+                
+                public static function testGetPaginatedResponse(string \$endpoint, array \$params = []): \\CanvasLMS\\Pagination\\PaginatedResponse
+                {
+                    return parent::getPaginatedResponse(\$endpoint, \$params);
+                }
+                
+                public static function testConvertPaginatedResponseToModels(\\CanvasLMS\\Pagination\\PaginatedResponse \$paginatedResponse): array
+                {
+                    return parent::convertPaginatedResponseToModels(\$paginatedResponse);
+                }
+                
+                public static function testFetchAllPagesAsModels(string \$endpoint, array \$params = []): array
+                {
+                    return parent::fetchAllPagesAsModels(\$endpoint, \$params);
+                }
+                
+                public static function testCreatePaginationResult(\\CanvasLMS\\Pagination\\PaginatedResponse \$paginatedResponse): \\CanvasLMS\\Pagination\\PaginationResult
+                {
+                    return parent::createPaginationResult(\$paginatedResponse);
+                }
+            }
+        ");
+        
+        return $className;
+    }
+
+    /**
+     * Test getPaginatedResponse method
+     */
+    public function testGetPaginatedResponse(): void
+    {
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('/test/endpoint', ['query' => ['per_page' => 10]])
+            ->willReturn($mockPaginatedResponse);
+
+        $result = $this->testApiClass::testGetPaginatedResponse('/test/endpoint', ['per_page' => 10]);
+
+        $this->assertSame($mockPaginatedResponse, $result);
+    }
+
+    /**
+     * Test convertPaginatedResponseToModels method
+     */
+    public function testConvertPaginatedResponseToModels(): void
+    {
+        $responseData = [
+            ['id' => 1, 'name' => 'Item 1'],
+            ['id' => 2, 'name' => 'Item 2'],
+            ['id' => 3, 'name' => 'Item 3'],
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+
+        $models = $this->testApiClass::testConvertPaginatedResponseToModels($mockPaginatedResponse);
+
+        $this->assertIsArray($models);
+        $this->assertCount(3, $models);
+        
+        foreach ($models as $index => $model) {
+            $this->assertInstanceOf($this->testApiClass, $model);
+            $this->assertEquals($responseData[$index]['id'], $model->id);
+            $this->assertEquals($responseData[$index]['name'], $model->name);
+        }
+    }
+
+    /**
+     * Test fetchAllPagesAsModels method
+     */
+    public function testFetchAllPagesAsModels(): void
+    {
+        $allPagesData = [
+            ['id' => 1, 'name' => 'Item 1'],
+            ['id' => 2, 'name' => 'Item 2'],
+            ['id' => 3, 'name' => 'Item 3'],
+            ['id' => 4, 'name' => 'Item 4'],
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($allPagesData);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('/test/endpoint', ['query' => ['per_page' => 50]])
+            ->willReturn($mockPaginatedResponse);
+
+        $models = $this->testApiClass::testFetchAllPagesAsModels('/test/endpoint', ['per_page' => 50]);
+
+        $this->assertIsArray($models);
+        $this->assertCount(4, $models);
+        
+        foreach ($models as $index => $model) {
+            $this->assertInstanceOf($this->testApiClass, $model);
+            $this->assertEquals($allPagesData[$index]['id'], $model->id);
+            $this->assertEquals($allPagesData[$index]['name'], $model->name);
+        }
+    }
+
+    /**
+     * Test createPaginationResult method
+     */
+    public function testCreatePaginationResult(): void
+    {
+        $responseData = [
+            ['id' => 1, 'name' => 'Item 1'],
+            ['id' => 2, 'name' => 'Item 2'],
+        ];
+
+        $mockPaginationResult = $this->createMock(PaginationResult::class);
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+
+        $mockPaginatedResponse->expects($this->once())
+            ->method('toPaginationResult')
+            ->with($this->callback(function ($models) use ($responseData) {
+                // Verify that models are correctly created
+                $this->assertIsArray($models);
+                $this->assertCount(2, $models);
+                
+                foreach ($models as $index => $model) {
+                    $this->assertInstanceOf($this->testApiClass, $model);
+                    $this->assertEquals($responseData[$index]['id'], $model->id);
+                    $this->assertEquals($responseData[$index]['name'], $model->name);
+                }
+                
+                return true;
+            }))
+            ->willReturn($mockPaginationResult);
+
+        $result = $this->testApiClass::testCreatePaginationResult($mockPaginatedResponse);
+
+        $this->assertSame($mockPaginationResult, $result);
+    }
+
+    /**
+     * Test method aliases work correctly
+     */
+    public function testMethodAliases(): void
+    {
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        
+        // Test that aliases are registered
+        $aliases = $this->getMethodAliases();
+        
+        $this->assertArrayHasKey('fetchAll', $aliases);
+        $this->assertArrayHasKey('find', $aliases);
+        $this->assertArrayHasKey('fetchAllPaginated', $aliases);
+        $this->assertArrayHasKey('fetchAllPages', $aliases);
+        $this->assertArrayHasKey('fetchPage', $aliases);
+        
+        // Test specific alias mappings
+        $this->assertEquals(['all', 'get', 'getAll'], $aliases['fetchAll']);
+        $this->assertEquals(['one', 'getOne'], $aliases['find']);
+        $this->assertEquals(['allPaginated', 'getPaginated'], $aliases['fetchAllPaginated']);
+        $this->assertEquals(['allPages', 'getPages'], $aliases['fetchAllPages']);
+        $this->assertEquals(['page', 'getPage'], $aliases['fetchPage']);
+    }
+
+    /**
+     * Test backward compatibility - existing methods should still work
+     */
+    public function testBackwardCompatibility(): void
+    {
+        // Create a test class that implements fetchAll like existing API classes
+        $testClass = $this->createTestApiClassWithFetchAll();
+        
+        $mockResponse = $this->createMock(ResponseInterface::class);
+        $mockStream = $this->createMock(StreamInterface::class);
+        
+        $responseData = [
+            ['id' => 1, 'name' => 'Item 1'],
+            ['id' => 2, 'name' => 'Item 2'],
+        ];
+        
+        $mockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn(json_encode($responseData));
+            
+        $mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($mockStream);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/test', ['query' => ['per_page' => 10]])
+            ->willReturn($mockResponse);
+
+        $testClass::setApiClient($this->mockHttpClient);
+        $result = $testClass::fetchAll(['per_page' => 10]);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        
+        foreach ($result as $index => $model) {
+            $this->assertInstanceOf($testClass, $model);
+            $this->assertEquals($responseData[$index]['id'], $model->id);
+            $this->assertEquals($responseData[$index]['name'], $model->name);
+        }
+    }
+
+    /**
+     * Create a test class that implements fetchAll like existing API classes
+     */
+    private function createTestApiClassWithFetchAll(): string
+    {
+        $className = 'TestApiWithFetchAll' . uniqid();
+        
+        eval("
+            class {$className} extends \\CanvasLMS\\Api\\AbstractBaseApi
+            {
+                public \$id;
+                public \$name;
+                
+                public static function find(int \$id): self
+                {
+                    return new self(['id' => \$id, 'name' => 'Test Item']);
+                }
+                
+                public static function fetchAll(array \$params = []): array
+                {
+                    self::checkApiClient();
+                    
+                    \$response = self::\$apiClient->get('/test', ['query' => \$params]);
+                    \$data = json_decode(\$response->getBody()->getContents(), true);
+                    
+                    return array_map(function (\$item) {
+                        return new self(\$item);
+                    }, \$data);
+                }
+            }
+        ");
+        
+        return $className;
+    }
+
+    /**
+     * Helper method to access method aliases
+     */
+    private function getMethodAliases(): array
+    {
+        $reflection = new \ReflectionClass($this->testApiClass);
+        $property = $reflection->getProperty('methodAliases');
+        $property->setAccessible(true);
+        
+        return $property->getValue();
+    }
+
+    /**
+     * Test that invalid method calls throw appropriate exceptions
+     */
+    public function testInvalidMethodCallThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Method invalidMethod does not exist');
+        
+        $this->testApiClass::invalidMethod();
+    }
+
+    /**
+     * Test that constructor properly sets properties
+     */
+    public function testConstructorSetsProperties(): void
+    {
+        $data = [
+            'id' => 123,
+            'name' => 'Test Name',
+            'non_existent_property' => 'should be ignored'
+        ];
+        
+        $instance = new $this->testApiClass($data);
+        
+        $this->assertEquals(123, $instance->id);
+        $this->assertEquals('Test Name', $instance->name);
+        $this->assertFalse(property_exists($instance, 'non_existent_property'));
+    }
+
+    /**
+     * Test that snake_case properties are converted to camelCase
+     */
+    public function testSnakeCaseToCarmelCaseConversion(): void
+    {
+        // Create a test class with camelCase property
+        $className = 'TestApiCamelCase' . uniqid();
+        
+        eval("
+            class {$className} extends \\CanvasLMS\\Api\\AbstractBaseApi
+            {
+                public \$someProperty;
+                
+                public static function find(int \$id): self
+                {
+                    return new self(['id' => \$id]);
+                }
+                
+                public static function fetchAll(array \$params = []): array
+                {
+                    return [];
+                }
+            }
+        ");
+        
+        $data = [
+            'some_property' => 'test value'
+        ];
+        
+        $instance = new $className($data);
+        
+        $this->assertEquals('test value', $instance->someProperty);
+    }
+}

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Psr7\Response;
 use CanvasLMS\Http\HttpClient;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Handler\MockHandler;
+use CanvasLMS\Pagination\PaginatedResponse;
 
 class HttpClientTest extends TestCase
 {
@@ -105,6 +106,132 @@ class HttpClientTest extends TestCase
         $response = $this->httpClient->delete('/endpoint');
 
         // Assert status code and body of the response
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('body content', $response->getBody()->getContents());
+    }
+
+    public function testGetPaginatedRequestWithSuccessfulResponse()
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="prev", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="first", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=5&per_page=10>; rel="last", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="current"';
+
+        $responseData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2'],
+        ];
+
+        // Create a mock and queue responses
+        $mock = new MockHandler([
+            new Response(200, ['Link' => $linkHeader], json_encode($responseData)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $guzzleClient = new Client(['handler' => $handlerStack]);
+
+        // Create an instance of HttpClient with mocked dependencies
+        $this->httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        // Call the getPaginated method
+        $paginatedResponse = $this->httpClient->getPaginated('/courses');
+
+        // Assert the response is a PaginatedResponse
+        $this->assertInstanceOf(PaginatedResponse::class, $paginatedResponse);
+        $this->assertEquals($linkHeader, $paginatedResponse->getLinkHeader());
+        $this->assertEquals($responseData, $paginatedResponse->getJsonData());
+        $this->assertEquals(2, $paginatedResponse->getCurrentPage());
+        $this->assertEquals(5, $paginatedResponse->getTotalPages());
+        $this->assertEquals(10, $paginatedResponse->getPerPage());
+        $this->assertTrue($paginatedResponse->hasNext());
+        $this->assertTrue($paginatedResponse->hasPrev());
+    }
+
+    public function testGetPaginatedRequestWithoutLinkHeader()
+    {
+        $responseData = [
+            ['id' => 1, 'name' => 'Course 1'],
+        ];
+
+        // Create a mock and queue responses
+        $mock = new MockHandler([
+            new Response(200, [], json_encode($responseData)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $guzzleClient = new Client(['handler' => $handlerStack]);
+
+        // Create an instance of HttpClient with mocked dependencies
+        $this->httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        // Call the getPaginated method
+        $paginatedResponse = $this->httpClient->getPaginated('/courses');
+
+        // Assert the response is a PaginatedResponse
+        $this->assertInstanceOf(PaginatedResponse::class, $paginatedResponse);
+        $this->assertEquals('', $paginatedResponse->getLinkHeader());
+        $this->assertEquals($responseData, $paginatedResponse->getJsonData());
+        $this->assertEquals(1, $paginatedResponse->getCurrentPage());
+        $this->assertNull($paginatedResponse->getTotalPages());
+        $this->assertNull($paginatedResponse->getPerPage());
+        $this->assertFalse($paginatedResponse->hasNext());
+        $this->assertFalse($paginatedResponse->hasPrev());
+    }
+
+    public function testRequestPaginatedWithSuccessfulResponse()
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=1&per_page=50>; rel="first", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=50>; rel="current"';
+
+        $responseData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2'],
+            ['id' => 3, 'name' => 'Course 3'],
+        ];
+
+        // Create a mock and queue responses
+        $mock = new MockHandler([
+            new Response(200, ['Link' => $linkHeader], json_encode($responseData)),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $guzzleClient = new Client(['handler' => $handlerStack]);
+
+        // Create an instance of HttpClient with mocked dependencies
+        $this->httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        // Call the requestPaginated method
+        $paginatedResponse = $this->httpClient->requestPaginated('GET', '/courses');
+
+        // Assert the response is a PaginatedResponse
+        $this->assertInstanceOf(PaginatedResponse::class, $paginatedResponse);
+        $this->assertEquals($linkHeader, $paginatedResponse->getLinkHeader());
+        $this->assertEquals($responseData, $paginatedResponse->getJsonData());
+        $this->assertEquals(1, $paginatedResponse->getCurrentPage());
+        $this->assertNull($paginatedResponse->getTotalPages());
+        $this->assertEquals(50, $paginatedResponse->getPerPage());
+        $this->assertFalse($paginatedResponse->hasNext());
+        $this->assertFalse($paginatedResponse->hasPrev());
+    }
+
+    public function testBackwardCompatibilityMaintained()
+    {
+        // Create a mock and queue responses
+        $mock = new MockHandler([
+            new Response(200, [], 'body content'),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $guzzleClient = new Client(['handler' => $handlerStack]);
+
+        // Create an instance of HttpClient with mocked dependencies
+        $this->httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        // Call the original get method
+        $response = $this->httpClient->get('/endpoint');
+
+        // Assert that the original method still works the same way
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('body content', $response->getBody()->getContents());
     }

--- a/tests/Pagination/LinkHeaderParserTest.php
+++ b/tests/Pagination/LinkHeaderParserTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace CanvasLMS\Tests\Pagination;
+
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Pagination\LinkHeaderParser;
+
+/**
+ * LinkHeaderParserTest Class
+ *
+ * Test cases for LinkHeaderParser class functionality including:
+ * - Parsing valid Link headers
+ * - Handling malformed headers
+ * - Extracting specific relations
+ * - Parsing page numbers and per_page values
+ * - Edge cases and error handling
+ */
+class LinkHeaderParserTest extends TestCase
+{
+    /**
+     * @var LinkHeaderParser
+     */
+    private LinkHeaderParser $parser;
+
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        $this->parser = new LinkHeaderParser();
+    }
+
+    /**
+     * Test parsing a complete Canvas API Link header
+     */
+    public function testParseCompleteCanvasLinkHeader(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="prev", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="first", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=5&per_page=10>; rel="last", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="current"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(5, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2&per_page=10', $result['next']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1&per_page=10', $result['prev']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1&per_page=10', $result['first']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=5&per_page=10', $result['last']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2&per_page=10', $result['current']);
+    }
+
+    /**
+     * Test parsing Link header with only next relation
+     */
+    public function testParsePartialLinkHeader(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2&per_page=50>; rel="next"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2&per_page=50', $result['next']);
+    }
+
+    /**
+     * Test parsing empty Link header
+     */
+    public function testParseEmptyLinkHeader(): void
+    {
+        $result = $this->parser->parse('');
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test parsing malformed Link header
+     */
+    public function testParseMalformedLinkHeader(): void
+    {
+        $linkHeader = 'invalid-link-header-format';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test parsing Link header with spaces and different formatting
+     */
+    public function testParseWithVariousSpacing(): void
+    {
+        $linkHeader = ' <https://canvas.example.com/api/v1/courses?page=2>; rel="next" , ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>;  rel="prev"  ';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2', $result['next']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1', $result['prev']);
+    }
+
+    /**
+     * Test extracting specific relation from Link header
+     */
+    public function testExtractRelation(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>; rel="prev"';
+
+        $nextUrl = $this->parser->extractRelation($linkHeader, 'next');
+        $prevUrl = $this->parser->extractRelation($linkHeader, 'prev');
+        $lastUrl = $this->parser->extractRelation($linkHeader, 'last');
+
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2', $nextUrl);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1', $prevUrl);
+        $this->assertNull($lastUrl);
+    }
+
+    /**
+     * Test checking if relation exists in Link header
+     */
+    public function testHasRelation(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="next"';
+
+        $this->assertTrue($this->parser->hasRelation($linkHeader, 'next'));
+        $this->assertFalse($this->parser->hasRelation($linkHeader, 'prev'));
+        $this->assertFalse($this->parser->hasRelation($linkHeader, 'last'));
+    }
+
+    /**
+     * Test getting all relations from Link header
+     */
+    public function testGetRelations(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>; rel="prev", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>; rel="first"';
+
+        $relations = $this->parser->getRelations($linkHeader);
+
+        $this->assertIsArray($relations);
+        $this->assertCount(3, $relations);
+        $this->assertContains('next', $relations);
+        $this->assertContains('prev', $relations);
+        $this->assertContains('first', $relations);
+    }
+
+    /**
+     * Test extracting page number from URL
+     */
+    public function testExtractPageNumber(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?page=5&per_page=10';
+        $pageNumber = $this->parser->extractPageNumber($url);
+
+        $this->assertEquals(5, $pageNumber);
+    }
+
+    /**
+     * Test extracting page number from URL without page parameter
+     */
+    public function testExtractPageNumberWithoutPageParam(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?per_page=10';
+        $pageNumber = $this->parser->extractPageNumber($url);
+
+        $this->assertNull($pageNumber);
+    }
+
+    /**
+     * Test extracting page number from URL without query string
+     */
+    public function testExtractPageNumberWithoutQuery(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses';
+        $pageNumber = $this->parser->extractPageNumber($url);
+
+        $this->assertNull($pageNumber);
+    }
+
+    /**
+     * Test extracting per_page parameter from URL
+     */
+    public function testExtractPerPage(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?page=2&per_page=50';
+        $perPage = $this->parser->extractPerPage($url);
+
+        $this->assertEquals(50, $perPage);
+    }
+
+    /**
+     * Test extracting per_page parameter from URL without per_page parameter
+     */
+    public function testExtractPerPageWithoutPerPageParam(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?page=2';
+        $perPage = $this->parser->extractPerPage($url);
+
+        $this->assertNull($perPage);
+    }
+
+    /**
+     * Test extracting per_page parameter from URL without query string
+     */
+    public function testExtractPerPageWithoutQuery(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses';
+        $perPage = $this->parser->extractPerPage($url);
+
+        $this->assertNull($perPage);
+    }
+
+    /**
+     * Test parsing Link header with non-standard rel values
+     */
+    public function testParseWithNonStandardRelValues(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="custom", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>; rel="special-page"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2', $result['custom']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1', $result['special-page']);
+    }
+
+    /**
+     * Test parsing Link header with URLs containing special characters
+     */
+    public function testParseWithSpecialCharactersInUrl(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?search=test%20query&page=2>; rel="next"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?search=test%20query&page=2', $result['next']);
+    }
+
+    /**
+     * Test parsing Link header with mixed case rel values
+     */
+    public function testParseWithMixedCaseRelValues(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="NEXT", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1>; rel="Prev"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2', $result['NEXT']);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1', $result['Prev']);
+    }
+
+    /**
+     * Test parsing Link header with duplicate rel values (last one wins)
+     */
+    public function testParseWithDuplicateRelValues(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=3>; rel="next"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=3', $result['next']);
+    }
+
+    /**
+     * Test extracting page number from URL with non-numeric page value
+     */
+    public function testExtractPageNumberWithNonNumericValue(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?page=abc&per_page=10';
+        $pageNumber = $this->parser->extractPageNumber($url);
+
+        $this->assertNull($pageNumber);
+    }
+
+    /**
+     * Test extracting per_page from URL with non-numeric value
+     */
+    public function testExtractPerPageWithNonNumericValue(): void
+    {
+        $url = 'https://canvas.example.com/api/v1/courses?page=2&per_page=abc';
+        $perPage = $this->parser->extractPerPage($url);
+
+        $this->assertNull($perPage);
+    }
+}

--- a/tests/Pagination/PaginatedResponseTest.php
+++ b/tests/Pagination/PaginatedResponseTest.php
@@ -1,0 +1,628 @@
+<?php
+
+namespace CanvasLMS\Tests\Pagination;
+
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * PaginatedResponseTest Class
+ *
+ * Test cases for PaginatedResponse class functionality including:
+ * - Wrapping HTTP responses with pagination
+ * - Parsing Link headers from responses
+ * - Navigation through paginated results
+ * - Converting to PaginationResult objects
+ * - Fetching all pages
+ */
+class PaginatedResponseTest extends TestCase
+{
+    /**
+     * Mock HTTP client
+     * @var HttpClientInterface
+     */
+    private HttpClientInterface $mockHttpClient;
+
+    /**
+     * Mock HTTP response
+     * @var ResponseInterface
+     */
+    private ResponseInterface $mockResponse;
+
+    /**
+     * Mock response stream
+     * @var StreamInterface
+     */
+    private StreamInterface $mockStream;
+
+    /**
+     * Sample response data
+     * @var mixed[]
+     */
+    private array $sampleData;
+
+    /**
+     * Sample Link header
+     * @var string
+     */
+    private string $sampleLinkHeader;
+
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $this->mockResponse = $this->createMock(ResponseInterface::class);
+        $this->mockStream = $this->createMock(StreamInterface::class);
+
+        $this->sampleData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2'],
+            ['id' => 3, 'name' => 'Course 3'],
+        ];
+
+        $this->sampleLinkHeader = '<https://canvas.example.com/api/v1/courses?page=3&per_page=10>; rel="next", ' .
+                                  '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="prev", ' .
+                                  '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="first", ' .
+                                  '<https://canvas.example.com/api/v1/courses?page=5&per_page=10>; rel="last", ' .
+                                  '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="current"';
+    }
+
+    /**
+     * Test creating PaginatedResponse with Link header
+     */
+    public function testCreateWithLinkHeader(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals($this->mockResponse, $paginatedResponse->getResponse());
+        $this->assertEquals($this->sampleLinkHeader, $paginatedResponse->getLinkHeader());
+    }
+
+    /**
+     * Test creating PaginatedResponse without Link header
+     */
+    public function testCreateWithoutLinkHeader(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals('', $paginatedResponse->getLinkHeader());
+        $this->assertEmpty($paginatedResponse->getNavigationUrls());
+    }
+
+    /**
+     * Test getting response body
+     */
+    public function testGetBody(): void
+    {
+        $responseBody = json_encode($this->sampleData);
+
+        $this->mockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($responseBody);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($this->mockStream);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals($responseBody, $paginatedResponse->getBody());
+    }
+
+    /**
+     * Test getting JSON data
+     */
+    public function testGetJsonData(): void
+    {
+        $responseBody = json_encode($this->sampleData);
+
+        $this->mockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($responseBody);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($this->mockStream);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals($this->sampleData, $paginatedResponse->getJsonData());
+    }
+
+    /**
+     * Test getting JSON data with invalid JSON
+     */
+    public function testGetJsonDataWithInvalidJson(): void
+    {
+        $invalidJson = '{invalid json}';
+
+        $this->mockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($invalidJson);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($this->mockStream);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals([], $paginatedResponse->getJsonData());
+    }
+
+    /**
+     * Test navigation URL methods
+     */
+    public function testNavigationUrlMethods(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=3&per_page=10', $paginatedResponse->getNextUrl());
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1&per_page=10', $paginatedResponse->getPrevUrl());
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=1&per_page=10', $paginatedResponse->getFirstUrl());
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=5&per_page=10', $paginatedResponse->getLastUrl());
+        $this->assertEquals('https://canvas.example.com/api/v1/courses?page=2&per_page=10', $paginatedResponse->getCurrentUrl());
+    }
+
+    /**
+     * Test navigation state methods
+     */
+    public function testNavigationStateMethods(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertTrue($paginatedResponse->hasNext());
+        $this->assertTrue($paginatedResponse->hasPrev());
+        $this->assertTrue($paginatedResponse->hasRelation('next'));
+        $this->assertTrue($paginatedResponse->hasRelation('prev'));
+        $this->assertFalse($paginatedResponse->hasRelation('nonexistent'));
+    }
+
+    /**
+     * Test getting current page number
+     */
+    public function testGetCurrentPage(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals(2, $paginatedResponse->getCurrentPage());
+    }
+
+    /**
+     * Test getting current page number without current URL
+     */
+    public function testGetCurrentPageWithoutCurrentUrl(): void
+    {
+        $linkHeaderWithoutCurrent = '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next"';
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$linkHeaderWithoutCurrent]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals(1, $paginatedResponse->getCurrentPage());
+    }
+
+    /**
+     * Test getting total pages
+     */
+    public function testGetTotalPages(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals(5, $paginatedResponse->getTotalPages());
+    }
+
+    /**
+     * Test getting total pages without last URL
+     */
+    public function testGetTotalPagesWithoutLastUrl(): void
+    {
+        $linkHeaderWithoutLast = '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next"';
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$linkHeaderWithoutLast]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertNull($paginatedResponse->getTotalPages());
+    }
+
+    /**
+     * Test getting per_page parameter
+     */
+    public function testGetPerPage(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $this->assertEquals(10, $paginatedResponse->getPerPage());
+    }
+
+    /**
+     * Test converting to PaginationResult
+     */
+    public function testToPaginationResult(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $result = $paginatedResponse->toPaginationResult($this->sampleData);
+
+        $this->assertInstanceOf(PaginationResult::class, $result);
+        $this->assertEquals($this->sampleData, $result->getData());
+        $this->assertEquals(2, $result->getCurrentPage());
+        $this->assertEquals(5, $result->getTotalPages());
+        $this->assertEquals(10, $result->getPerPage());
+    }
+
+    /**
+     * Test getting pagination info
+     */
+    public function testGetPaginationInfo(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $info = $paginatedResponse->getPaginationInfo();
+
+        $this->assertIsArray($info);
+        $this->assertEquals(2, $info['current_page']);
+        $this->assertEquals(5, $info['total_pages']);
+        $this->assertEquals(10, $info['per_page']);
+        $this->assertTrue($info['has_next']);
+        $this->assertTrue($info['has_prev']);
+        $this->assertIsArray($info['navigation_urls']);
+    }
+
+    /**
+     * Test getting next page
+     */
+    public function testGetNext(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $nextResponseBody = json_encode([['id' => 4, 'name' => 'Course 4']]);
+        $nextMockStream = $this->createMock(StreamInterface::class);
+        $nextMockResponse = $this->createMock(ResponseInterface::class);
+
+        $nextMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($nextResponseBody);
+
+        $nextMockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($nextMockStream);
+
+        $nextMockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/courses', ['query' => ['page' => '3', 'per_page' => '10']])
+            ->willReturn($nextMockResponse);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $nextResponse = $paginatedResponse->getNext();
+
+        $this->assertInstanceOf(PaginatedResponse::class, $nextResponse);
+        $this->assertEquals([['id' => 4, 'name' => 'Course 4']], $nextResponse->getJsonData());
+    }
+
+    /**
+     * Test getting next page when no next URL exists
+     */
+    public function testGetNextWithoutNextUrl(): void
+    {
+        $linkHeaderWithoutNext = '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="prev"';
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$linkHeaderWithoutNext]);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $nextResponse = $paginatedResponse->getNext();
+
+        $this->assertNull($nextResponse);
+    }
+
+    /**
+     * Test getting previous page
+     */
+    public function testGetPrev(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $prevResponseBody = json_encode([['id' => 0, 'name' => 'Course 0']]);
+        $prevMockStream = $this->createMock(StreamInterface::class);
+        $prevMockResponse = $this->createMock(ResponseInterface::class);
+
+        $prevMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($prevResponseBody);
+
+        $prevMockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($prevMockStream);
+
+        $prevMockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/courses', ['query' => ['page' => '1', 'per_page' => '10']])
+            ->willReturn($prevMockResponse);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $prevResponse = $paginatedResponse->getPrev();
+
+        $this->assertInstanceOf(PaginatedResponse::class, $prevResponse);
+        $this->assertEquals([['id' => 0, 'name' => 'Course 0']], $prevResponse->getJsonData());
+    }
+
+    /**
+     * Test getting first page
+     */
+    public function testGetFirst(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $firstResponseBody = json_encode([['id' => 1, 'name' => 'First Course']]);
+        $firstMockStream = $this->createMock(StreamInterface::class);
+        $firstMockResponse = $this->createMock(ResponseInterface::class);
+
+        $firstMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($firstResponseBody);
+
+        $firstMockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($firstMockStream);
+
+        $firstMockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/courses', ['query' => ['page' => '1', 'per_page' => '10']])
+            ->willReturn($firstMockResponse);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $firstResponse = $paginatedResponse->getFirst();
+
+        $this->assertInstanceOf(PaginatedResponse::class, $firstResponse);
+        $this->assertEquals([['id' => 1, 'name' => 'First Course']], $firstResponse->getJsonData());
+    }
+
+    /**
+     * Test getting last page
+     */
+    public function testGetLast(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $lastResponseBody = json_encode([['id' => 50, 'name' => 'Last Course']]);
+        $lastMockStream = $this->createMock(StreamInterface::class);
+        $lastMockResponse = $this->createMock(ResponseInterface::class);
+
+        $lastMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($lastResponseBody);
+
+        $lastMockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($lastMockStream);
+
+        $lastMockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/courses', ['query' => ['page' => '5', 'per_page' => '10']])
+            ->willReturn($lastMockResponse);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $lastResponse = $paginatedResponse->getLast();
+
+        $this->assertInstanceOf(PaginatedResponse::class, $lastResponse);
+        $this->assertEquals([['id' => 50, 'name' => 'Last Course']], $lastResponse->getJsonData());
+    }
+
+    /**
+     * Test fetch all pages
+     */
+    public function testFetchAllPages(): void
+    {
+        // Mock the current response
+        $currentResponseBody = json_encode([['id' => 1, 'name' => 'Course 1']]);
+        $currentMockStream = $this->createMock(StreamInterface::class);
+        
+        $currentMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($currentResponseBody);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($currentMockStream);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn(['<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next"']);
+
+        // Mock the next response
+        $nextResponseBody = json_encode([['id' => 2, 'name' => 'Course 2']]);
+        $nextMockStream = $this->createMock(StreamInterface::class);
+        $nextMockResponse = $this->createMock(ResponseInterface::class);
+
+        $nextMockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($nextResponseBody);
+
+        $nextMockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($nextMockStream);
+
+        $nextMockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]); // No more pages
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/courses', ['query' => ['page' => '2', 'per_page' => '10']])
+            ->willReturn($nextMockResponse);
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $allData = $paginatedResponse->fetchAllPages();
+
+        $expectedData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2'],
+        ];
+
+        $this->assertEquals($expectedData, $allData);
+    }
+
+    /**
+     * Test fetch all pages with single page
+     */
+    public function testFetchAllPagesWithSinglePage(): void
+    {
+        $responseBody = json_encode($this->sampleData);
+        $mockStream = $this->createMock(StreamInterface::class);
+        
+        $mockStream->expects($this->once())
+            ->method('getContents')
+            ->willReturn($responseBody);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getBody')
+            ->willReturn($mockStream);
+
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([]); // No pagination links
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $allData = $paginatedResponse->fetchAllPages();
+
+        $this->assertEquals($this->sampleData, $allData);
+    }
+
+    /**
+     * Test error handling when fetching next page fails
+     */
+    public function testGetNextWithException(): void
+    {
+        $this->mockResponse->expects($this->once())
+            ->method('getHeader')
+            ->with('Link')
+            ->willReturn([$this->sampleLinkHeader]);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->willThrowException(new \Exception('Network error'));
+
+        $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
+
+        $nextResponse = $paginatedResponse->getNext();
+
+        $this->assertNull($nextResponse);
+    }
+}

--- a/tests/Pagination/PaginationResultTest.php
+++ b/tests/Pagination/PaginationResultTest.php
@@ -1,0 +1,378 @@
+<?php
+
+namespace CanvasLMS\Tests\Pagination;
+
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Pagination\PaginationResult;
+
+/**
+ * PaginationResultTest Class
+ *
+ * Test cases for PaginationResult class functionality including:
+ * - Creating results with navigation links
+ * - Creating results from Link headers
+ * - Accessing pagination metadata
+ * - Navigation and state checking
+ * - Edge cases and error handling
+ */
+class PaginationResultTest extends TestCase
+{
+    /**
+     * Sample data for testing
+     * @var mixed[]
+     */
+    private array $sampleData;
+
+    /**
+     * Sample navigation links for testing
+     * @var string[]
+     */
+    private array $sampleLinks;
+
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        $this->sampleData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2'],
+            ['id' => 3, 'name' => 'Course 3'],
+        ];
+
+        $this->sampleLinks = [
+            'first' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'prev' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'current' => 'https://canvas.example.com/api/v1/courses?page=2&per_page=10',
+            'next' => 'https://canvas.example.com/api/v1/courses?page=3&per_page=10',
+            'last' => 'https://canvas.example.com/api/v1/courses?page=5&per_page=10',
+        ];
+    }
+
+    /**
+     * Test creating PaginationResult with basic data
+     */
+    public function testCreateWithBasicData(): void
+    {
+        $result = new PaginationResult($this->sampleData);
+
+        $this->assertEquals($this->sampleData, $result->getData());
+        $this->assertEquals(1, $result->getCurrentPage());
+        $this->assertNull($result->getTotalPages());
+        $this->assertNull($result->getPerPage());
+        $this->assertFalse($result->hasNext());
+        $this->assertFalse($result->hasPrev());
+    }
+
+    /**
+     * Test creating PaginationResult with navigation links
+     */
+    public function testCreateWithNavigationLinks(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $this->assertEquals($this->sampleData, $result->getData());
+        $this->assertEquals(2, $result->getCurrentPage());
+        $this->assertEquals(5, $result->getTotalPages());
+        $this->assertEquals(10, $result->getPerPage());
+        $this->assertTrue($result->hasNext());
+        $this->assertTrue($result->hasPrev());
+    }
+
+    /**
+     * Test creating PaginationResult from Link header
+     */
+    public function testCreateFromLinkHeader(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=3&per_page=10>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="prev", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=1&per_page=10>; rel="first", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=5&per_page=10>; rel="last", ' .
+                      '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="current"';
+
+        $result = PaginationResult::fromLinkHeader($this->sampleData, $linkHeader);
+
+        $this->assertEquals($this->sampleData, $result->getData());
+        $this->assertEquals(2, $result->getCurrentPage());
+        $this->assertEquals(5, $result->getTotalPages());
+        $this->assertEquals(10, $result->getPerPage());
+        $this->assertTrue($result->hasNext());
+        $this->assertTrue($result->hasPrev());
+    }
+
+    /**
+     * Test navigation URL getters
+     */
+    public function testNavigationUrlGetters(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $this->assertEquals($this->sampleLinks['first'], $result->getFirstUrl());
+        $this->assertEquals($this->sampleLinks['prev'], $result->getPrevUrl());
+        $this->assertEquals($this->sampleLinks['current'], $result->getCurrentUrl());
+        $this->assertEquals($this->sampleLinks['next'], $result->getNextUrl());
+        $this->assertEquals($this->sampleLinks['last'], $result->getLastUrl());
+    }
+
+    /**
+     * Test pagination state checks
+     */
+    public function testPaginationStateChecks(): void
+    {
+        // Test first page
+        $firstPageResult = new PaginationResult($this->sampleData, [
+            'current' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'next' => 'https://canvas.example.com/api/v1/courses?page=2&per_page=10',
+            'last' => 'https://canvas.example.com/api/v1/courses?page=5&per_page=10',
+        ], 1, 5, 10);
+
+        $this->assertTrue($firstPageResult->isFirstPage());
+        $this->assertFalse($firstPageResult->isLastPage());
+        $this->assertTrue($firstPageResult->hasNext());
+        $this->assertFalse($firstPageResult->hasPrev());
+
+        // Test last page
+        $lastPageResult = new PaginationResult($this->sampleData, [
+            'first' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'prev' => 'https://canvas.example.com/api/v1/courses?page=4&per_page=10',
+            'current' => 'https://canvas.example.com/api/v1/courses?page=5&per_page=10',
+        ], 5, 5, 10);
+
+        $this->assertFalse($lastPageResult->isFirstPage());
+        $this->assertTrue($lastPageResult->isLastPage());
+        $this->assertFalse($lastPageResult->hasNext());
+        $this->assertTrue($lastPageResult->hasPrev());
+    }
+
+    /**
+     * Test middle page state
+     */
+    public function testMiddlePageState(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $this->assertFalse($result->isFirstPage());
+        $this->assertFalse($result->isLastPage());
+        $this->assertTrue($result->hasNext());
+        $this->assertTrue($result->hasPrev());
+        $this->assertTrue($result->hasMore());
+    }
+
+    /**
+     * Test single page result
+     */
+    public function testSinglePageResult(): void
+    {
+        $result = new PaginationResult($this->sampleData, [
+            'current' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+        ], 1, 1, 10);
+
+        $this->assertTrue($result->isFirstPage());
+        $this->assertTrue($result->isLastPage());
+        $this->assertFalse($result->hasNext());
+        $this->assertFalse($result->hasPrev());
+        $this->assertFalse($result->hasMore());
+    }
+
+    /**
+     * Test empty result
+     */
+    public function testEmptyResult(): void
+    {
+        $result = new PaginationResult([]);
+
+        $this->assertTrue($result->isEmpty());
+        $this->assertEquals(0, $result->getCount());
+        $this->assertEmpty($result->getData());
+    }
+
+    /**
+     * Test non-empty result
+     */
+    public function testNonEmptyResult(): void
+    {
+        $result = new PaginationResult($this->sampleData);
+
+        $this->assertFalse($result->isEmpty());
+        $this->assertEquals(3, $result->getCount());
+        $this->assertEquals($this->sampleData, $result->getData());
+    }
+
+    /**
+     * Test pagination summary
+     */
+    public function testPaginationSummary(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $summary = $result->getSummary();
+        $this->assertEquals('Page 2 of 5 (3 items)', $summary);
+    }
+
+    /**
+     * Test pagination summary without total pages
+     */
+    public function testPaginationSummaryWithoutTotalPages(): void
+    {
+        $result = new PaginationResult($this->sampleData, [], 2, null, 10);
+
+        $summary = $result->getSummary();
+        $this->assertEquals('Page 2 (3 items)', $summary);
+    }
+
+    /**
+     * Test navigation URLs getter
+     */
+    public function testGetNavigationUrls(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $navigationUrls = $result->getNavigationUrls();
+        $this->assertEquals($this->sampleLinks, $navigationUrls);
+    }
+
+    /**
+     * Test navigation URLs getter with null values filtered out
+     */
+    public function testGetNavigationUrlsWithNullValues(): void
+    {
+        $linksWithNulls = [
+            'first' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'prev' => null,
+            'current' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'next' => 'https://canvas.example.com/api/v1/courses?page=2&per_page=10',
+            'last' => null,
+        ];
+
+        $result = new PaginationResult($this->sampleData, $linksWithNulls, 1, null, 10);
+
+        $navigationUrls = $result->getNavigationUrls();
+        $expectedUrls = [
+            'first' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'current' => 'https://canvas.example.com/api/v1/courses?page=1&per_page=10',
+            'next' => 'https://canvas.example.com/api/v1/courses?page=2&per_page=10',
+        ];
+
+        $this->assertEquals($expectedUrls, $navigationUrls);
+    }
+
+    /**
+     * Test toArray method
+     */
+    public function testToArray(): void
+    {
+        $result = new PaginationResult($this->sampleData, $this->sampleLinks, 2, 5, 10);
+
+        $array = $result->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('data', $array);
+        $this->assertArrayHasKey('pagination', $array);
+
+        $this->assertEquals($this->sampleData, $array['data']);
+
+        $pagination = $array['pagination'];
+        $this->assertEquals(2, $pagination['current_page']);
+        $this->assertEquals(5, $pagination['total_pages']);
+        $this->assertEquals(10, $pagination['per_page']);
+        $this->assertEquals(3, $pagination['count']);
+        $this->assertTrue($pagination['has_next']);
+        $this->assertTrue($pagination['has_prev']);
+        $this->assertFalse($pagination['is_first_page']);
+        $this->assertFalse($pagination['is_last_page']);
+        $this->assertEquals($this->sampleLinks, $pagination['navigation_urls']);
+    }
+
+    /**
+     * Test creating from Link header with missing current URL
+     */
+    public function testCreateFromLinkHeaderWithoutCurrentUrl(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2&per_page=10>; rel="next"';
+
+        $result = PaginationResult::fromLinkHeader($this->sampleData, $linkHeader);
+
+        $this->assertEquals(1, $result->getCurrentPage()); // Should default to 1
+        $this->assertNull($result->getTotalPages());
+        $this->assertEquals(10, $result->getPerPage());
+    }
+
+    /**
+     * Test creating from empty Link header
+     */
+    public function testCreateFromEmptyLinkHeader(): void
+    {
+        $result = PaginationResult::fromLinkHeader($this->sampleData, '');
+
+        $this->assertEquals($this->sampleData, $result->getData());
+        $this->assertEquals(1, $result->getCurrentPage());
+        $this->assertNull($result->getTotalPages());
+        $this->assertNull($result->getPerPage());
+        $this->assertFalse($result->hasNext());
+        $this->assertFalse($result->hasPrev());
+    }
+
+    /**
+     * Test isLastPage when total pages is unknown
+     */
+    public function testIsLastPageWithUnknownTotalPages(): void
+    {
+        // Test with next URL available
+        $resultWithNext = new PaginationResult($this->sampleData, [
+            'next' => 'https://canvas.example.com/api/v1/courses?page=3&per_page=10',
+        ], 2, null, 10);
+
+        $this->assertFalse($resultWithNext->isLastPage());
+
+        // Test without next URL
+        $resultWithoutNext = new PaginationResult($this->sampleData, [], 2, null, 10);
+
+        $this->assertTrue($resultWithoutNext->isLastPage());
+    }
+
+    /**
+     * Test hasMore method
+     */
+    public function testHasMore(): void
+    {
+        $resultWithNext = new PaginationResult($this->sampleData, [
+            'next' => 'https://canvas.example.com/api/v1/courses?page=3&per_page=10',
+        ], 2, 5, 10);
+
+        $this->assertTrue($resultWithNext->hasMore());
+
+        $resultWithoutNext = new PaginationResult($this->sampleData, [], 2, 5, 10);
+
+        $this->assertFalse($resultWithoutNext->hasMore());
+    }
+
+    /**
+     * Test with complex data structure
+     */
+    public function testWithComplexData(): void
+    {
+        $complexData = [
+            [
+                'id' => 1,
+                'name' => 'Course 1',
+                'enrollments' => [
+                    ['role' => 'student', 'user_id' => 123],
+                    ['role' => 'teacher', 'user_id' => 456],
+                ],
+                'term' => ['name' => 'Fall 2023'],
+            ],
+            [
+                'id' => 2,
+                'name' => 'Course 2',
+                'enrollments' => [],
+                'term' => ['name' => 'Spring 2024'],
+            ],
+        ];
+
+        $result = new PaginationResult($complexData, $this->sampleLinks, 2, 5, 10);
+
+        $this->assertEquals($complexData, $result->getData());
+        $this->assertEquals(2, $result->getCount());
+        $this->assertFalse($result->isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive pagination support for Canvas LMS Kit SDK (closes #13)
- Adds RFC 5988 Link header parsing for Canvas API pagination
- Provides multiple pagination methods for flexible usage patterns

## Changes

### Core Pagination Infrastructure
- **LinkHeaderParser**: RFC 5988 compliant parser for Canvas API Link headers
- **PaginationResult**: Wrapper class providing pagination metadata and navigation
- **PaginatedResponse**: HTTP response wrapper with pagination functionality

### HTTP Client Enhancement
- Added `getPaginated()` and `requestPaginated()` methods to HttpClient
- Updated HttpClientInterface with pagination method signatures
- Maintains 100% backward compatibility

### Base API Integration
- Added pagination helper methods to AbstractBaseApi
- All API classes inherit pagination functionality automatically
- Method aliases for convenient access (e.g., `getPaginated()`, `getPages()`)

### API Class Updates
- Updated Course, User, Module, and File classes with:
  - `fetchAllPaginated()` - Returns PaginatedResponse for full control
  - `fetchPage()` - Returns PaginationResult for specific page access
  - `fetchAllPages()` - Automatically fetches all pages
- Updated documentation with pagination examples

## Key Features
- ✅ RFC 5988 Link header compliance
- ✅ Automatic page traversal with `fetchAllPages()`
- ✅ Rich pagination metadata (current page, total pages, navigation URLs)
- ✅ 100% backward compatibility - existing code continues to work
- ✅ Comprehensive test coverage (127 tests, 470 assertions)
- ✅ PHPStan level 6 compliance
- ✅ PSR-12 coding standards

## Usage Examples

```php
// Fetch courses with pagination
$paginatedResponse = Course::fetchAllPaginated(['per_page' => 10]);
$courses = $paginatedResponse->getJsonData();
$hasNext = $paginatedResponse->hasNext();

// Fetch specific page
$page2 = Course::fetchPage(['page' => 2, 'per_page' => 10]);
$courses = $page2->getData();

// Fetch all pages automatically
$allCourses = Course::fetchAllPages(['per_page' => 50]);
```

## Test Plan
- [x] All existing tests pass (127/127)
- [x] New unit tests for pagination classes
- [x] Integration tests for HTTP client pagination
- [x] PHPStan level 6 analysis passes
- [x] PSR-12 compliance verified
- [x] Pre-commit hooks pass