### PR TITLE
feat: Add Admin/Account API classes

### DIFF
--- a/src/Api/Accounts/Account.php
+++ b/src/Api/Accounts/Account.php
@@ -1,0 +1,671 @@
+<?php
+
+namespace CanvasLMS\Api\Accounts;
+
+use CanvasLMS\Config;
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Courses\Course;
+use CanvasLMS\Dto\Accounts\CreateAccountDTO;
+use CanvasLMS\Dto\Accounts\UpdateAccountDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginationResult;
+use CanvasLMS\Pagination\PaginatedResponse;
+
+/**
+ * Account Class
+ *
+ * Represents an account in the Canvas LMS. Accounts are organizational units that contain
+ * courses, sub-accounts, users, and other Canvas resources. This class provides methods
+ * to create, update, find, and manage accounts and their hierarchical relationships.
+ *
+ * Usage:
+ *
+ * ```php
+ * // Finding an account by ID
+ * $account = Account::find(1);
+ *
+ * // Creating a new sub-account
+ * $accountData = [
+ *     'name' => 'Mathematics Department',
+ *     'sisAccountId' => 'MATH_DEPT',
+ *     'parentAccountId' => 1
+ * ];
+ * $account = Account::create($accountData);
+ *
+ * // Updating an existing account
+ * $account->name = 'Mathematics and Statistics Department';
+ * $account->save();
+ *
+ * // Getting sub-accounts
+ * $subAccounts = $account->getSubAccounts();
+ *
+ * // Getting account settings
+ * $settings = $account->getSettings();
+ *
+ * // Fetching manageable accounts
+ * $manageableAccounts = Account::getManageableAccounts();
+ * ```
+ *
+ * @package CanvasLMS\Api\Accounts
+ */
+class Account extends AbstractBaseApi
+{
+    /**
+     * The ID of the Account object
+     * @var int|null
+     */
+    public ?int $id = null;
+
+    /**
+     * The display name of the account
+     * @var string|null
+     */
+    public ?string $name = null;
+
+    /**
+     * The UUID of the account
+     * @var string|null
+     */
+    public ?string $uuid = null;
+
+    /**
+     * The account's parent ID, or null if this is the root account
+     * @var int|null
+     */
+    public ?int $parentAccountId = null;
+
+    /**
+     * The ID of the root account, or null if this is the root account
+     * @var int|null
+     */
+    public ?int $rootAccountId = null;
+
+    /**
+     * The storage quota for the account in megabytes
+     * @var int|null
+     */
+    public ?int $defaultStorageQuotaMb = null;
+
+    /**
+     * The storage quota for a user in the account in megabytes
+     * @var int|null
+     */
+    public ?int $defaultUserStorageQuotaMb = null;
+
+    /**
+     * The storage quota for a group in the account in megabytes
+     * @var int|null
+     */
+    public ?int $defaultGroupStorageQuotaMb = null;
+
+    /**
+     * The default time zone of the account
+     * @var string|null
+     */
+    public ?string $defaultTimeZone = null;
+
+    /**
+     * The account's identifier in the Student Information System
+     * @var string|null
+     */
+    public ?string $sisAccountId = null;
+
+    /**
+     * The account's identifier in the Student Information System (alternative field)
+     * @var string|null
+     */
+    public ?string $integrationId = null;
+
+    /**
+     * The id of the SIS import if created through SIS
+     * @var int|null
+     */
+    public ?int $sisImportId = null;
+
+    /**
+     * The account's identifier that is sent as context_id in LTI launches
+     * @var string|null
+     */
+    public ?string $ltiGuid = null;
+
+    /**
+     * The state of the account. Can be 'active' or 'deleted'
+     * @var string|null
+     */
+    public ?string $workflowState = null;
+
+    /**
+     * The number of courses directly under the account
+     * @var int|null
+     */
+    public ?int $courseCount = null;
+
+    /**
+     * The number of sub-accounts directly under the account
+     * @var int|null
+     */
+    public ?int $subAccountCount = null;
+
+    /**
+     * Account settings
+     * @var array<string, mixed>|null
+     */
+    public ?array $settings = null;
+
+    /**
+     * Create a new account
+     *
+     * @param array<string, mixed>|CreateAccountDTO $data Account data
+     * @param int|null $parentAccountId Parent account ID (if creating sub-account)
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function create(array|CreateAccountDTO $data, ?int $parentAccountId = null): self
+    {
+        self::checkApiClient();
+
+        $parentId = $parentAccountId ?? Config::getAccountId();
+
+        if (!$parentId || $parentId == 0) {
+            throw new CanvasApiException("Parent account ID must be provided or set in Config");
+        }
+
+        if (is_array($data)) {
+            $data = new CreateAccountDTO($data);
+        }
+
+        $endpoint = sprintf('accounts/%d/sub_accounts', $parentId);
+        $response = self::$apiClient->post($endpoint, [
+            'multipart' => $data->toApiArray()
+        ]);
+
+        $responseData = json_decode($response->getBody(), true);
+        return new self($responseData);
+    }
+
+    /**
+     * Find an account by ID
+     *
+     * @param int|string $id Account ID or SIS ID
+     * @param array<string, mixed> $params Additional query parameters
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function find(int|string $id, array $params = []): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('accounts/%s', $id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return new self($responseData);
+    }
+
+    /**
+     * Get a list of accounts the current user can view or manage
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function fetchAll(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $endpoint = 'accounts';
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) {
+            return new self($item);
+        }, $responseData);
+    }
+
+    /**
+     * Get accounts with pagination support
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPaginated(array $params = []): PaginatedResponse
+    {
+        self::checkApiClient();
+
+        $endpoint = 'accounts';
+        return self::getPaginatedResponse($endpoint, $params);
+    }
+
+    /**
+     * Get a specific page of accounts
+     *
+     * @param array<string, mixed> $params Query parameters including page and per_page
+     * @return PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function fetchPage(array $params = []): PaginationResult
+    {
+        $paginatedResponse = self::fetchAllPaginated($params);
+        $data = self::convertPaginatedResponseToModels($paginatedResponse);
+
+        return $paginatedResponse->toPaginationResult($data);
+    }
+
+    /**
+     * Get all accounts from all pages
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPages(array $params = []): array
+    {
+        return self::fetchAllPagesAsModels('accounts', $params);
+    }
+
+    /**
+     * Get accounts where the current user has permission to create or manage courses
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function getManageableAccounts(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $endpoint = 'manageable_accounts';
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) {
+            return new self($item);
+        }, $responseData);
+    }
+
+    /**
+     * Get accounts where the current user has permission to create courses
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function getCourseCreationAccounts(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $endpoint = 'course_creation_accounts';
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) {
+            return new self($item);
+        }, $responseData);
+    }
+
+    /**
+     * Get accounts that the current user can view through their admin course enrollments
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function getCourseAccounts(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $endpoint = 'course_accounts';
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) {
+            return new self($item);
+        }, $responseData);
+    }
+
+    /**
+     * Get the root account
+     *
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function getRootAccount(): self
+    {
+        $accountId = Config::getAccountId();
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be set in Config");
+        }
+
+        return self::find($accountId);
+    }
+
+    /**
+     * Update an account
+     *
+     * @param int $id Account ID
+     * @param array<string, mixed>|UpdateAccountDTO $data Account data to update
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function update(int $id, array|UpdateAccountDTO $data): self
+    {
+        self::checkApiClient();
+
+        if (is_array($data)) {
+            $data = new UpdateAccountDTO($data);
+        }
+
+        $endpoint = sprintf('accounts/%d', $id);
+        $response = self::$apiClient->put($endpoint, [
+            'multipart' => $data->toApiArray()
+        ]);
+
+        $responseData = json_decode($response->getBody(), true);
+        return new self($responseData);
+    }
+
+    /**
+     * Save the current account instance
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function save(): bool
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Cannot save account without ID");
+        }
+
+        $dto = new UpdateAccountDTO($this->toDtoArray());
+        $updated = self::update($this->id, $dto);
+
+        // Update properties from the response
+        foreach (get_object_vars($updated) as $key => $value) {
+            if (property_exists($this, $key)) {
+                $this->$key = $value;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Delete the account (only sub-accounts can be deleted)
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function delete(): bool
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Cannot delete account without ID");
+        }
+
+        if (!$this->parentAccountId) {
+            throw new CanvasApiException("Cannot delete root account");
+        }
+
+        $endpoint = sprintf('accounts/%d/sub_accounts/%d', $this->parentAccountId, $this->id);
+        $response = self::$apiClient->delete($endpoint);
+
+        json_decode($response->getBody(), true);
+        return true;
+    }
+
+    /**
+     * Get sub-accounts of this account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public function getSubAccounts(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/sub_accounts', $this->id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) {
+            return new self($item);
+        }, $responseData);
+    }
+
+    /**
+     * Get the parent account
+     *
+     * @return self|null
+     * @throws CanvasApiException
+     */
+    public function getParentAccount(): ?self
+    {
+        if (!$this->parentAccountId) {
+            return null;
+        }
+
+        return self::find($this->parentAccountId);
+    }
+
+    /**
+     * Check if this is a root account
+     *
+     * @return bool
+     */
+    public function isRootAccount(): bool
+    {
+        return $this->parentAccountId === null && $this->rootAccountId === null;
+    }
+
+    /**
+     * Get account settings
+     *
+     * @return array<string, mixed>
+     * @throws CanvasApiException
+     */
+    public function getSettings(): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/settings', $this->id);
+        $response = self::$apiClient->get($endpoint);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Update account settings
+     *
+     * @param array<string, mixed> $settings Settings to update
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function updateSettings(array $settings): bool
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $dto = new UpdateAccountDTO(['settings' => $settings]);
+        $endpoint = sprintf('accounts/%d', $this->id);
+
+        $response = self::$apiClient->put($endpoint, [
+            'multipart' => $dto->toApiArray()
+        ]);
+
+        json_decode($response->getBody(), true);
+
+        // Refresh settings
+        $this->settings = $this->getSettings();
+
+        return true;
+    }
+
+    /**
+     * Get permissions for the calling user and this account
+     *
+     * @param array<int, string> $permissions List of permissions to check
+     * @return array<string, bool>
+     * @throws CanvasApiException
+     */
+    public function getPermissions(array $permissions = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/permissions', $this->id);
+        $params = [];
+
+        if (!empty($permissions)) {
+            $params['permissions'] = $permissions;
+        }
+
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Get the terms of service for this account
+     *
+     * @return array<string, mixed>|null
+     * @throws CanvasApiException
+     */
+    public function getTermsOfService(): ?array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/terms_of_service', $this->id);
+
+        try {
+            $response = self::$apiClient->get($endpoint);
+            return json_decode($response->getBody(), true);
+        } catch (CanvasApiException $e) {
+            if ($e->getCode() === 404) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Get help links for this account
+     *
+     * @return array<string, mixed>|null
+     * @throws CanvasApiException
+     */
+    public function getHelpLinks(): ?array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/help_links', $this->id);
+
+        try {
+            $response = self::$apiClient->get($endpoint);
+            return json_decode($response->getBody(), true);
+        } catch (CanvasApiException $e) {
+            if ($e->getCode() === 404) {
+                return null;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Get active courses in this account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<int, Course>
+     * @throws CanvasApiException
+     */
+    public function getCourses(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Account ID is required");
+        }
+
+        $endpoint = sprintf('accounts/%d/courses', $this->id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        // Convert to Course objects
+        return array_map(function ($courseData) {
+            return new Course($courseData);
+        }, $responseData);
+    }
+
+    /**
+     * Get account ID getter
+     *
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set account ID
+     *
+     * @param int $id
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Get account name
+     *
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set account name
+     *
+     * @param string $name
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get SIS account ID
+     *
+     * @return string|null
+     */
+    public function getSisAccountId(): ?string
+    {
+        return $this->sisAccountId;
+    }
+
+    /**
+     * Set SIS account ID
+     *
+     * @param string|null $sisAccountId
+     * @return self
+     */
+    public function setSisAccountId(?string $sisAccountId): self
+    {
+        $this->sisAccountId = $sisAccountId;
+        return $this;
+    }
+}

--- a/src/Api/Admins/Admin.php
+++ b/src/Api/Admins/Admin.php
@@ -1,0 +1,458 @@
+<?php
+
+namespace CanvasLMS\Api\Admins;
+
+use CanvasLMS\Config;
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Accounts\Account;
+use CanvasLMS\Dto\Admins\CreateAdminDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginationResult;
+use CanvasLMS\Pagination\PaginatedResponse;
+
+/**
+ * Admin Class
+ *
+ * Represents an admin user in the Canvas LMS. Admins are users with specific
+ * permissions to manage accounts and their resources. This class provides methods
+ * to create, manage, and remove admin privileges for users at the account level.
+ *
+ * Admin operations always require an account context, as admins are assigned
+ * permissions within specific accounts in the Canvas hierarchy.
+ *
+ * Usage:
+ *
+ * ```php
+ * // Creating a new admin for an account
+ * $adminData = [
+ *     'userId' => 123,
+ *     'role' => 'AccountAdmin',
+ *     'sendConfirmation' => true
+ * ];
+ * $admin = Admin::create($adminData, 1); // Account ID 1
+ *
+ * // Finding all admins for an account
+ * $admins = Admin::fetchAll(1);
+ *
+ * // Removing admin privileges
+ * $admin = Admin::find(123, 1); // User ID 123, Account ID 1
+ * $admin->delete();
+ *
+ * // Getting available admin roles
+ * $roles = Admin::getSelfAdminRoles(1);
+ * ```
+ *
+ * @package CanvasLMS\Api\Admins
+ */
+class Admin extends AbstractBaseApi
+{
+    /**
+     * The ID of the User object who is the admin
+     * @var int|null
+     */
+    public ?int $id = null;
+
+    /**
+     * The account ID this admin is associated with
+     * @var int|null
+     */
+    public ?int $accountId = null;
+
+    /**
+     * The admin's user name
+     * @var string|null
+     */
+    public ?string $name = null;
+
+    /**
+     * The admin's email address
+     * @var string|null
+     */
+    public ?string $email = null;
+
+    /**
+     * The admin's login ID
+     * @var string|null
+     */
+    public ?string $loginId = null;
+
+    /**
+     * The role of the admin (e.g., 'AccountAdmin', 'SubAccountAdmin')
+     * @var string|null
+     */
+    public ?string $role = null;
+
+    /**
+     * The ID of the role
+     * @var int|null
+     */
+    public ?int $roleId = null;
+
+    /**
+     * The workflow state of the admin
+     * @var string|null
+     */
+    public ?string $workflowState = null;
+
+    /**
+     * Additional user details (optional, based on include parameters)
+     * @var array<string, mixed>|null
+     */
+    public ?array $user = null;
+
+    /**
+     * Create a new admin for an account
+     *
+     * @param array<string, mixed>|CreateAdminDTO $data Admin data
+     * @param int|null $accountId Account ID (required)
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function create(array|CreateAdminDTO $data, ?int $accountId = null): self
+    {
+        self::checkApiClient();
+
+        $accountId = $accountId ?? Config::getAccountId();
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        if (is_array($data)) {
+            $data = new CreateAdminDTO($data);
+        }
+
+        $endpoint = sprintf('accounts/%d/admins', $accountId);
+        $response = self::$apiClient->post($endpoint, [
+            'multipart' => $data->toApiArray()
+        ]);
+
+        $responseData = json_decode($response->getBody(), true);
+        $admin = new self($responseData);
+        $admin->accountId = $accountId;
+        return $admin;
+    }
+
+    /**
+     * Find an admin by user ID in a specific account
+     * Note: This implementation differs from the interface as it requires account context
+     *
+     * @param int $userId User ID of the admin
+     * @param array<string, mixed> $params Optional parameters including account_id
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function find(int $userId, array $params = []): self
+    {
+        self::checkApiClient();
+
+        $accountId = $params['account_id'] ?? Config::getAccountId();
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        // First, we need to get all admins and find the specific one
+        $admins = self::fetchAll(['account_id' => $accountId, 'user_id' => [$userId]]);
+
+        if (empty($admins)) {
+            throw new CanvasApiException("Admin with user ID {$userId} not found in account {$accountId}");
+        }
+
+        return $admins[0];
+    }
+
+    /**
+     * Get a list of account admins
+     *
+     * @param array<string, mixed> $params Query parameters (can include 'account_id')
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function fetchAll(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $accountId = $params['account_id'] ?? Config::getAccountId();
+        unset($params['account_id']); // Remove from query params
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        $endpoint = sprintf('accounts/%d/admins', $accountId);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $responseData = json_decode($response->getBody(), true);
+
+        return array_map(function ($item) use ($accountId) {
+            $admin = new self($item);
+            $admin->accountId = $accountId;
+            return $admin;
+        }, $responseData);
+    }
+
+    /**
+     * Get admins with pagination support
+     *
+     * @param array<string, mixed> $params Query parameters (can include 'account_id')
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPaginated(array $params = []): PaginatedResponse
+    {
+        self::checkApiClient();
+
+        $accountId = $params['account_id'] ?? Config::getAccountId();
+        unset($params['account_id']); // Remove from query params
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        $endpoint = sprintf('accounts/%d/admins', $accountId);
+        return self::getPaginatedResponse($endpoint, $params);
+    }
+
+    /**
+     * Get a specific page of admins
+     *
+     * @param array<string, mixed> $params Query parameters including page, per_page, and account_id
+     * @return PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function fetchPage(array $params = []): PaginationResult
+    {
+        $accountId = $params['account_id'] ?? Config::getAccountId();
+        $paginatedResponse = self::fetchAllPaginated($params);
+        $data = self::convertPaginatedResponseToModels($paginatedResponse);
+
+        // Add account ID to each admin
+        foreach ($data as $admin) {
+            $admin->accountId = $accountId;
+        }
+
+        return $paginatedResponse->toPaginationResult($data);
+    }
+
+    /**
+     * Get all admins from all pages
+     *
+     * @param array<string, mixed> $params Query parameters (can include 'account_id')
+     * @return array<int, self>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPages(array $params = []): array
+    {
+        self::checkApiClient();
+
+        $accountId = $params['account_id'] ?? Config::getAccountId();
+        unset($params['account_id']); // Remove from query params
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        $endpoint = sprintf('accounts/%d/admins', $accountId);
+        $admins = self::fetchAllPagesAsModels($endpoint, $params);
+
+        // Add account ID to each admin
+        foreach ($admins as $admin) {
+            $admin->accountId = $accountId;
+        }
+
+        return $admins;
+    }
+
+    /**
+     * Remove admin privileges (delete admin)
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function delete(): bool
+    {
+        if (!$this->id) {
+            throw new CanvasApiException("Cannot delete admin without user ID");
+        }
+
+        if (!$this->accountId) {
+            throw new CanvasApiException("Cannot delete admin without account ID");
+        }
+
+        $endpoint = sprintf('accounts/%d/admins/%d', $this->accountId, $this->id);
+        $response = self::$apiClient->delete($endpoint);
+
+        json_decode($response->getBody(), true);
+        return true;
+    }
+
+    /**
+     * Get a list of roles that can be assigned to users in the current account
+     *
+     * @param int|null $accountId Account ID
+     * @return array<int, array<string, mixed>>
+     * @throws CanvasApiException
+     */
+    public static function getSelfAdminRoles(?int $accountId = null): array
+    {
+        self::checkApiClient();
+
+        $accountId = $accountId ?? Config::getAccountId();
+
+        if (!$accountId || $accountId == 0) {
+            throw new CanvasApiException("Account ID must be provided or set in Config");
+        }
+
+        $endpoint = sprintf('accounts/%d/admins/self/roles', $accountId);
+        $response = self::$apiClient->get($endpoint);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * Get the account this admin belongs to
+     *
+     * @return Account|null
+     * @throws CanvasApiException
+     */
+    public function getAccount(): ?Account
+    {
+        if (!$this->accountId) {
+            return null;
+        }
+
+        return Account::find($this->accountId);
+    }
+
+    /**
+     * Get admin user ID
+     *
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set admin user ID
+     *
+     * @param int $id
+     * @return self
+     */
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * Get account ID
+     *
+     * @return int|null
+     */
+    public function getAccountId(): ?int
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * Set account ID
+     *
+     * @param int $accountId
+     * @return self
+     */
+    public function setAccountId(int $accountId): self
+    {
+        $this->accountId = $accountId;
+        return $this;
+    }
+
+    /**
+     * Get admin name
+     *
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set admin name
+     *
+     * @param string $name
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get admin email
+     *
+     * @return string|null
+     */
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    /**
+     * Set admin email
+     *
+     * @param string $email
+     * @return self
+     */
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+        return $this;
+    }
+
+    /**
+     * Get admin role
+     *
+     * @return string|null
+     */
+    public function getRole(): ?string
+    {
+        return $this->role;
+    }
+
+    /**
+     * Set admin role
+     *
+     * @param string $role
+     * @return self
+     */
+    public function setRole(string $role): self
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    /**
+     * Get admin role ID
+     *
+     * @return int|null
+     */
+    public function getRoleId(): ?int
+    {
+        return $this->roleId;
+    }
+
+    /**
+     * Set admin role ID
+     *
+     * @param int $roleId
+     * @return self
+     */
+    public function setRoleId(int $roleId): self
+    {
+        $this->roleId = $roleId;
+        return $this;
+    }
+}

--- a/src/Dto/Accounts/CreateAccountDTO.php
+++ b/src/Dto/Accounts/CreateAccountDTO.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace CanvasLMS\Dto\Accounts;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+use CanvasLMS\Interfaces\DTOInterface;
+
+/**
+ * Data Transfer Object for creating a new Canvas account
+ *
+ * @package CanvasLMS\Dto\Accounts
+ */
+class CreateAccountDTO extends AbstractBaseDto implements DTOInterface
+{
+    /**
+     * The name of the property in the API
+     * @var string
+     */
+    protected string $apiPropertyName = 'account';
+
+    /**
+     * The name of the new sub-account
+     * @var string
+     */
+    public string $name;
+
+    /**
+     * The account's identifier in the Student Information System
+     * @var string|null
+     */
+    public ?string $sisAccountId = null;
+
+    /**
+     * The account's identifier in external systems
+     * @var string|null
+     */
+    public ?string $integrationId = null;
+
+    /**
+     * The parent account ID (required for sub-accounts)
+     * @var int|null
+     */
+    public ?int $parentAccountId = null;
+
+    /**
+     * The default course storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultStorageQuotaMb = null;
+
+    /**
+     * The default user storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultUserStorageQuotaMb = null;
+
+    /**
+     * The default group storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultGroupStorageQuotaMb = null;
+
+    /**
+     * The default time zone of the account
+     * @var string|null
+     */
+    public ?string $defaultTimeZone = null;
+
+    /**
+     * Get the account name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the account name
+     *
+     * @param string $name
+     * @return self
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get the SIS account ID
+     *
+     * @return string|null
+     */
+    public function getSisAccountId(): ?string
+    {
+        return $this->sisAccountId;
+    }
+
+    /**
+     * Set the SIS account ID
+     *
+     * @param string|null $sisAccountId
+     * @return self
+     */
+    public function setSisAccountId(?string $sisAccountId): self
+    {
+        $this->sisAccountId = $sisAccountId;
+        return $this;
+    }
+
+    /**
+     * Get the integration ID
+     *
+     * @return string|null
+     */
+    public function getIntegrationId(): ?string
+    {
+        return $this->integrationId;
+    }
+
+    /**
+     * Set the integration ID
+     *
+     * @param string|null $integrationId
+     * @return self
+     */
+    public function setIntegrationId(?string $integrationId): self
+    {
+        $this->integrationId = $integrationId;
+        return $this;
+    }
+
+    /**
+     * Get the parent account ID
+     *
+     * @return int|null
+     */
+    public function getParentAccountId(): ?int
+    {
+        return $this->parentAccountId;
+    }
+
+    /**
+     * Set the parent account ID
+     *
+     * @param int|null $parentAccountId
+     * @return self
+     */
+    public function setParentAccountId(?int $parentAccountId): self
+    {
+        $this->parentAccountId = $parentAccountId;
+        return $this;
+    }
+
+    /**
+     * Get the default storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultStorageQuotaMb(): ?int
+    {
+        return $this->defaultStorageQuotaMb;
+    }
+
+    /**
+     * Set the default storage quota in MB
+     *
+     * @param int|null $defaultStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultStorageQuotaMb(?int $defaultStorageQuotaMb): self
+    {
+        $this->defaultStorageQuotaMb = $defaultStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the default user storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultUserStorageQuotaMb(): ?int
+    {
+        return $this->defaultUserStorageQuotaMb;
+    }
+
+    /**
+     * Set the default user storage quota in MB
+     *
+     * @param int|null $defaultUserStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultUserStorageQuotaMb(?int $defaultUserStorageQuotaMb): self
+    {
+        $this->defaultUserStorageQuotaMb = $defaultUserStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the default group storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultGroupStorageQuotaMb(): ?int
+    {
+        return $this->defaultGroupStorageQuotaMb;
+    }
+
+    /**
+     * Set the default group storage quota in MB
+     *
+     * @param int|null $defaultGroupStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultGroupStorageQuotaMb(?int $defaultGroupStorageQuotaMb): self
+    {
+        $this->defaultGroupStorageQuotaMb = $defaultGroupStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the default time zone
+     *
+     * @return string|null
+     */
+    public function getDefaultTimeZone(): ?string
+    {
+        return $this->defaultTimeZone;
+    }
+
+    /**
+     * Set the default time zone
+     *
+     * @param string|null $defaultTimeZone
+     * @return self
+     */
+    public function setDefaultTimeZone(?string $defaultTimeZone): self
+    {
+        $this->defaultTimeZone = $defaultTimeZone;
+        return $this;
+    }
+}

--- a/src/Dto/Accounts/UpdateAccountDTO.php
+++ b/src/Dto/Accounts/UpdateAccountDTO.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace CanvasLMS\Dto\Accounts;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+use CanvasLMS\Interfaces\DTOInterface;
+
+/**
+ * Data Transfer Object for updating an existing Canvas account
+ *
+ * @package CanvasLMS\Dto\Accounts
+ */
+class UpdateAccountDTO extends AbstractBaseDto implements DTOInterface
+{
+    /**
+     * The name of the property in the API
+     * @var string
+     */
+    protected string $apiPropertyName = 'account';
+
+    /**
+     * Updates the account name
+     * @var string|null
+     */
+    public ?string $name = null;
+
+    /**
+     * Updates the account sis_account_id
+     * @var string|null
+     */
+    public ?string $sisAccountId = null;
+
+    /**
+     * Updates the account integration_id
+     * @var string|null
+     */
+    public ?string $integrationId = null;
+
+    /**
+     * The ID of a parent account to move the account to
+     * @var int|null
+     */
+    public ?int $parentAccountId = null;
+
+    /**
+     * The default time zone of the account.
+     * Allowed time zones are IANA time zones or friendlier Ruby on Rails time zones.
+     * @var string|null
+     */
+    public ?string $defaultTimeZone = null;
+
+    /**
+     * The default course storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultStorageQuotaMb = null;
+
+    /**
+     * The default user storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultUserStorageQuotaMb = null;
+
+    /**
+     * The default group storage quota in megabytes
+     * @var int|null
+     */
+    public ?int $defaultGroupStorageQuotaMb = null;
+
+    /**
+     * The ID of a course to be used as a template for all newly created courses
+     * @var int|null
+     */
+    public ?int $courseTemplateId = null;
+
+    /**
+     * Account settings
+     * @var array<string, mixed>|null
+     */
+    public ?array $settings = null;
+
+    /**
+     * Override SIS stickiness for this update (default true)
+     * @var bool|null
+     */
+    public ?bool $overrideSisStickiness = null;
+
+    /**
+     * Enable or disable services (hash of service names to boolean values)
+     * @var array<string, bool>|null
+     */
+    public ?array $services = null;
+
+    /**
+     * Get the account name
+     *
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the account name
+     *
+     * @param string|null $name
+     * @return self
+     */
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Get the SIS account ID
+     *
+     * @return string|null
+     */
+    public function getSisAccountId(): ?string
+    {
+        return $this->sisAccountId;
+    }
+
+    /**
+     * Set the SIS account ID
+     *
+     * @param string|null $sisAccountId
+     * @return self
+     */
+    public function setSisAccountId(?string $sisAccountId): self
+    {
+        $this->sisAccountId = $sisAccountId;
+        return $this;
+    }
+
+    /**
+     * Get the integration ID
+     *
+     * @return string|null
+     */
+    public function getIntegrationId(): ?string
+    {
+        return $this->integrationId;
+    }
+
+    /**
+     * Set the integration ID
+     *
+     * @param string|null $integrationId
+     * @return self
+     */
+    public function setIntegrationId(?string $integrationId): self
+    {
+        $this->integrationId = $integrationId;
+        return $this;
+    }
+
+    /**
+     * Get the parent account ID
+     *
+     * @return int|null
+     */
+    public function getParentAccountId(): ?int
+    {
+        return $this->parentAccountId;
+    }
+
+    /**
+     * Set the parent account ID
+     *
+     * @param int|null $parentAccountId
+     * @return self
+     */
+    public function setParentAccountId(?int $parentAccountId): self
+    {
+        $this->parentAccountId = $parentAccountId;
+        return $this;
+    }
+
+    /**
+     * Get the default time zone
+     *
+     * @return string|null
+     */
+    public function getDefaultTimeZone(): ?string
+    {
+        return $this->defaultTimeZone;
+    }
+
+    /**
+     * Set the default time zone
+     *
+     * @param string|null $defaultTimeZone
+     * @return self
+     */
+    public function setDefaultTimeZone(?string $defaultTimeZone): self
+    {
+        $this->defaultTimeZone = $defaultTimeZone;
+        return $this;
+    }
+
+    /**
+     * Get the default storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultStorageQuotaMb(): ?int
+    {
+        return $this->defaultStorageQuotaMb;
+    }
+
+    /**
+     * Set the default storage quota in MB
+     *
+     * @param int|null $defaultStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultStorageQuotaMb(?int $defaultStorageQuotaMb): self
+    {
+        $this->defaultStorageQuotaMb = $defaultStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the default user storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultUserStorageQuotaMb(): ?int
+    {
+        return $this->defaultUserStorageQuotaMb;
+    }
+
+    /**
+     * Set the default user storage quota in MB
+     *
+     * @param int|null $defaultUserStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultUserStorageQuotaMb(?int $defaultUserStorageQuotaMb): self
+    {
+        $this->defaultUserStorageQuotaMb = $defaultUserStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the default group storage quota in MB
+     *
+     * @return int|null
+     */
+    public function getDefaultGroupStorageQuotaMb(): ?int
+    {
+        return $this->defaultGroupStorageQuotaMb;
+    }
+
+    /**
+     * Set the default group storage quota in MB
+     *
+     * @param int|null $defaultGroupStorageQuotaMb
+     * @return self
+     */
+    public function setDefaultGroupStorageQuotaMb(?int $defaultGroupStorageQuotaMb): self
+    {
+        $this->defaultGroupStorageQuotaMb = $defaultGroupStorageQuotaMb;
+        return $this;
+    }
+
+    /**
+     * Get the course template ID
+     *
+     * @return int|null
+     */
+    public function getCourseTemplateId(): ?int
+    {
+        return $this->courseTemplateId;
+    }
+
+    /**
+     * Set the course template ID
+     *
+     * @param int|null $courseTemplateId
+     * @return self
+     */
+    public function setCourseTemplateId(?int $courseTemplateId): self
+    {
+        $this->courseTemplateId = $courseTemplateId;
+        return $this;
+    }
+
+    /**
+     * Get the account settings
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getSettings(): ?array
+    {
+        return $this->settings;
+    }
+
+    /**
+     * Set the account settings
+     *
+     * @param array<string, mixed>|null $settings
+     * @return self
+     */
+    public function setSettings(?array $settings): self
+    {
+        $this->settings = $settings;
+        return $this;
+    }
+
+    /**
+     * Add a setting to the account settings
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return self
+     */
+    public function addSetting(string $key, $value): self
+    {
+        if ($this->settings === null) {
+            $this->settings = [];
+        }
+
+        $this->settings[$key] = $value;
+        return $this;
+    }
+
+    /**
+     * Get the override SIS stickiness flag
+     *
+     * @return bool|null
+     */
+    public function getOverrideSisStickiness(): ?bool
+    {
+        return $this->overrideSisStickiness;
+    }
+
+    /**
+     * Set the override SIS stickiness flag
+     *
+     * @param bool|null $overrideSisStickiness
+     * @return self
+     */
+    public function setOverrideSisStickiness(?bool $overrideSisStickiness): self
+    {
+        $this->overrideSisStickiness = $overrideSisStickiness;
+        return $this;
+    }
+
+    /**
+     * Get the services
+     *
+     * @return array<string, bool>|null
+     */
+    public function getServices(): ?array
+    {
+        return $this->services;
+    }
+
+    /**
+     * Set the services
+     *
+     * @param array<string, bool>|null $services
+     * @return self
+     */
+    public function setServices(?array $services): self
+    {
+        $this->services = $services;
+        return $this;
+    }
+
+    /**
+     * Enable or disable a specific service
+     *
+     * @param string $serviceName
+     * @param bool $enabled
+     * @return self
+     */
+    public function setService(string $serviceName, bool $enabled): self
+    {
+        if ($this->services === null) {
+            $this->services = [];
+        }
+
+        $this->services[$serviceName] = $enabled;
+        return $this;
+    }
+
+    /**
+     * Convert the DTO to an array for API requests
+     * This override handles nested settings array properly
+     *
+     * @return array<int, array{name: string, contents: mixed}>
+     */
+    public function toApiArray(): array
+    {
+        $properties = get_object_vars($this);
+        $modifiedProperties = [];
+
+        foreach ($properties as $property => $value) {
+            // Skip the apiPropertyName itself
+            if ($property === 'apiPropertyName') {
+                continue;
+            }
+
+            // Skip null values
+            if ($value === null) {
+                continue;
+            }
+
+            // Handle nested settings array
+            if ($property === 'settings' && is_array($value)) {
+                foreach ($value as $settingKey => $settingValue) {
+                    // Handle nested setting structures
+                    if (is_array($settingValue)) {
+                        foreach ($settingValue as $subKey => $subValue) {
+                            $modifiedProperties[] = [
+                                'name' => sprintf('%s[settings][%s][%s]', $this->apiPropertyName, $settingKey, $subKey),
+                                'contents' => $subValue
+                            ];
+                        }
+                    } else {
+                        $modifiedProperties[] = [
+                            'name' => sprintf('%s[settings][%s]', $this->apiPropertyName, $settingKey),
+                            'contents' => $settingValue
+                        ];
+                    }
+                }
+                continue;
+            }
+
+            // Handle services array
+            if ($property === 'services' && is_array($value)) {
+                foreach ($value as $serviceKey => $serviceValue) {
+                    $modifiedProperties[] = [
+                        'name' => sprintf('%s[services][%s]', $this->apiPropertyName, $serviceKey),
+                        'contents' => $serviceValue ? 'true' : 'false'
+                    ];
+                }
+                continue;
+            }
+
+            // Handle override_sis_stickiness separately (not wrapped in account[])
+            if ($property === 'overrideSisStickiness') {
+                $modifiedProperties[] = [
+                    'name' => 'override_sis_stickiness',
+                    'contents' => $value ? 'true' : 'false'
+                ];
+                continue;
+            }
+
+            // Convert property name to snake_case
+            $snakeCase = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $property));
+
+            // Handle boolean values
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+
+            $modifiedProperties[] = [
+                'name' => sprintf('%s[%s]', $this->apiPropertyName, $snakeCase),
+                'contents' => $value
+            ];
+        }
+
+        return $modifiedProperties;
+    }
+}

--- a/src/Dto/Admins/CreateAdminDTO.php
+++ b/src/Dto/Admins/CreateAdminDTO.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace CanvasLMS\Dto\Admins;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+use CanvasLMS\Interfaces\DTOInterface;
+
+/**
+ * Data Transfer Object for creating a new Canvas admin
+ *
+ * @package CanvasLMS\Dto\Admins
+ */
+class CreateAdminDTO extends AbstractBaseDto implements DTOInterface
+{
+    /**
+     * The ID of the user to be made an admin
+     * @var int
+     */
+    public int $userId;
+
+    /**
+     * The role to give the user. Can be a string role name or integer role ID
+     * @var string|int|null
+     */
+    public string|int|null $role = null;
+
+    /**
+     * The ID of the role to assign. Alternative to using role name
+     * @var int|null
+     */
+    public ?int $roleId = null;
+
+    /**
+     * Send a notification email to the new admin (defaults to true)
+     * @var bool|null
+     */
+    public ?bool $sendConfirmation = null;
+
+    /**
+     * Get the user ID
+     *
+     * @return int
+     */
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+
+    /**
+     * Set the user ID
+     *
+     * @param int $userId
+     * @return self
+     */
+    public function setUserId(int $userId): self
+    {
+        $this->userId = $userId;
+        return $this;
+    }
+
+    /**
+     * Get the role
+     *
+     * @return string|int|null
+     */
+    public function getRole(): string|int|null
+    {
+        return $this->role;
+    }
+
+    /**
+     * Set the role
+     *
+     * @param string|int|null $role
+     * @return self
+     */
+    public function setRole(string|int|null $role): self
+    {
+        $this->role = $role;
+        return $this;
+    }
+
+    /**
+     * Get the role ID
+     *
+     * @return int|null
+     */
+    public function getRoleId(): ?int
+    {
+        return $this->roleId;
+    }
+
+    /**
+     * Set the role ID
+     *
+     * @param int|null $roleId
+     * @return self
+     */
+    public function setRoleId(?int $roleId): self
+    {
+        $this->roleId = $roleId;
+        return $this;
+    }
+
+    /**
+     * Get send confirmation flag
+     *
+     * @return bool|null
+     */
+    public function getSendConfirmation(): ?bool
+    {
+        return $this->sendConfirmation;
+    }
+
+    /**
+     * Set send confirmation flag
+     *
+     * @param bool|null $sendConfirmation
+     * @return self
+     */
+    public function setSendConfirmation(?bool $sendConfirmation): self
+    {
+        $this->sendConfirmation = $sendConfirmation;
+        return $this;
+    }
+
+    /**
+     * Convert the DTO to an array for API requests
+     *
+     * @return array<int, array{name: string, contents: mixed}>
+     */
+    public function toApiArray(): array
+    {
+        $modifiedProperties = [];
+
+        // User ID is required
+        $modifiedProperties[] = [
+            'name' => 'user_id',
+            'contents' => $this->userId
+        ];
+
+        // Role can be either string or ID
+        if ($this->role !== null) {
+            $modifiedProperties[] = [
+                'name' => 'role',
+                'contents' => $this->role
+            ];
+        } elseif ($this->roleId !== null) {
+            $modifiedProperties[] = [
+                'name' => 'role_id',
+                'contents' => $this->roleId
+            ];
+        }
+
+        // Send confirmation
+        if ($this->sendConfirmation !== null) {
+            $modifiedProperties[] = [
+                'name' => 'send_confirmation',
+                'contents' => $this->sendConfirmation ? '1' : '0'
+            ];
+        }
+
+        return $modifiedProperties;
+    }
+}

--- a/tests/Api/Accounts/AccountTest.php
+++ b/tests/Api/Accounts/AccountTest.php
@@ -1,0 +1,717 @@
+<?php
+
+namespace Tests\Api\Accounts;
+
+use GuzzleHttp\Psr7\Response;
+use CanvasLMS\Http\HttpClient;
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Api\Accounts\Account;
+use CanvasLMS\Api\Courses\Course;
+use CanvasLMS\Dto\Accounts\CreateAccountDTO;
+use CanvasLMS\Dto\Accounts\UpdateAccountDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Config;
+
+class AccountTest extends TestCase
+{
+    /**
+     * @var Account
+     */
+    private Account $account;
+
+    /**
+     * @var mixed
+     */
+    private $httpClientMock;
+
+    /**
+     * Set up the test
+     */
+    protected function setUp(): void
+    {
+        $this->httpClientMock = $this->createMock(HttpClient::class);
+        Account::setApiClient($this->httpClientMock);
+        Course::setApiClient($this->httpClientMock);
+        
+        // Set default account ID in config
+        Config::setAccountId(1);
+        
+        $this->account = new Account([]);
+    }
+
+    /**
+     * Account data provider
+     * @return array
+     */
+    public static function accountDataProvider(): array
+    {
+        return [
+            'basic_account' => [
+                [
+                    'name' => 'Mathematics Department',
+                    'sisAccountId' => 'MATH_DEPT',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Mathematics Department',
+                    'uuid' => 'WvAHhY5FINzq5IyRIJybGeiXyFkG3SqHUPb7jZY5',
+                    'parent_account_id' => 1,
+                    'root_account_id' => 1,
+                    'sis_account_id' => 'MATH_DEPT',
+                    'workflow_state' => 'active'
+                ]
+            ],
+            'account_with_storage' => [
+                [
+                    'name' => 'Science Department',
+                    'sisAccountId' => 'SCI_DEPT',
+                    'defaultStorageQuotaMb' => 1000,
+                    'defaultUserStorageQuotaMb' => 100,
+                    'defaultGroupStorageQuotaMb' => 200
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'Science Department',
+                    'uuid' => 'XvBHhY5FINzq5IyRIJybGeiXyFkG3SqHUPb7jZY6',
+                    'parent_account_id' => 1,
+                    'root_account_id' => 1,
+                    'sis_account_id' => 'SCI_DEPT',
+                    'default_storage_quota_mb' => 1000,
+                    'default_user_storage_quota_mb' => 100,
+                    'default_group_storage_quota_mb' => 200,
+                    'workflow_state' => 'active'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Test the create account method
+     * @dataProvider accountDataProvider
+     * @param array $accountData
+     * @param array $expectedResult
+     * @return void
+     */
+    public function testCreateAccount(array $accountData, array $expectedResult): void
+    {
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/1/sub_accounts'),
+                $this->anything()
+            )
+            ->willReturn($response);
+
+        $account = Account::create($accountData);
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals($expectedResult['name'], $account->getName());
+        $this->assertEquals($expectedResult['sis_account_id'], $account->getSisAccountId());
+    }
+
+    /**
+     * Test the create account method with DTO
+     * @dataProvider accountDataProvider
+     * @param array $accountData
+     * @param array $expectedResult
+     * @return void
+     */
+    public function testCreateAccountWithDto(array $accountData, array $expectedResult): void
+    {
+        $accountDto = new CreateAccountDTO($accountData);
+        $expectedPayload = $accountDto->toApiArray();
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/1/sub_accounts'),
+                $this->callback(function ($subject) use ($expectedPayload) {
+                    return $subject['multipart'] === $expectedPayload;
+                })
+            )
+            ->willReturn($response);
+
+        $account = Account::create($accountDto);
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals($expectedResult['name'], $account->getName());
+    }
+
+    /**
+     * Test create account with explicit parent ID
+     * @return void
+     */
+    public function testCreateAccountWithParentId(): void
+    {
+        $accountData = [
+            'name' => 'Sub Department',
+            'sisAccountId' => 'SUB_DEPT'
+        ];
+
+        $expectedResult = [
+            'id' => 4,
+            'name' => 'Sub Department',
+            'parent_account_id' => 2,
+            'root_account_id' => 1,
+            'sis_account_id' => 'SUB_DEPT'
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/2/sub_accounts'),
+                $this->anything()
+            )
+            ->willReturn($response);
+
+        $account = Account::create($accountData, 2);
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals(2, $account->parentAccountId);
+    }
+
+    /**
+     * Test create account without parent ID and no config
+     * @return void
+     */
+    public function testCreateAccountWithoutParentIdThrowsException(): void
+    {
+        // Save current account ID and clear it
+        $originalAccountId = Config::getAccountId();
+        Config::setAccountId(0); // Set to 0 to simulate no account ID
+        
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Parent account ID must be provided or set in Config');
+
+        try {
+            Account::create(['name' => 'Test']);
+        } finally {
+            // Restore original account ID
+            if ($originalAccountId) {
+                Config::setAccountId($originalAccountId);
+            }
+        }
+    }
+
+    /**
+     * Test the find account method
+     * @return void
+     */
+    public function testFindAccount(): void
+    {
+        $expectedResult = [
+            'id' => 123,
+            'name' => 'Found Account',
+            'uuid' => 'ABC123',
+            'workflow_state' => 'active'
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/123'))
+            ->willReturn($response);
+
+        $account = Account::find(123);
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals(123, $account->getId());
+        $this->assertEquals('Found Account', $account->getName());
+    }
+
+    /**
+     * Test find account with SIS ID
+     * @return void
+     */
+    public function testFindAccountWithSisId(): void
+    {
+        $expectedResult = [
+            'id' => 456,
+            'name' => 'SIS Account',
+            'sis_account_id' => 'SIS_ACCT_123'
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/sis_account_id:SIS_ACCT_123'))
+            ->willReturn($response);
+
+        $account = Account::find('sis_account_id:SIS_ACCT_123');
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals('SIS_ACCT_123', $account->getSisAccountId());
+    }
+
+    /**
+     * Test the fetchAll method
+     * @return void
+     */
+    public function testFetchAll(): void
+    {
+        $expectedResult = [
+            ['id' => 1, 'name' => 'Account 1'],
+            ['id' => 2, 'name' => 'Account 2'],
+            ['id' => 3, 'name' => 'Account 3']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts'))
+            ->willReturn($response);
+
+        $accounts = Account::fetchAll();
+
+        $this->assertIsArray($accounts);
+        $this->assertCount(3, $accounts);
+        $this->assertInstanceOf(Account::class, $accounts[0]);
+        $this->assertEquals('Account 1', $accounts[0]->getName());
+    }
+
+    /**
+     * Test the update account method
+     * @return void
+     */
+    public function testUpdateAccount(): void
+    {
+        $updateData = [
+            'name' => 'Updated Department',
+            'defaultStorageQuotaMb' => 2000
+        ];
+
+        $expectedResult = [
+            'id' => 1,
+            'name' => 'Updated Department',
+            'default_storage_quota_mb' => 2000
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('put')
+            ->with($this->equalTo('accounts/1'))
+            ->willReturn($response);
+
+        $account = Account::update(1, $updateData);
+
+        $this->assertEquals('Updated Department', $account->getName());
+        $this->assertEquals(2000, $account->defaultStorageQuotaMb);
+    }
+
+    /**
+     * Test the update account method with DTO
+     * @return void
+     */
+    public function testUpdateAccountWithDto(): void
+    {
+        $updateDto = new UpdateAccountDTO(['name' => 'Updated Department']);
+
+        $expectedResult = [
+            'id' => 1,
+            'name' => 'Updated Department'
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('put')
+            ->willReturn($response);
+
+        $account = Account::update(1, $updateDto);
+
+        $this->assertEquals('Updated Department', $account->getName());
+    }
+
+    /**
+     * Test the save account method
+     * @return void
+     */
+    public function testSaveAccount(): void
+    {
+        $this->account->setId(1);
+        $this->account->setName('Test Account');
+
+        $responseBody = json_encode(['id' => 1, 'name' => 'Test Account']);
+        $response = new Response(200, [], $responseBody);
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('put')
+            ->with(
+                $this->equalTo('accounts/1'),
+                $this->anything()
+            )
+            ->willReturn($response);
+
+        $result = $this->account->save();
+
+        $this->assertTrue($result, 'The save method should return true on successful save.');
+        $this->assertEquals('Test Account', $this->account->getName());
+    }
+
+    /**
+     * Test save without ID throws exception
+     * @return void
+     */
+    public function testSaveWithoutIdThrowsException(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Cannot save account without ID');
+
+        $this->account->save();
+    }
+
+    /**
+     * Test the delete account method
+     * @return void
+     */
+    public function testDeleteAccount(): void
+    {
+        $this->account->setId(2);
+        $this->account->parentAccountId = 1;
+
+        $response = new Response(200, [], json_encode(['id' => 2, 'workflow_state' => 'deleted']));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo('accounts/1/sub_accounts/2'))
+            ->willReturn($response);
+
+        $result = $this->account->delete();
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test delete root account throws exception
+     * @return void
+     */
+    public function testDeleteRootAccountThrowsException(): void
+    {
+        $this->account->setId(1);
+        $this->account->parentAccountId = null;
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Cannot delete root account');
+
+        $this->account->delete();
+    }
+
+    /**
+     * Test get sub accounts
+     * @return void
+     */
+    public function testGetSubAccounts(): void
+    {
+        $this->account->setId(1);
+
+        $expectedResult = [
+            ['id' => 2, 'name' => 'Sub Account 1', 'parent_account_id' => 1],
+            ['id' => 3, 'name' => 'Sub Account 2', 'parent_account_id' => 1]
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1/sub_accounts'))
+            ->willReturn($response);
+
+        $subAccounts = $this->account->getSubAccounts();
+
+        $this->assertIsArray($subAccounts);
+        $this->assertCount(2, $subAccounts);
+        $this->assertInstanceOf(Account::class, $subAccounts[0]);
+        $this->assertEquals(1, $subAccounts[0]->parentAccountId);
+    }
+
+    /**
+     * Test get parent account
+     * @return void
+     */
+    public function testGetParentAccount(): void
+    {
+        $this->account->parentAccountId = 1;
+
+        $expectedResult = [
+            'id' => 1,
+            'name' => 'Root Account',
+            'parent_account_id' => null
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1'))
+            ->willReturn($response);
+
+        $parentAccount = $this->account->getParentAccount();
+
+        $this->assertInstanceOf(Account::class, $parentAccount);
+        $this->assertEquals(1, $parentAccount->getId());
+        $this->assertNull($parentAccount->parentAccountId);
+    }
+
+    /**
+     * Test get parent account returns null for root account
+     * @return void
+     */
+    public function testGetParentAccountReturnsNullForRootAccount(): void
+    {
+        $this->account->parentAccountId = null;
+
+        $parentAccount = $this->account->getParentAccount();
+
+        $this->assertNull($parentAccount);
+    }
+
+    /**
+     * Test is root account
+     * @return void
+     */
+    public function testIsRootAccount(): void
+    {
+        $this->account->parentAccountId = null;
+        $this->account->rootAccountId = null;
+
+        $this->assertTrue($this->account->isRootAccount());
+
+        $this->account->parentAccountId = 1;
+        $this->assertFalse($this->account->isRootAccount());
+    }
+
+    /**
+     * Test get account settings
+     * @return void
+     */
+    public function testGetSettings(): void
+    {
+        $this->account->setId(1);
+
+        $expectedSettings = [
+            'microsoft_sync_enabled' => true,
+            'microsoft_sync_login_attribute_suffix' => false,
+            'restrict_student_past_view' => [
+                'value' => true,
+                'locked' => false
+            ]
+        ];
+
+        $response = new Response(200, [], json_encode($expectedSettings));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1/settings'))
+            ->willReturn($response);
+
+        $settings = $this->account->getSettings();
+
+        $this->assertIsArray($settings);
+        $this->assertTrue($settings['microsoft_sync_enabled']);
+        $this->assertIsArray($settings['restrict_student_past_view']);
+    }
+
+    /**
+     * Test update account settings
+     * @return void
+     */
+    public function testUpdateSettings(): void
+    {
+        $this->account->setId(1);
+
+        $newSettings = [
+            'microsoft_sync_enabled' => false,
+            'restrict_student_past_view' => [
+                'value' => false,
+                'locked' => true
+            ]
+        ];
+
+        $updateResponse = new Response(200, [], json_encode(['id' => 1]));
+        $settingsResponse = new Response(200, [], json_encode($newSettings));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('put')
+            ->willReturn($updateResponse);
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($settingsResponse);
+
+        $result = $this->account->updateSettings($newSettings);
+
+        $this->assertTrue($result);
+        $this->assertEquals($newSettings, $this->account->settings);
+    }
+
+    /**
+     * Test get permissions
+     * @return void
+     */
+    public function testGetPermissions(): void
+    {
+        $this->account->setId(1);
+
+        $expectedPermissions = [
+            'manage_account_memberships' => false,
+            'become_user' => true
+        ];
+
+        $response = new Response(200, [], json_encode($expectedPermissions));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('accounts/1/permissions'),
+                $this->callback(function ($options) {
+                    return isset($options['query']['permissions']) &&
+                           in_array('manage_account_memberships', $options['query']['permissions']) &&
+                           in_array('become_user', $options['query']['permissions']);
+                })
+            )
+            ->willReturn($response);
+
+        $permissions = $this->account->getPermissions(['manage_account_memberships', 'become_user']);
+
+        $this->assertIsArray($permissions);
+        $this->assertFalse($permissions['manage_account_memberships']);
+        $this->assertTrue($permissions['become_user']);
+    }
+
+    /**
+     * Test get courses for account
+     * @return void
+     */
+    public function testGetCourses(): void
+    {
+        $this->account->setId(1);
+
+        $expectedCourses = [
+            ['id' => 1, 'name' => 'Course 1', 'account_id' => 1],
+            ['id' => 2, 'name' => 'Course 2', 'account_id' => 1]
+        ];
+
+        $response = new Response(200, [], json_encode($expectedCourses));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1/courses'))
+            ->willReturn($response);
+
+        $courses = $this->account->getCourses();
+
+        $this->assertIsArray($courses);
+        $this->assertCount(2, $courses);
+        $this->assertInstanceOf(Course::class, $courses[0]);
+        $this->assertEquals('Course 1', $courses[0]->getName());
+    }
+
+    /**
+     * Test get manageable accounts
+     * @return void
+     */
+    public function testGetManageableAccounts(): void
+    {
+        $expectedResult = [
+            ['id' => 1, 'name' => 'Account 1'],
+            ['id' => 2, 'name' => 'Account 2']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('manageable_accounts'))
+            ->willReturn($response);
+
+        $accounts = Account::getManageableAccounts();
+
+        $this->assertIsArray($accounts);
+        $this->assertCount(2, $accounts);
+        $this->assertInstanceOf(Account::class, $accounts[0]);
+    }
+
+    /**
+     * Test get course creation accounts
+     * @return void
+     */
+    public function testGetCourseCreationAccounts(): void
+    {
+        $expectedResult = [
+            ['id' => 1, 'name' => 'Account 1'],
+            ['id' => 3, 'name' => 'Account 3']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('course_creation_accounts'))
+            ->willReturn($response);
+
+        $accounts = Account::getCourseCreationAccounts();
+
+        $this->assertIsArray($accounts);
+        $this->assertCount(2, $accounts);
+        $this->assertInstanceOf(Account::class, $accounts[0]);
+    }
+
+    /**
+     * Test get root account
+     * @return void
+     */
+    public function testGetRootAccount(): void
+    {
+        Config::setAccountId(1);
+
+        $expectedResult = [
+            'id' => 1,
+            'name' => 'Root Account',
+            'parent_account_id' => null,
+            'root_account_id' => null
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1'))
+            ->willReturn($response);
+
+        $rootAccount = Account::getRootAccount();
+
+        $this->assertInstanceOf(Account::class, $rootAccount);
+        $this->assertEquals(1, $rootAccount->getId());
+        $this->assertTrue($rootAccount->isRootAccount());
+    }
+}

--- a/tests/Api/Admins/AdminTest.php
+++ b/tests/Api/Admins/AdminTest.php
@@ -1,0 +1,478 @@
+<?php
+
+namespace Tests\Api\Admins;
+
+use GuzzleHttp\Psr7\Response;
+use CanvasLMS\Http\HttpClient;
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Api\Admins\Admin;
+use CanvasLMS\Api\Accounts\Account;
+use CanvasLMS\Dto\Admins\CreateAdminDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Config;
+
+class AdminTest extends TestCase
+{
+    /**
+     * @var Admin
+     */
+    private Admin $admin;
+
+    /**
+     * @var mixed
+     */
+    private $httpClientMock;
+
+    /**
+     * Set up the test
+     */
+    protected function setUp(): void
+    {
+        $this->httpClientMock = $this->createMock(HttpClient::class);
+        Admin::setApiClient($this->httpClientMock);
+        Account::setApiClient($this->httpClientMock);
+
+        // Set default account ID in config
+        Config::setAccountId(1);
+
+        $this->admin = new Admin([]);
+    }
+
+    /**
+     * Admin data provider
+     * @return array<string, array<int, mixed>>
+     */
+    public static function adminDataProvider(): array
+    {
+        return [
+            'basic_admin' => [
+                [
+                    'userId' => 123,
+                    'role' => 'AccountAdmin',
+                ],
+                [
+                    'id' => 123,
+                    'name' => 'John Doe',
+                    'email' => 'john.doe@example.com',
+                    'role' => 'AccountAdmin',
+                    'role_id' => 1,
+                    'workflow_state' => 'active'
+                ]
+            ],
+            'admin_with_role_id' => [
+                [
+                    'userId' => 456,
+                    'roleId' => 2,
+                    'sendConfirmation' => false
+                ],
+                [
+                    'id' => 456,
+                    'name' => 'Jane Smith',
+                    'email' => 'jane.smith@example.com',
+                    'role' => 'SubAccountAdmin',
+                    'role_id' => 2,
+                    'workflow_state' => 'active'
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Test the create admin method
+     * @dataProvider adminDataProvider
+     * @param array<string, mixed> $adminData
+     * @param array<string, mixed> $expectedResult
+     * @return void
+     */
+    public function testCreateAdmin(array $adminData, array $expectedResult): void
+    {
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/1/admins'),
+                $this->anything()
+            )
+            ->willReturn($response);
+
+        $admin = Admin::create($adminData);
+
+        $this->assertInstanceOf(Admin::class, $admin);
+        $this->assertEquals($expectedResult['name'], $admin->getName());
+        $this->assertEquals($expectedResult['role'], $admin->getRole());
+        $this->assertEquals(1, $admin->getAccountId());
+    }
+
+    /**
+     * Test the create admin method with DTO
+     * @dataProvider adminDataProvider
+     * @param array<string, mixed> $adminData
+     * @param array<string, mixed> $expectedResult
+     * @return void
+     */
+    public function testCreateAdminWithDto(array $adminData, array $expectedResult): void
+    {
+        $adminDto = new CreateAdminDTO($adminData);
+        $expectedPayload = $adminDto->toApiArray();
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/1/admins'),
+                $this->callback(function ($subject) use ($expectedPayload) {
+                    return $subject['multipart'] === $expectedPayload;
+                })
+            )
+            ->willReturn($response);
+
+        $admin = Admin::create($adminDto);
+
+        $this->assertInstanceOf(Admin::class, $admin);
+        $this->assertEquals($expectedResult['name'], $admin->getName());
+    }
+
+    /**
+     * Test create admin with explicit account ID
+     * @return void
+     */
+    public function testCreateAdminWithAccountId(): void
+    {
+        $adminData = [
+            'userId' => 789,
+            'role' => 'AccountAdmin'
+        ];
+
+        $expectedResult = [
+            'id' => 789,
+            'name' => 'Test Admin',
+            'role' => 'AccountAdmin'
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('post')
+            ->with(
+                $this->equalTo('accounts/2/admins'),
+                $this->anything()
+            )
+            ->willReturn($response);
+
+        $admin = Admin::create($adminData, 2);
+
+        $this->assertInstanceOf(Admin::class, $admin);
+        $this->assertEquals(2, $admin->getAccountId());
+    }
+
+    /**
+     * Test create admin without account ID throws exception
+     * @return void
+     */
+    public function testCreateAdminWithoutAccountIdThrowsException(): void
+    {
+        // Save current account ID and clear it
+        $originalAccountId = Config::getAccountId();
+        Config::setAccountId(0);
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Account ID must be provided or set in Config');
+
+        try {
+            Admin::create(['userId' => 123, 'role' => 'AccountAdmin']);
+        } finally {
+            // Restore original account ID
+            if ($originalAccountId) {
+                Config::setAccountId($originalAccountId);
+            }
+        }
+    }
+
+    /**
+     * Test the find admin method
+     * @return void
+     */
+    public function testFindAdmin(): void
+    {
+        $expectedResult = [
+            [
+                'id' => 123,
+                'name' => 'Found Admin',
+                'role' => 'AccountAdmin'
+            ]
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo('accounts/1/admins'),
+                $this->callback(function ($options) {
+                    return isset($options['query']['user_id']) &&
+                           $options['query']['user_id'] === [123];
+                })
+            )
+            ->willReturn($response);
+
+        $admin = Admin::find(123, ['account_id' => 1]);
+
+        $this->assertInstanceOf(Admin::class, $admin);
+        $this->assertEquals(123, $admin->getId());
+        $this->assertEquals('Found Admin', $admin->getName());
+        $this->assertEquals(1, $admin->getAccountId());
+    }
+
+    /**
+     * Test find admin not found throws exception
+     * @return void
+     */
+    public function testFindAdminNotFoundThrowsException(): void
+    {
+        $response = new Response(200, [], json_encode([]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->willReturn($response);
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Admin with user ID 999 not found in account 1');
+
+        Admin::find(999);
+    }
+
+    /**
+     * Test the fetchAll method
+     * @return void
+     */
+    public function testFetchAll(): void
+    {
+        $expectedResult = [
+            ['id' => 1, 'name' => 'Admin 1', 'role' => 'AccountAdmin'],
+            ['id' => 2, 'name' => 'Admin 2', 'role' => 'SubAccountAdmin'],
+            ['id' => 3, 'name' => 'Admin 3', 'role' => 'AccountAdmin']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1/admins'))
+            ->willReturn($response);
+
+        $admins = Admin::fetchAll();
+
+        $this->assertIsArray($admins);
+        $this->assertCount(3, $admins);
+        $this->assertInstanceOf(Admin::class, $admins[0]);
+        $this->assertEquals('Admin 1', $admins[0]->getName());
+        $this->assertEquals(1, $admins[0]->getAccountId());
+    }
+
+    /**
+     * Test the delete admin method
+     * @return void
+     */
+    public function testDeleteAdmin(): void
+    {
+        $this->admin->setId(123);
+        $this->admin->setAccountId(1);
+
+        $response = new Response(200, [], json_encode(['success' => true]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('delete')
+            ->with($this->equalTo('accounts/1/admins/123'))
+            ->willReturn($response);
+
+        $result = $this->admin->delete();
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test delete without ID throws exception
+     * @return void
+     */
+    public function testDeleteWithoutIdThrowsException(): void
+    {
+        $this->admin->setAccountId(1);
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Cannot delete admin without user ID');
+
+        $this->admin->delete();
+    }
+
+    /**
+     * Test delete without account ID throws exception
+     * @return void
+     */
+    public function testDeleteWithoutAccountIdThrowsException(): void
+    {
+        $this->admin->setId(123);
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Cannot delete admin without account ID');
+
+        $this->admin->delete();
+    }
+
+    /**
+     * Test get self admin roles
+     * @return void
+     */
+    public function testGetSelfAdminRoles(): void
+    {
+        $expectedRoles = [
+            ['id' => 1, 'label' => 'Account Admin', 'base_role_type' => 'AccountMembership'],
+            ['id' => 2, 'label' => 'Sub-Account Admin', 'base_role_type' => 'AccountMembership']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedRoles));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1/admins/self/roles'))
+            ->willReturn($response);
+
+        $roles = Admin::getSelfAdminRoles();
+
+        $this->assertIsArray($roles);
+        $this->assertCount(2, $roles);
+        $this->assertEquals('Account Admin', $roles[0]['label']);
+    }
+
+    /**
+     * Test get account
+     * @return void
+     */
+    public function testGetAccount(): void
+    {
+        $this->admin->setAccountId(1);
+
+        $expectedAccount = [
+            'id' => 1,
+            'name' => 'Test Account',
+            'parent_account_id' => null
+        ];
+
+        $response = new Response(200, [], json_encode($expectedAccount));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/1'))
+            ->willReturn($response);
+
+        $account = $this->admin->getAccount();
+
+        $this->assertInstanceOf(Account::class, $account);
+        $this->assertEquals(1, $account->getId());
+        $this->assertEquals('Test Account', $account->getName());
+    }
+
+    /**
+     * Test get account returns null when no account ID
+     * @return void
+     */
+    public function testGetAccountReturnsNullWhenNoAccountId(): void
+    {
+        $account = $this->admin->getAccount();
+
+        $this->assertNull($account);
+    }
+
+    /**
+     * Test DTO creation for role name
+     * @return void
+     */
+    public function testCreateAdminDtoWithRoleName(): void
+    {
+        $dto = new CreateAdminDTO([
+            'userId' => 123,
+            'role' => 'AccountAdmin',
+            'sendConfirmation' => true
+        ]);
+
+        $array = $dto->toApiArray();
+
+        $this->assertCount(3, $array);
+        $this->assertEquals('user_id', $array[0]['name']);
+        $this->assertEquals(123, $array[0]['contents']);
+        $this->assertEquals('role', $array[1]['name']);
+        $this->assertEquals('AccountAdmin', $array[1]['contents']);
+        $this->assertEquals('send_confirmation', $array[2]['name']);
+        $this->assertEquals('1', $array[2]['contents']);
+    }
+
+    /**
+     * Test DTO creation for role ID
+     * @return void
+     */
+    public function testCreateAdminDtoWithRoleId(): void
+    {
+        $dto = new CreateAdminDTO([
+            'userId' => 456,
+            'roleId' => 2,
+            'sendConfirmation' => false
+        ]);
+
+        $array = $dto->toApiArray();
+
+        $this->assertCount(3, $array);
+        $this->assertEquals('user_id', $array[0]['name']);
+        $this->assertEquals(456, $array[0]['contents']);
+        $this->assertEquals('role_id', $array[1]['name']);
+        $this->assertEquals(2, $array[1]['contents']);
+        $this->assertEquals('send_confirmation', $array[2]['name']);
+        $this->assertEquals('0', $array[2]['contents']);
+    }
+
+    /**
+     * Test fetchAll with custom account ID
+     * @return void
+     */
+    public function testFetchAllWithAccountId(): void
+    {
+        $expectedResult = [
+            ['id' => 1, 'name' => 'Admin 1', 'role' => 'AccountAdmin']
+        ];
+
+        $response = new Response(200, [], json_encode($expectedResult));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('accounts/5/admins'))
+            ->willReturn($response);
+
+        $admins = Admin::fetchAll(['account_id' => 5]);
+
+        $this->assertIsArray($admins);
+        $this->assertCount(1, $admins);
+        $this->assertEquals(5, $admins[0]->getAccountId());
+    }
+
+    /**
+     * Test pagination methods throw proper exceptions without account ID
+     * @return void
+     */
+    public function testPaginationMethodsRequireAccountId(): void
+    {
+        Config::setAccountId(0);
+
+        $this->expectException(CanvasApiException::class);
+        Admin::fetchAllPaginated();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive Account and Admin API functionality for Canvas LMS SDK
- Adds account-level management capabilities with full CRUD operations
- Provides admin user management with account-scoped permissions

## Implementation Details

### Account API ()
- Full CRUD operations (create, find, update, delete)
- Sub-account hierarchy management
- Account settings and permissions
- Special endpoints (manageable accounts, course creation accounts)
- 26 comprehensive tests

### Admin API ()
- Admin user management with account context
- Create/remove admin privileges
- Role management and assignment
- Self admin roles endpoint
- 19 comprehensive tests

### Data Transfer Objects
-  - For creating new accounts
-  - For updating accounts with complex settings
-  - For assigning admin privileges

## Testing
- All tests passing (1072 total tests)
- PHPStan level 6 compliance
- PSR-12 coding standards compliance

## Related Issues
Closes #38