### PR TITLE
feat: Add PHP version matrix testing to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,21 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        php-version: ['8.1', '8.2', '8.3']
+
+    name: PHP ${{ matrix.php-version }}
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        coverage: none
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress


### PR DESCRIPTION
## Summary
- Updates CI workflow to test against PHP 8.1, 8.2, and 8.3
- Ensures the library maintains compatibility across all declared PHP versions
- Uses GitHub Actions matrix strategy for parallel testing

## Motivation
The library declares support for PHP 8.1+ in composer.json, but CI was using the Ubuntu default PHP version (8.3). This change ensures we properly test against all supported versions to catch version-specific issues early.

## Changes
- Added PHP version matrix strategy to test PHP 8.1, 8.2, and 8.3
- Added shivammathur/setup-php action to set up specific PHP versions
- Added descriptive job names showing which PHP version is being tested

## Test Plan
- CI will now run tests 3 times, once for each PHP version
- All existing tests should pass on all PHP versions
- Future PRs will automatically test against all versions