### PR TITLE
feat: Complete Groups API implementation (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Complete Groups API implementation with student collaboration features (#63)
+  - **Group** class enhanced with pagination support, activity streams, permissions, and membership management
+  - **GroupCategory** class for organizing groups within courses with bulk member assignment
+  - **GroupMembership** class for managing group membership, moderator status, and invitations
+  - Added relationship methods to Course and User classes for group-related operations
+  - Full support for student group collaboration workflows and self-signup groups
+  - Comprehensive test coverage for all group-related functionality
+
 ### Changed
+- Enhanced User relationship methods to use pagination for groups listing (#63)
 - Refactored Rubric API classes to follow SDK conventions for context handling (#80)
   - Rubric class now uses `setCourse()` pattern like other API classes
   - Removed context parameters from all Rubric methods

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -679,6 +679,100 @@ class Course extends AbstractBaseApi
     }
 
     /**
+     * Get groups in this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\Groups\Group>
+     * @throws CanvasApiException
+     */
+    public function groups(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch groups');
+        }
+
+        return \CanvasLMS\Api\Groups\Group::fetchByContext('courses', $this->id, $params);
+    }
+
+    /**
+     * Get paginated groups in this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function groupsPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch groups');
+        }
+
+        return \CanvasLMS\Api\Groups\Group::fetchByContextPaginated('courses', $this->id, $params);
+    }
+
+    /**
+     * Get group categories in this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\GroupCategories\GroupCategory>
+     * @throws CanvasApiException
+     */
+    public function groupCategories(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch group categories');
+        }
+
+        return \CanvasLMS\Api\GroupCategories\GroupCategory::fetchAllPagesAsModels(
+            sprintf('courses/%d/group_categories', $this->id),
+            $params
+        );
+    }
+
+    /**
+     * Get paginated group categories in this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function groupCategoriesPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch group categories');
+        }
+
+        return \CanvasLMS\Api\GroupCategories\GroupCategory::getPaginatedResponse(
+            sprintf('courses/%d/group_categories', $this->id),
+            $params
+        );
+    }
+
+    /**
+     * Create a group category in this course
+     *
+     * @param array<string, mixed>|\CanvasLMS\Dto\GroupCategories\CreateGroupCategoryDTO $data Group category data
+     * @return \CanvasLMS\Api\GroupCategories\GroupCategory
+     * @throws CanvasApiException
+     */
+    public function createGroupCategory(
+        array|\CanvasLMS\Dto\GroupCategories\CreateGroupCategoryDTO $data
+    ): \CanvasLMS\Api\GroupCategories\GroupCategory {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to create group category');
+        }
+
+        // Transform data to include course_id
+        if (is_array($data)) {
+            $data['course_id'] = $this->id;
+        } else {
+            $data->courseId = $this->id;
+        }
+
+        return \CanvasLMS\Api\GroupCategories\GroupCategory::create($data);
+    }
+
+    /**
      * Conclude the course in the Canvas LMS system
      * @return bool
      */

--- a/src/Api/GroupCategories/GroupCategory.php
+++ b/src/Api/GroupCategories/GroupCategory.php
@@ -1,0 +1,509 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Api\GroupCategories;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Groups\Group;
+use CanvasLMS\Api\Users\User;
+use CanvasLMS\Config;
+use CanvasLMS\Dto\GroupCategories\CreateGroupCategoryDTO;
+use CanvasLMS\Dto\GroupCategories\UpdateGroupCategoryDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
+
+/**
+ * Canvas LMS Group Categories API
+ *
+ * Group Categories allow organizing groups together in Canvas. They provide a way to
+ * manage collections of groups with shared settings and permissions.
+ *
+ * @see https://canvas.instructure.com/doc/api/group_categories.html
+ *
+ * @package CanvasLMS\Api\GroupCategories
+ */
+class GroupCategory extends AbstractBaseApi
+{
+    /**
+     * The ID of the group category
+     */
+    public ?int $id = null;
+
+    /**
+     * The display name of the group category
+     */
+    public ?string $name = null;
+
+    /**
+     * Special role designations: 'communities', 'student_organized', 'imported', or null
+     */
+    public ?string $role = null;
+
+    /**
+     * Self signup configuration: 'enabled', 'restricted', or null
+     */
+    public ?string $selfSignup = null;
+
+    /**
+     * Auto leader configuration: 'first', 'random', or null
+     */
+    public ?string $autoLeader = null;
+
+    /**
+     * The context type (Course or Account)
+     */
+    public ?string $contextType = null;
+
+    /**
+     * The ID of the context (course_id or account_id)
+     */
+    public ?int $contextId = null;
+
+    /**
+     * The course ID if context_type is Course
+     */
+    public ?int $courseId = null;
+
+    /**
+     * The account ID if context_type is Account
+     */
+    public ?int $accountId = null;
+
+    /**
+     * Maximum number of users in each group (if self-signup enabled)
+     */
+    public ?int $groupLimit = null;
+
+    /**
+     * The SIS identifier for the group category
+     */
+    public ?string $sisGroupCategoryId = null;
+
+    /**
+     * The unique identifier for the SIS import
+     */
+    public ?int $sisImportId = null;
+
+    /**
+     * Progress object for async operations
+     * @var array<string, mixed>|null
+     */
+    public ?array $progress = null;
+
+    /**
+     * Indicates whether this group category is non-collaborative
+     */
+    public ?bool $nonCollaborative = null;
+
+    /**
+     * Get a single group category by ID
+     *
+     * @param int $id Group Category ID
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function find(int $id): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('group_categories/%d', $id);
+        $response = self::$apiClient->get($endpoint);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new self($data);
+    }
+
+    /**
+     * List group categories in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupCategory>
+     * @throws CanvasApiException
+     */
+    public static function fetchAll(array $params = []): array
+    {
+        return self::fetchAllPages($params);
+    }
+
+    /**
+     * Get paginated group categories in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPaginated(array $params = []): PaginatedResponse
+    {
+        $accountId = Config::getAccountId();
+        return self::getPaginatedResponse(sprintf('accounts/%d/group_categories', $accountId), $params);
+    }
+
+    /**
+     * Get a single page of group categories in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function fetchPage(array $params = []): PaginationResult
+    {
+        $paginatedResponse = self::fetchAllPaginated($params);
+        return self::createPaginationResult($paginatedResponse);
+    }
+
+    /**
+     * Get all pages of group categories in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupCategory>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPages(array $params = []): array
+    {
+        $accountId = Config::getAccountId();
+        return self::fetchAllPagesAsModels(sprintf('accounts/%d/group_categories', $accountId), $params);
+    }
+
+
+    /**
+     * Create a new group category in the current account
+     *
+     * @param array<string, mixed>|CreateGroupCategoryDTO $data Group category data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function create(array|CreateGroupCategoryDTO $data): self
+    {
+        self::checkApiClient();
+
+        if (is_array($data)) {
+            $data = new CreateGroupCategoryDTO($data);
+        }
+
+        $accountId = Config::getAccountId();
+        $endpoint = sprintf('accounts/%d/group_categories', $accountId);
+        $response = self::$apiClient->post($endpoint, ['multipart' => $data->toApiArray()]);
+        $categoryData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($categoryData);
+    }
+
+    /**
+     * Update group category
+     *
+     * @param int $id Group Category ID
+     * @param array<string, mixed>|UpdateGroupCategoryDTO $data Update data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function update(int $id, array|UpdateGroupCategoryDTO $data): self
+    {
+        self::checkApiClient();
+
+        if (is_array($data)) {
+            $data = new UpdateGroupCategoryDTO($data);
+        }
+
+        $endpoint = sprintf('group_categories/%d', $id);
+        $response = self::$apiClient->put($endpoint, ['multipart' => $data->toApiArray()]);
+        $categoryData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($categoryData);
+    }
+
+    /**
+     * Save the group category (create or update)
+     *
+     * @return bool
+     */
+    public function save(): bool
+    {
+        try {
+            if ($this->id) {
+                $dto = new UpdateGroupCategoryDTO($this->toDtoArray());
+                $updated = self::update($this->id, $dto);
+                $this->populate(get_object_vars($updated));
+            } else {
+                $dto = new CreateGroupCategoryDTO($this->toDtoArray());
+                $created = self::create($dto);
+                $this->populate(get_object_vars($created));
+            }
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Delete the group category
+     *
+     * @return bool
+     */
+    public function delete(): bool
+    {
+        if (!$this->id) {
+            return false;
+        }
+
+        try {
+            self::checkApiClient();
+            $endpoint = sprintf('group_categories/%d', $this->id);
+            self::$apiClient->delete($endpoint);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * List groups in this category
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<Group>
+     * @throws CanvasApiException
+     */
+    public function groups(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required to fetch groups');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('group_categories/%d/groups', $this->id);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->fetchAllPages();
+
+        return array_map(fn($data) => new Group($data), $allData);
+    }
+
+    /**
+     * Get paginated groups in this category
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function groupsPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required to fetch groups');
+        }
+
+        return self::getPaginatedResponse(sprintf('group_categories/%d/groups', $this->id), $params);
+    }
+
+    /**
+     * List users in this category
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<User>
+     * @throws CanvasApiException
+     */
+    public function users(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required to fetch users');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('group_categories/%d/users', $this->id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $usersData = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn($data) => new User($data), $usersData);
+    }
+
+    /**
+     * Get paginated users in this category
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function usersPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required to fetch users');
+        }
+
+        return self::getPaginatedResponse(sprintf('group_categories/%d/users', $this->id), $params);
+    }
+
+    /**
+     * Assign unassigned members to groups
+     *
+     * @param bool $sync Whether to perform synchronously (default: false)
+     * @return array<Group>|array<mixed> Groups if sync=true, progress object if async
+     * @throws CanvasApiException
+     */
+    public function assignUnassignedMembers(bool $sync = false): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required to assign members');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('group_categories/%d/assign_unassigned_members', $this->id);
+        $params = $sync ? ['multipart' => [['name' => 'sync', 'contents' => 'true']]] : [];
+
+        $response = self::$apiClient->post($endpoint, $params);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        // If sync=true, we get groups back. Otherwise, we get a progress object
+        if ($sync && isset($data[0]['id']) && isset($data[0]['name'])) {
+            return array_map(fn($groupData) => new Group($groupData), $data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Export groups and users in this category
+     *
+     * @return array<mixed>
+     * @throws CanvasApiException
+     */
+    public function export(): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group Category ID is required for export');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('group_categories/%d/export', $this->id);
+        $response = self::$apiClient->get($endpoint);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Convert group category to DTO array
+     *
+     * @return array<string, mixed>
+     */
+    public function toDtoArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'self_signup' => $this->selfSignup,
+            'auto_leader' => $this->autoLeader,
+            'group_limit' => $this->groupLimit,
+            'sis_group_category_id' => $this->sisGroupCategoryId,
+            'non_collaborative' => $this->nonCollaborative,
+        ], fn($value) => $value !== null);
+    }
+
+    // Getter and setter methods
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getRole(): ?string
+    {
+        return $this->role;
+    }
+
+    public function setRole(?string $role): void
+    {
+        $this->role = $role;
+    }
+
+    public function getSelfSignup(): ?string
+    {
+        return $this->selfSignup;
+    }
+
+    public function setSelfSignup(?string $selfSignup): void
+    {
+        $this->selfSignup = $selfSignup;
+    }
+
+    public function getAutoLeader(): ?string
+    {
+        return $this->autoLeader;
+    }
+
+    public function setAutoLeader(?string $autoLeader): void
+    {
+        $this->autoLeader = $autoLeader;
+    }
+
+    public function getContextType(): ?string
+    {
+        return $this->contextType;
+    }
+
+    public function setContextType(?string $contextType): void
+    {
+        $this->contextType = $contextType;
+    }
+
+    public function getContextId(): ?int
+    {
+        return $this->contextId;
+    }
+
+    public function setContextId(?int $contextId): void
+    {
+        $this->contextId = $contextId;
+    }
+
+    public function getGroupLimit(): ?int
+    {
+        return $this->groupLimit;
+    }
+
+    public function setGroupLimit(?int $groupLimit): void
+    {
+        $this->groupLimit = $groupLimit;
+    }
+
+    public function getNonCollaborative(): ?bool
+    {
+        return $this->nonCollaborative;
+    }
+
+    public function setNonCollaborative(?bool $nonCollaborative): void
+    {
+        $this->nonCollaborative = $nonCollaborative;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getProgress(): ?array
+    {
+        return $this->progress;
+    }
+
+    /**
+     * @param array<string, mixed>|null $progress
+     */
+    public function setProgress(?array $progress): void
+    {
+        $this->progress = $progress;
+    }
+}

--- a/src/Api/Groups/Group.php
+++ b/src/Api/Groups/Group.php
@@ -8,6 +8,7 @@ use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Api\Users\User;
 use CanvasLMS\Config;
 use CanvasLMS\Dto\Groups\CreateGroupDTO;
+use CanvasLMS\Dto\Groups\CreateGroupMembershipDTO;
 use CanvasLMS\Dto\Groups\UpdateGroupDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Pagination\PaginatedResponse;
@@ -46,7 +47,7 @@ class Group extends AbstractBaseApi
     public ?bool $isPublic = null;
 
     /**
-     * Whether the group has wiki pages
+     * Whether the current user is following this group
      */
     public ?bool $followedByUser = null;
 
@@ -101,6 +102,11 @@ class Group extends AbstractBaseApi
     public ?string $contextType = null;
 
     /**
+     * The course or account name that the group belongs to
+     */
+    public ?string $contextName = null;
+
+    /**
      * The role of the current user in the group
      */
     public ?string $role = null;
@@ -132,6 +138,18 @@ class Group extends AbstractBaseApi
     public ?array $permissions = null;
 
     /**
+     * Optional list of users that are members in the group
+     * Returned only if include[]=users
+     * @var array<mixed>|null
+     */
+    public ?array $users = null;
+
+    /**
+     * Indicates whether this group category is non-collaborative
+     */
+    public ?bool $nonCollaborative = null;
+
+    /**
      * Get a single group by ID
      *
      * @param int $id Group ID
@@ -155,17 +173,50 @@ class Group extends AbstractBaseApi
      * @param array<string, mixed> $params Query parameters
      * @return array<Group>
      * @throws CanvasApiException
+     * @deprecated Use fetchAllPaginated(), fetchPage(), or fetchAllPages() for better pagination support
      */
     public static function fetchAll(array $params = []): array
     {
-        self::checkApiClient();
+        return self::fetchAllPages($params);
+    }
 
+    /**
+     * Get paginated groups in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPaginated(array $params = []): PaginatedResponse
+    {
         $accountId = Config::getAccountId();
-        $endpoint = sprintf('accounts/%d/groups', $accountId);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $groupsData = json_decode($response->getBody()->getContents(), true);
+        return self::getPaginatedResponse(sprintf('accounts/%d/groups', $accountId), $params);
+    }
 
-        return array_map(fn($data) => new self($data), $groupsData);
+    /**
+     * Get a single page of groups in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function fetchPage(array $params = []): PaginationResult
+    {
+        $paginatedResponse = self::fetchAllPaginated($params);
+        return self::createPaginationResult($paginatedResponse);
+    }
+
+    /**
+     * Get all pages of groups in current account
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<Group>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPages(array $params = []): array
+    {
+        $accountId = Config::getAccountId();
+        return self::fetchAllPagesAsModels(sprintf('accounts/%d/groups', $accountId), $params);
     }
 
     /**
@@ -179,13 +230,24 @@ class Group extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
-        self::checkApiClient();
+        return self::fetchAllPagesAsModels(sprintf('%s/%d/groups', $contextType, $contextId), $params);
+    }
 
-        $endpoint = sprintf('%s/%d/groups', $contextType, $contextId);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $groupsData = json_decode($response->getBody()->getContents(), true);
-
-        return array_map(fn($data) => new self($data), $groupsData);
+    /**
+     * Get paginated groups for a specific context
+     *
+     * @param string $contextType 'accounts' or 'courses'
+     * @param int $contextId Account or Course ID
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchByContextPaginated(
+        string $contextType,
+        int $contextId,
+        array $params = []
+    ): PaginatedResponse {
+        return self::getPaginatedResponse(sprintf('%s/%d/groups', $contextType, $contextId), $params);
     }
 
     /**
@@ -198,13 +260,20 @@ class Group extends AbstractBaseApi
      */
     public static function fetchUserGroups(int $userId, array $params = []): array
     {
-        self::checkApiClient();
+        return self::fetchAllPagesAsModels(sprintf('users/%d/groups', $userId), $params);
+    }
 
-        $endpoint = sprintf('users/%d/groups', $userId);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $groupsData = json_decode($response->getBody()->getContents(), true);
-
-        return array_map(fn($data) => new self($data), $groupsData);
+    /**
+     * Get paginated groups for a specific user
+     *
+     * @param int $userId User ID
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchUserGroupsPaginated(int $userId, array $params = []): PaginatedResponse
+    {
+        return self::getPaginatedResponse(sprintf('users/%d/groups', $userId), $params);
     }
 
     /**
@@ -313,10 +382,26 @@ class Group extends AbstractBaseApi
         self::checkApiClient();
 
         $endpoint = sprintf('groups/%d/users', $this->id);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $usersData = json_decode($response->getBody()->getContents(), true);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->fetchAllPages();
 
-        return array_map(fn($data) => new User($data), $usersData);
+        return array_map(fn($data) => new User($data), $allData);
+    }
+
+    /**
+     * Get paginated group members
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function membersPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch group members');
+        }
+
+        return self::getPaginatedResponse(sprintf('groups/%d/users', $this->id), $params);
     }
 
     /**
@@ -325,20 +410,87 @@ class Group extends AbstractBaseApi
      * @param int $userId User ID to add
      * @return bool
      * @throws CanvasApiException
+     * @deprecated Use createMembership() for more control
      */
     public function addUser(int $userId): bool
     {
+        try {
+            $membership = $this->createMembership(['user_id' => $userId]);
+            return $membership !== null;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Create a membership in this group
+     *
+     * @param array<string, mixed>|CreateGroupMembershipDTO $data Membership data
+     * @return GroupMembership
+     * @throws CanvasApiException
+     */
+    public function createMembership(array|CreateGroupMembershipDTO $data): GroupMembership
+    {
         if (!$this->id) {
-            throw new CanvasApiException('Group ID is required to add user to group');
+            throw new CanvasApiException('Group ID is required to create membership');
+        }
+
+        return GroupMembership::create($this->id, $data);
+    }
+
+    /**
+     * Get memberships for this group
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupMembership>
+     * @throws CanvasApiException
+     */
+    public function memberships(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch memberships');
+        }
+
+        return GroupMembership::fetchAllForGroup($this->id, $params);
+    }
+
+    /**
+     * Get paginated memberships for this group
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public function membershipsPaginated(array $params = []): PaginatedResponse
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch memberships');
+        }
+
+        return GroupMembership::fetchAllPaginated($this->id, $params);
+    }
+
+    /**
+     * Invite users to this group
+     *
+     * @param array<string> $emails Email addresses to invite
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function invite(array $emails): bool
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to invite users');
         }
 
         self::checkApiClient();
 
         try {
-            $endpoint = sprintf('groups/%d/memberships', $this->id);
-            $data = [
-                ['name' => 'user_id', 'contents' => (string)$userId]
-            ];
+            $endpoint = sprintf('groups/%d/invite', $this->id);
+            $data = [];
+            foreach ($emails as $email) {
+                $data[] = ['name' => 'invitees[]', 'contents' => $email];
+            }
             self::$apiClient->post($endpoint, ['multipart' => $data]);
             return true;
         } catch (\Exception $e) {
@@ -359,33 +511,94 @@ class Group extends AbstractBaseApi
             throw new CanvasApiException('Group ID is required to remove user from group');
         }
 
-        self::checkApiClient();
-
         try {
-            // First get the membership ID
-            $endpoint = sprintf('groups/%d/memberships', $this->id);
-            $response = self::$apiClient->get($endpoint, ['query' => ['filter_states[]' => 'accepted']]);
-            $memberships = json_decode($response->getBody()->getContents(), true);
+            // Find the user's membership
+            $memberships = $this->memberships(['filter_states[]' => 'accepted']);
+            $membershipToDelete = null;
 
-            $membershipId = null;
             foreach ($memberships as $membership) {
-                if ($membership['user_id'] == $userId) {
-                    $membershipId = $membership['id'];
+                if ($membership->userId == $userId) {
+                    $membershipToDelete = $membership;
                     break;
                 }
             }
 
-            if (!$membershipId) {
+            if (!$membershipToDelete) {
                 return false;
             }
 
             // Delete the membership
-            $deleteEndpoint = sprintf('groups/%d/memberships/%d', $this->id, $membershipId);
-            self::$apiClient->delete($deleteEndpoint);
-            return true;
+            return $membershipToDelete->delete();
         } catch (\Exception $e) {
             return false;
         }
+    }
+
+    /**
+     * Get group activity stream
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<mixed>
+     * @throws CanvasApiException
+     */
+    public function activityStream(array $params = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch activity stream');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/activity_stream', $this->id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Get group activity stream summary
+     *
+     * @return array<mixed>
+     * @throws CanvasApiException
+     */
+    public function activityStreamSummary(): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch activity stream summary');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/activity_stream/summary', $this->id);
+        $response = self::$apiClient->get($endpoint);
+
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
+     * Get permissions for the current user
+     *
+     * @param array<string> $permissions Optional array of permission names to check
+     * @return array<string, bool>
+     * @throws CanvasApiException
+     */
+    public function permissions(array $permissions = []): array
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch permissions');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/permissions', $this->id);
+        $params = [];
+        if (!empty($permissions)) {
+            $params['permissions'] = $permissions;
+        }
+
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+
+        return json_decode($response->getBody()->getContents(), true);
     }
 
     /**
@@ -485,5 +698,107 @@ class Group extends AbstractBaseApi
     public function setHtmlUrl(?string $htmlUrl): void
     {
         $this->htmlUrl = $htmlUrl;
+    }
+
+    public function getContextName(): ?string
+    {
+        return $this->contextName;
+    }
+
+    public function setContextName(?string $contextName): void
+    {
+        $this->contextName = $contextName;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getUsers(): ?array
+    {
+        return $this->users;
+    }
+
+    /**
+     * @param array<mixed>|null $users
+     */
+    public function setUsers(?array $users): void
+    {
+        $this->users = $users;
+    }
+
+    public function getNonCollaborative(): ?bool
+    {
+        return $this->nonCollaborative;
+    }
+
+    public function setNonCollaborative(?bool $nonCollaborative): void
+    {
+        $this->nonCollaborative = $nonCollaborative;
+    }
+
+    public function getContextType(): ?string
+    {
+        return $this->contextType;
+    }
+
+    public function setContextType(?string $contextType): void
+    {
+        $this->contextType = $contextType;
+    }
+
+    public function getRole(): ?string
+    {
+        return $this->role;
+    }
+
+    public function setRole(?string $role): void
+    {
+        $this->role = $role;
+    }
+
+    public function getGroupCategoryId(): ?int
+    {
+        return $this->groupCategoryId;
+    }
+
+    public function setGroupCategoryId(?int $groupCategoryId): void
+    {
+        $this->groupCategoryId = $groupCategoryId;
+    }
+
+    /**
+     * @return array<string, bool>|null
+     */
+    public function getPermissions(): ?array
+    {
+        return $this->permissions;
+    }
+
+    /**
+     * @param array<string, bool>|null $permissions
+     */
+    public function setPermissions(?array $permissions): void
+    {
+        $this->permissions = $permissions;
+    }
+
+    public function getJoinLevel(): ?string
+    {
+        return $this->joinLevel;
+    }
+
+    public function setJoinLevel(?string $joinLevel): void
+    {
+        $this->joinLevel = $joinLevel;
+    }
+
+    public function getWorkflowState(): ?string
+    {
+        return $this->workflowState;
+    }
+
+    public function setWorkflowState(?string $workflowState): void
+    {
+        $this->workflowState = $workflowState;
     }
 }

--- a/src/Api/Groups/GroupMembership.php
+++ b/src/Api/Groups/GroupMembership.php
@@ -1,0 +1,546 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Api\Groups;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Users\User;
+use CanvasLMS\Dto\Groups\CreateGroupMembershipDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
+
+/**
+ * Canvas LMS Group Memberships API
+ *
+ * Group memberships are the objects that tie users and groups together.
+ * They handle the relationships between users and groups including
+ * invitations, acceptances, and membership states.
+ *
+ * @see https://canvas.instructure.com/doc/api/groups.html#group-memberships
+ *
+ * @package CanvasLMS\Api\Groups
+ */
+class GroupMembership extends AbstractBaseApi
+{
+    /**
+     * The unique identifier for the membership
+     */
+    public ?int $id = null;
+
+    /**
+     * The ID of the group
+     */
+    public ?int $groupId = null;
+
+    /**
+     * The ID of the user
+     */
+    public ?int $userId = null;
+
+    /**
+     * The workflow state of the membership
+     * Values: 'accepted', 'invited', 'requested'
+     */
+    public ?string $workflowState = null;
+
+    /**
+     * Whether the user is a moderator of the group (observer, admin, etc)
+     */
+    public ?bool $moderator = null;
+
+    /**
+     * The user object (when include[]=user)
+     * @var User|null
+     */
+    public ?User $user = null;
+
+    /**
+     * The group object (when include[]=group)
+     * @var Group|null
+     */
+    public ?Group $group = null;
+
+    /**
+     * When the membership was created
+     */
+    public ?string $createdAt = null;
+
+    /**
+     * When the membership was last updated
+     */
+    public ?string $updatedAt = null;
+
+    /**
+     * Just created membership flag
+     */
+    public ?bool $justCreated = null;
+
+    /**
+     * The SIS ID of the group
+     */
+    public ?string $sisGroupId = null;
+
+    /**
+     * The SIS import ID
+     */
+    public ?int $sisImportId = null;
+
+    /**
+     * Get a single group membership
+     *
+     * @param int $id Membership ID (for interface compatibility)
+     * @param int|null $groupId Group ID (required for this resource)
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function find(int $id, ?int $groupId = null): self
+    {
+        if ($groupId === null) {
+            throw new CanvasApiException('Group ID is required to find a membership');
+        }
+
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/memberships/%d', $groupId, $id);
+        $response = self::$apiClient->get($endpoint);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new self($data);
+    }
+
+    /**
+     * List group memberships (interface requirement)
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupMembership>
+     * @throws CanvasApiException
+     */
+    public static function fetchAll(array $params = []): array
+    {
+        throw new CanvasApiException('Group ID is required. Use fetchAllForGroup($groupId, $params) instead.');
+    }
+
+    /**
+     * List group memberships for a specific group
+     *
+     * @param int $groupId Group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupMembership>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllForGroup(int $groupId, array $params = []): array
+    {
+        return self::fetchAllPages($groupId, $params);
+    }
+
+    /**
+     * Get paginated group memberships
+     *
+     * @param int $groupId Group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginatedResponse
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPaginated(int $groupId, array $params = []): PaginatedResponse
+    {
+        return self::getPaginatedResponse(sprintf('groups/%d/memberships', $groupId), $params);
+    }
+
+    /**
+     * Get a single page of group memberships
+     *
+     * @param int $groupId Group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function fetchPage(int $groupId, array $params = []): PaginationResult
+    {
+        $paginatedResponse = self::fetchAllPaginated($groupId, $params);
+        return self::createPaginationResult($paginatedResponse);
+    }
+
+    /**
+     * Get all pages of group memberships
+     *
+     * @param int $groupId Group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<GroupMembership>
+     * @throws CanvasApiException
+     */
+    public static function fetchAllPages(int $groupId, array $params = []): array
+    {
+        return self::fetchAllPagesAsModels(sprintf('groups/%d/memberships', $groupId), $params);
+    }
+
+    /**
+     * Create a membership
+     *
+     * @param int $groupId Group ID
+     * @param array<string, mixed>|CreateGroupMembershipDTO $data Membership data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function create(int $groupId, array|CreateGroupMembershipDTO $data): self
+    {
+        self::checkApiClient();
+
+        if (is_array($data)) {
+            $data = new CreateGroupMembershipDTO($data);
+        }
+
+        $endpoint = sprintf('groups/%d/memberships', $groupId);
+        $response = self::$apiClient->post($endpoint, ['multipart' => $data->toApiArray()]);
+        $membershipData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($membershipData);
+    }
+
+    /**
+     * Update a membership
+     *
+     * @param int $groupId Group ID
+     * @param int $membershipId Membership ID
+     * @param array<string, mixed> $data Update data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function update(int $groupId, int $membershipId, array $data): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/memberships/%d', $groupId, $membershipId);
+        $multipart = [];
+
+        if (isset($data['workflow_state'])) {
+            $multipart[] = ['name' => 'workflow_state', 'contents' => $data['workflow_state']];
+        }
+
+        if (isset($data['moderator'])) {
+            $multipart[] = ['name' => 'moderator', 'contents' => $data['moderator'] ? 'true' : 'false'];
+        }
+
+        $response = self::$apiClient->put($endpoint, ['multipart' => $multipart]);
+        $membershipData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($membershipData);
+    }
+
+    /**
+     * Update a membership by user ID
+     *
+     * @param int $groupId Group ID
+     * @param int $userId User ID
+     * @param array<string, mixed> $data Update data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function updateByUserId(int $groupId, int $userId, array $data): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/users/%d', $groupId, $userId);
+        $multipart = [];
+
+        if (isset($data['workflow_state'])) {
+            $multipart[] = ['name' => 'workflow_state', 'contents' => $data['workflow_state']];
+        }
+
+        if (isset($data['moderator'])) {
+            $multipart[] = ['name' => 'moderator', 'contents' => $data['moderator'] ? 'true' : 'false'];
+        }
+
+        $response = self::$apiClient->put($endpoint, ['multipart' => $multipart]);
+        $membershipData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($membershipData);
+    }
+
+    /**
+     * Delete a membership (leave group)
+     *
+     * @param int $groupId Group ID
+     * @param int $membershipId Membership ID
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public static function deleteMembership(int $groupId, int $membershipId): bool
+    {
+        try {
+            self::checkApiClient();
+            $endpoint = sprintf('groups/%d/memberships/%d', $groupId, $membershipId);
+            self::$apiClient->delete($endpoint);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Delete this membership instance
+     *
+     * @return bool
+     */
+    public function delete(): bool
+    {
+        if (!$this->groupId || !$this->id) {
+            return false;
+        }
+
+        return self::deleteMembership($this->groupId, $this->id);
+    }
+
+    /**
+     * Leave a group (for current user)
+     *
+     * @param int $groupId Group ID
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public static function leave(int $groupId): bool
+    {
+        try {
+            self::checkApiClient();
+            $endpoint = sprintf('groups/%d/memberships/self', $groupId);
+            self::$apiClient->delete($endpoint);
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Constructor override to handle nested objects
+     *
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data)
+    {
+        $userData = null;
+        $groupData = null;
+
+        // Extract nested objects before parent constructor
+        if (isset($data['user']) && is_array($data['user'])) {
+            $userData = $data['user'];
+            unset($data['user']);
+        }
+
+        if (isset($data['group']) && is_array($data['group'])) {
+            $groupData = $data['group'];
+            unset($data['group']);
+        }
+
+        // Call parent constructor with cleaned data
+        parent::__construct($data);
+
+        // Create nested objects after properties are set
+        if ($userData !== null) {
+            $this->user = new User($userData);
+        }
+
+        if ($groupData !== null) {
+            $this->group = new Group($groupData);
+        }
+    }
+
+    /**
+     * Get membership by user ID
+     *
+     * @param int $groupId Group ID
+     * @param int $userId User ID
+     * @return self
+     * @throws CanvasApiException
+     */
+    public static function findByUserId(int $groupId, int $userId): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('groups/%d/users/%d', $groupId, $userId);
+        $response = self::$apiClient->get($endpoint);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new self($data);
+    }
+
+
+    /**
+     * Accept this membership invitation
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function accept(): bool
+    {
+        if (!$this->groupId || !$this->id) {
+            throw new CanvasApiException('Group ID and Membership ID are required');
+        }
+
+        try {
+            $updated = self::update($this->groupId, $this->id, ['workflow_state' => 'accepted']);
+            // Update properties from the returned object
+            foreach (get_object_vars($updated) as $key => $value) {
+                if (property_exists($this, $key)) {
+                    $this->$key = $value;
+                }
+            }
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Reject this membership invitation
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function reject(): bool
+    {
+        if (!$this->groupId || !$this->id) {
+            throw new CanvasApiException('Group ID and Membership ID are required');
+        }
+
+        return self::deleteMembership($this->groupId, $this->id);
+    }
+
+    /**
+     * Make this member a moderator
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function makeModerator(): bool
+    {
+        if (!$this->groupId || !$this->id) {
+            throw new CanvasApiException('Group ID and Membership ID are required');
+        }
+
+        try {
+            $updated = self::update($this->groupId, $this->id, ['moderator' => true]);
+            // Update properties from the returned object
+            foreach (get_object_vars($updated) as $key => $value) {
+                if (property_exists($this, $key)) {
+                    $this->$key = $value;
+                }
+            }
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Remove moderator status
+     *
+     * @return bool
+     * @throws CanvasApiException
+     */
+    public function removeModerator(): bool
+    {
+        if (!$this->groupId || !$this->id) {
+            throw new CanvasApiException('Group ID and Membership ID are required');
+        }
+
+        try {
+            $updated = self::update($this->groupId, $this->id, ['moderator' => false]);
+            // Update properties from the returned object
+            foreach (get_object_vars($updated) as $key => $value) {
+                if (property_exists($this, $key)) {
+                    $this->$key = $value;
+                }
+            }
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    // Getter and setter methods
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getGroupId(): ?int
+    {
+        return $this->groupId;
+    }
+
+    public function setGroupId(?int $groupId): void
+    {
+        $this->groupId = $groupId;
+    }
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(?int $userId): void
+    {
+        $this->userId = $userId;
+    }
+
+    public function getWorkflowState(): ?string
+    {
+        return $this->workflowState;
+    }
+
+    public function setWorkflowState(?string $workflowState): void
+    {
+        $this->workflowState = $workflowState;
+    }
+
+    public function getModerator(): ?bool
+    {
+        return $this->moderator;
+    }
+
+    public function setModerator(?bool $moderator): void
+    {
+        $this->moderator = $moderator;
+    }
+
+    public function getUser(): ?User
+    {
+        if ($this->user === null && $this->userId !== null) {
+            self::checkApiClient();
+            $this->user = User::find($this->userId);
+        }
+        return $this->user;
+    }
+
+    public function setUser(?User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getGroup(): ?Group
+    {
+        return $this->group;
+    }
+
+    public function setGroup(?Group $group): void
+    {
+        $this->group = $group;
+    }
+
+    public function getJustCreated(): ?bool
+    {
+        return $this->justCreated;
+    }
+
+    public function setJustCreated(?bool $justCreated): void
+    {
+        $this->justCreated = $justCreated;
+    }
+}

--- a/src/Api/Users/User.php
+++ b/src/Api/Users/User.php
@@ -253,7 +253,7 @@ class User extends AbstractBaseApi
         self::checkApiClient();
 
         $response = self::$apiClient->get("/users/{$id}");
-        return new self(json_decode($response->getBody(), true));
+        return new self(json_decode($response->getBody()->getContents(), true));
     }
 
     /**

--- a/src/Dto/GroupCategories/CreateGroupCategoryDTO.php
+++ b/src/Dto/GroupCategories/CreateGroupCategoryDTO.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Dto\GroupCategories;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+
+/**
+ * Data Transfer Object for creating a group category in Canvas LMS.
+ *
+ * @package CanvasLMS\Dto\GroupCategories
+ */
+class CreateGroupCategoryDTO extends AbstractBaseDto
+{
+    /**
+     * Name of the group category (required)
+     */
+    public ?string $name = null;
+
+    /**
+     * Allow students to sign up for a group themselves
+     * Values: 'enabled', 'restricted', null
+     */
+    public ?string $selfSignup = null;
+
+    /**
+     * Assigns group leaders automatically
+     * Values: 'first', 'random', null
+     */
+    public ?string $autoLeader = null;
+
+    /**
+     * Limit the maximum number of users in each group
+     * Requires self signup
+     */
+    public ?int $groupLimit = null;
+
+    /**
+     * The unique SIS identifier
+     */
+    public ?string $sisGroupCategoryId = null;
+
+    /**
+     * Create this number of groups
+     */
+    public ?int $createGroupCount = null;
+
+    /**
+     * (Deprecated) Create groups and evenly distribute students
+     * @deprecated Use assign_unassigned_members endpoint instead
+     */
+    public ?string $splitGroupCount = null;
+
+    /**
+     * Can only be set by users with Differentiation Tag permissions
+     * If true, groups will only be visible to users with manage permission
+     */
+    public ?bool $nonCollaborative = null;
+
+    /**
+     * Course ID for creating group category in course context
+     */
+    public ?int $courseId = null;
+
+    /**
+     * Convert DTO to API-compatible array format
+     *
+     * @return array<array{name: string, contents: string}>
+     */
+    public function toApiArray(): array
+    {
+        $data = [];
+
+        if ($this->name !== null) {
+            $data[] = ['name' => 'name', 'contents' => $this->name];
+        }
+
+        if ($this->selfSignup !== null) {
+            $data[] = ['name' => 'self_signup', 'contents' => $this->selfSignup];
+        }
+
+        if ($this->autoLeader !== null) {
+            $data[] = ['name' => 'auto_leader', 'contents' => $this->autoLeader];
+        }
+
+        if ($this->groupLimit !== null) {
+            $data[] = ['name' => 'group_limit', 'contents' => (string)$this->groupLimit];
+        }
+
+        if ($this->sisGroupCategoryId !== null) {
+            $data[] = ['name' => 'sis_group_category_id', 'contents' => $this->sisGroupCategoryId];
+        }
+
+        if ($this->createGroupCount !== null) {
+            $data[] = ['name' => 'create_group_count', 'contents' => (string)$this->createGroupCount];
+        }
+
+        if ($this->splitGroupCount !== null) {
+            $data[] = ['name' => 'split_group_count', 'contents' => $this->splitGroupCount];
+        }
+
+        if ($this->nonCollaborative !== null) {
+            $data[] = ['name' => 'non_collaborative', 'contents' => $this->nonCollaborative ? 'true' : 'false'];
+        }
+
+        if ($this->courseId !== null) {
+            $data[] = ['name' => 'course_id', 'contents' => (string)$this->courseId];
+        }
+
+        return $data;
+    }
+}

--- a/src/Dto/GroupCategories/UpdateGroupCategoryDTO.php
+++ b/src/Dto/GroupCategories/UpdateGroupCategoryDTO.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Dto\GroupCategories;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+
+/**
+ * Data Transfer Object for updating a group category in Canvas LMS.
+ *
+ * @package CanvasLMS\Dto\GroupCategories
+ */
+class UpdateGroupCategoryDTO extends AbstractBaseDto
+{
+    /**
+     * Name of the group category
+     */
+    public ?string $name = null;
+
+    /**
+     * Allow students to sign up for a group themselves
+     * Values: 'enabled', 'restricted', null
+     */
+    public ?string $selfSignup = null;
+
+    /**
+     * Assigns group leaders automatically
+     * Values: 'first', 'random', null
+     */
+    public ?string $autoLeader = null;
+
+    /**
+     * Limit the maximum number of users in each group
+     * Requires self signup
+     */
+    public ?int $groupLimit = null;
+
+    /**
+     * The unique SIS identifier
+     */
+    public ?string $sisGroupCategoryId = null;
+
+    /**
+     * Create this number of groups
+     */
+    public ?int $createGroupCount = null;
+
+    /**
+     * (Deprecated) Create groups and evenly distribute students
+     * @deprecated Use assign_unassigned_members endpoint instead
+     */
+    public ?string $splitGroupCount = null;
+
+    /**
+     * Convert DTO to API-compatible array format
+     *
+     * @return array<array{name: string, contents: string}>
+     */
+    public function toApiArray(): array
+    {
+        $data = [];
+
+        if ($this->name !== null) {
+            $data[] = ['name' => 'name', 'contents' => $this->name];
+        }
+
+        if ($this->selfSignup !== null) {
+            $data[] = ['name' => 'self_signup', 'contents' => $this->selfSignup];
+        }
+
+        if ($this->autoLeader !== null) {
+            $data[] = ['name' => 'auto_leader', 'contents' => $this->autoLeader];
+        }
+
+        if ($this->groupLimit !== null) {
+            $data[] = ['name' => 'group_limit', 'contents' => (string)$this->groupLimit];
+        }
+
+        if ($this->sisGroupCategoryId !== null) {
+            $data[] = ['name' => 'sis_group_category_id', 'contents' => $this->sisGroupCategoryId];
+        }
+
+        if ($this->createGroupCount !== null) {
+            $data[] = ['name' => 'create_group_count', 'contents' => (string)$this->createGroupCount];
+        }
+
+        if ($this->splitGroupCount !== null) {
+            $data[] = ['name' => 'split_group_count', 'contents' => $this->splitGroupCount];
+        }
+
+        return $data;
+    }
+}

--- a/src/Dto/Groups/CreateGroupMembershipDTO.php
+++ b/src/Dto/Groups/CreateGroupMembershipDTO.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Dto\Groups;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+
+/**
+ * Data Transfer Object for creating a group membership in Canvas LMS.
+ *
+ * @package CanvasLMS\Dto\Groups
+ */
+class CreateGroupMembershipDTO extends AbstractBaseDto
+{
+    /**
+     * User ID to add to the group
+     */
+    public ?int $userId = null;
+
+    /**
+     * Array of user IDs to add to the group (for bulk operations)
+     * @var array<int>|null
+     */
+    public ?array $userIds = null;
+
+    /**
+     * Email addresses to invite to the group
+     * @var array<string>|null
+     */
+    public ?array $invitees = null;
+
+    /**
+     * Whether to make the user(s) a moderator
+     */
+    public ?bool $moderator = null;
+
+    /**
+     * Workflow state for the membership
+     * Values: 'accepted', 'invited', 'requested'
+     */
+    public ?string $workflowState = null;
+
+    /**
+     * Convert DTO to API-compatible array format
+     *
+     * @return array<array{name: string, contents: string}>
+     */
+    public function toApiArray(): array
+    {
+        $data = [];
+
+        if ($this->userId !== null) {
+            $data[] = ['name' => 'user_id', 'contents' => (string)$this->userId];
+        }
+
+        if ($this->userIds !== null) {
+            foreach ($this->userIds as $userId) {
+                $data[] = ['name' => 'user_ids[]', 'contents' => (string)$userId];
+            }
+        }
+
+        if ($this->invitees !== null) {
+            foreach ($this->invitees as $email) {
+                $data[] = ['name' => 'invitees[]', 'contents' => $email];
+            }
+        }
+
+        if ($this->moderator !== null) {
+            $data[] = ['name' => 'moderator', 'contents' => $this->moderator ? 'true' : 'false'];
+        }
+
+        if ($this->workflowState !== null) {
+            $data[] = ['name' => 'workflow_state', 'contents' => $this->workflowState];
+        }
+
+        return $data;
+    }
+}

--- a/src/Dto/Groups/UpdateGroupDTO.php
+++ b/src/Dto/Groups/UpdateGroupDTO.php
@@ -44,6 +44,22 @@ class UpdateGroupDTO extends AbstractBaseDto
     public ?string $sisGroupId = null;
 
     /**
+     * The ID of the avatar attachment to use for the group
+     */
+    public ?int $avatarId = null;
+
+    /**
+     * An array of user IDs to add as group members
+     * @var array<int>|null
+     */
+    public ?array $members = null;
+
+    /**
+     * Override any sis stickiness
+     */
+    public ?bool $overrideSisStickiness = null;
+
+    /**
      * Convert DTO to API-compatible array format
      *
      * @return array<array{name: string, contents: string}>
@@ -74,6 +90,23 @@ class UpdateGroupDTO extends AbstractBaseDto
 
         if ($this->sisGroupId !== null) {
             $data[] = ['name' => 'sis_group_id', 'contents' => $this->sisGroupId];
+        }
+
+        if ($this->avatarId !== null) {
+            $data[] = ['name' => 'avatar_id', 'contents' => (string)$this->avatarId];
+        }
+
+        if ($this->members !== null) {
+            foreach ($this->members as $memberId) {
+                $data[] = ['name' => 'members[]', 'contents' => (string)$memberId];
+            }
+        }
+
+        if ($this->overrideSisStickiness !== null) {
+            $data[] = [
+                'name' => 'override_sis_stickiness',
+                'contents' => $this->overrideSisStickiness ? 'true' : 'false'
+            ];
         }
 
         return $data;

--- a/tests/Api/GroupCategories/GroupCategoryTest.php
+++ b/tests/Api/GroupCategories/GroupCategoryTest.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Api\GroupCategories;
+
+use CanvasLMS\Api\GroupCategories\GroupCategory;
+use CanvasLMS\Api\Groups\Group;
+use CanvasLMS\Api\Users\User;
+use CanvasLMS\Dto\GroupCategories\CreateGroupCategoryDTO;
+use CanvasLMS\Dto\GroupCategories\UpdateGroupCategoryDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Pagination\PaginatedResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class GroupCategoryTest extends TestCase
+{
+    private HttpClientInterface $mockHttpClient;
+    private ResponseInterface $mockResponse;
+    private StreamInterface $mockStream;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $this->mockResponse = $this->createMock(ResponseInterface::class);
+        $this->mockStream = $this->createMock(StreamInterface::class);
+        
+        GroupCategory::setApiClient($this->mockHttpClient);
+        \CanvasLMS\Config::setAccountId(1);
+    }
+
+    public function testConstructor(): void
+    {
+        $data = [
+            'id' => 123,
+            'name' => 'Test Category',
+            'role' => 'communities',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'random',
+            'context_type' => 'Course',
+            'context_id' => 456,
+            'course_id' => 456,
+            'group_limit' => 5,
+            'sis_group_category_id' => 'SIS123',
+            'sis_import_id' => 999,
+            'progress' => ['completion' => 50],
+            'non_collaborative' => false
+        ];
+
+        $category = new GroupCategory($data);
+
+        $this->assertEquals(123, $category->id);
+        $this->assertEquals('Test Category', $category->name);
+        $this->assertEquals('communities', $category->role);
+        $this->assertEquals('enabled', $category->selfSignup);
+        $this->assertEquals('random', $category->autoLeader);
+        $this->assertEquals('Course', $category->contextType);
+        $this->assertEquals(456, $category->contextId);
+        $this->assertEquals(456, $category->courseId);
+        $this->assertEquals(5, $category->groupLimit);
+        $this->assertEquals('SIS123', $category->sisGroupCategoryId);
+        $this->assertEquals(999, $category->sisImportId);
+        $this->assertIsArray($category->progress);
+        $this->assertFalse($category->nonCollaborative);
+    }
+
+    public function testFind(): void
+    {
+        $categoryData = [
+            'id' => 123,
+            'name' => 'Test Category',
+            'role' => 'communities'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($categoryData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('group_categories/123')
+            ->willReturn($this->mockResponse);
+
+        $category = GroupCategory::find(123);
+
+        $this->assertInstanceOf(GroupCategory::class, $category);
+        $this->assertEquals(123, $category->id);
+        $this->assertEquals('Test Category', $category->name);
+    }
+
+    public function testFetchAll(): void
+    {
+        $categoriesData = [
+            ['id' => 1, 'name' => 'Category 1'],
+            ['id' => 2, 'name' => 'Category 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($categoriesData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('accounts/1/group_categories', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $categories = GroupCategory::fetchAll();
+
+        $this->assertIsArray($categories);
+        $this->assertCount(2, $categories);
+        $this->assertInstanceOf(GroupCategory::class, $categories[0]);
+        $this->assertEquals('Category 1', $categories[0]->name);
+    }
+
+    public function testFetchAllFromAccount(): void
+    {
+        $categoriesData = [
+            ['id' => 1, 'name' => 'Account Category 1'],
+            ['id' => 2, 'name' => 'Account Category 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($categoriesData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('accounts/1/group_categories', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $categories = GroupCategory::fetchAll();
+
+        $this->assertIsArray($categories);
+        $this->assertCount(2, $categories);
+        $this->assertInstanceOf(GroupCategory::class, $categories[0]);
+        $this->assertEquals('Account Category 1', $categories[0]->name);
+    }
+
+    public function testCreate(): void
+    {
+        $createData = [
+            'name' => 'New Category',
+            'self_signup' => 'enabled',
+            'group_limit' => 5
+        ];
+
+        $responseData = array_merge($createData, ['id' => 123]);
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('accounts/1/group_categories', $this->callback(function ($options) {
+                return isset($options['multipart']) && is_array($options['multipart']);
+            }))
+            ->willReturn($this->mockResponse);
+
+        $category = GroupCategory::create($createData);
+
+        $this->assertInstanceOf(GroupCategory::class, $category);
+        $this->assertEquals(123, $category->id);
+        $this->assertEquals('New Category', $category->name);
+    }
+
+    public function testCreateWithDTO(): void
+    {
+        $dto = new CreateGroupCategoryDTO(['name' => 'DTO Category']);
+        $dto->self_signup = 'restricted';
+        $dto->group_limit = 3;
+
+        $responseData = [
+            'id' => 123,
+            'name' => 'DTO Category',
+            'self_signup' => 'restricted',
+            'group_limit' => 3
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->willReturn($this->mockResponse);
+
+        $category = GroupCategory::create($dto);
+
+        $this->assertInstanceOf(GroupCategory::class, $category);
+        $this->assertEquals('restricted', $category->selfSignup);
+    }
+
+    public function testUpdate(): void
+    {
+        $updateData = [
+            'name' => 'Updated Category',
+            'self_signup' => 'disabled'
+        ];
+
+        $responseData = array_merge($updateData, ['id' => 123]);
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('group_categories/123', $this->callback(function ($options) {
+                return isset($options['multipart']) && is_array($options['multipart']);
+            }))
+            ->willReturn($this->mockResponse);
+
+        $category = GroupCategory::update(123, $updateData);
+
+        $this->assertInstanceOf(GroupCategory::class, $category);
+        $this->assertEquals('Updated Category', $category->name);
+        $this->assertEquals('disabled', $category->selfSignup);
+    }
+
+    public function testDelete(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('group_categories/123')
+            ->willReturn($this->mockResponse);
+
+        $result = $category->delete();
+
+        $this->assertTrue($result);
+    }
+
+    public function testSave(): void
+    {
+        $category = new GroupCategory(['name' => 'Test Category']);
+        
+        $responseData = [
+            'id' => 123,
+            'name' => 'Test Category'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->willReturn($this->mockResponse);
+
+        $result = $category->save();
+
+        $this->assertTrue($result);
+        $this->assertEquals(123, $category->id);
+    }
+
+    public function testGroups(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $groupsData = [
+            ['id' => 1, 'name' => 'Group 1'],
+            ['id' => 2, 'name' => 'Group 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($groupsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('group_categories/123/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $groups = $category->groups();
+
+        $this->assertIsArray($groups);
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+    }
+
+    public function testGroupsPaginated(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('group_categories/123/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $result = $category->groupsPaginated();
+
+        $this->assertSame($mockPaginatedResponse, $result);
+    }
+
+    public function testUsers(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $usersData = [
+            ['id' => 1, 'name' => 'User 1'],
+            ['id' => 2, 'name' => 'User 2']
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($usersData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('group_categories/123/users', ['query' => ['unassigned' => true]])
+            ->willReturn($this->mockResponse);
+
+        $users = $category->users(['unassigned' => true]);
+
+        $this->assertIsArray($users);
+        $this->assertCount(2, $users);
+        $this->assertInstanceOf(User::class, $users[0]);
+    }
+
+    public function testAssignUnassignedMembers(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $progressData = [
+            'id' => 456,
+            'workflow_state' => 'running',
+            'completion' => 0
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($progressData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('group_categories/123/assign_unassigned_members', [])
+            ->willReturn($this->mockResponse);
+
+        $result = $category->assignUnassignedMembers();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(456, $result['id']);
+        $this->assertEquals('running', $result['workflow_state']);
+        $this->assertEquals(0, $result['completion']);
+    }
+
+    public function testAssignUnassignedMembersSync(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $groupsData = [
+            ['id' => 1, 'name' => 'Group 1'],
+            ['id' => 2, 'name' => 'Group 2']
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($groupsData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('group_categories/123/assign_unassigned_members', ['multipart' => [['name' => 'sync', 'contents' => 'true']]])
+            ->willReturn($this->mockResponse);
+
+        $groups = $category->assignUnassignedMembers(true);
+
+        $this->assertIsArray($groups);
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+    }
+
+    public function testExport(): void
+    {
+        $category = new GroupCategory(['id' => 123]);
+        
+        $exportData = [
+            ['group_name' => 'Group 1', 'user_name' => 'User 1'],
+            ['group_name' => 'Group 2', 'user_name' => 'User 2']
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($exportData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('group_categories/123/export')
+            ->willReturn($this->mockResponse);
+
+        $export = $category->export();
+
+        $this->assertIsArray($export);
+        $this->assertCount(2, $export);
+        $this->assertEquals('Group 1', $export[0]['group_name']);
+        $this->assertEquals('User 1', $export[0]['user_name']);
+    }
+
+
+    public function testToDtoArray(): void
+    {
+        $category = new GroupCategory([
+            'id' => 123,
+            'name' => 'Test Category',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'first',
+            'group_limit' => 5,
+            'context_type' => 'Course',
+            'context_id' => 456
+        ]);
+
+        $array = $category->toDtoArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals('Test Category', $array['name']);
+        $this->assertEquals('enabled', $array['self_signup']);
+        $this->assertEquals('first', $array['auto_leader']);
+        $this->assertEquals(5, $array['group_limit']);
+        $this->assertArrayNotHasKey('id', $array);
+        $this->assertArrayNotHasKey('context_type', $array);
+        $this->assertArrayNotHasKey('context_id', $array);
+    }
+
+    public function testGettersAndSetters(): void
+    {
+        $category = new GroupCategory([]);
+        
+        $category->name = 'New Name';
+        $this->assertEquals('New Name', $category->name);
+        
+        $category->selfSignup = 'enabled';
+        $this->assertEquals('enabled', $category->selfSignup);
+        
+        $category->groupLimit = 10;
+        $this->assertEquals(10, $category->groupLimit);
+        
+        $category->autoLeader = 'random';
+        $this->assertEquals('random', $category->autoLeader);
+    }
+}

--- a/tests/Api/Groups/GroupMembershipTest.php
+++ b/tests/Api/Groups/GroupMembershipTest.php
@@ -1,0 +1,417 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Api\Groups;
+
+use CanvasLMS\Api\Groups\GroupMembership;
+use CanvasLMS\Api\Users\User;
+use CanvasLMS\Dto\Groups\CreateGroupMembershipDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Pagination\PaginatedResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class GroupMembershipTest extends TestCase
+{
+    private HttpClientInterface $mockHttpClient;
+    private ResponseInterface $mockResponse;
+    private StreamInterface $mockStream;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $this->mockResponse = $this->createMock(ResponseInterface::class);
+        $this->mockStream = $this->createMock(StreamInterface::class);
+        
+        GroupMembership::setApiClient($this->mockHttpClient);
+        User::setApiClient($this->mockHttpClient);
+    }
+
+    public function testConstructor(): void
+    {
+        $data = [
+            'id' => 123,
+            'group_id' => 456,
+            'user_id' => 789,
+            'workflow_state' => 'accepted',
+            'moderator' => true,
+            'just_created' => false,
+            'sis_import_id' => 999
+        ];
+
+        $membership = new GroupMembership($data);
+
+        $this->assertEquals(123, $membership->id);
+        $this->assertEquals(456, $membership->groupId);
+        $this->assertEquals(789, $membership->userId);
+        $this->assertEquals('accepted', $membership->workflowState);
+        $this->assertTrue($membership->moderator);
+        $this->assertFalse($membership->justCreated);
+        $this->assertEquals(999, $membership->sisImportId);
+    }
+
+    public function testFind(): void
+    {
+        $membershipData = [
+            'id' => 123,
+            'group_id' => 456,
+            'user_id' => 789,
+            'workflow_state' => 'accepted'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($membershipData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('groups/456/memberships/123')
+            ->willReturn($this->mockResponse);
+
+        $membership = GroupMembership::find(123, 456);
+
+        $this->assertInstanceOf(GroupMembership::class, $membership);
+        $this->assertEquals(123, $membership->id);
+        $this->assertEquals(456, $membership->groupId);
+    }
+
+    public function testFetchAllThrowsException(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Group ID is required. Use fetchAllForGroup($groupId, $params) instead.');
+        
+        GroupMembership::fetchAll();
+    }
+
+    public function testFetchAllForGroup(): void
+    {
+        $membershipsData = [
+            ['id' => 1, 'user_id' => 100, 'workflow_state' => 'accepted'],
+            ['id' => 2, 'user_id' => 200, 'workflow_state' => 'invited']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($membershipsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('groups/456/memberships', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $memberships = GroupMembership::fetchAllForGroup(456);
+
+        $this->assertIsArray($memberships);
+        $this->assertCount(2, $memberships);
+        $this->assertInstanceOf(GroupMembership::class, $memberships[0]);
+    }
+
+    public function testCreate(): void
+    {
+        $createData = ['user_id' => 789];
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'user_id' => 789,
+            'workflow_state' => 'accepted'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('groups/456/memberships', $this->callback(function ($options) {
+                return isset($options['multipart']) && 
+                       is_array($options['multipart']) &&
+                       $options['multipart'][0]['name'] === 'user_id' &&
+                       $options['multipart'][0]['contents'] === '789';
+            }))
+            ->willReturn($this->mockResponse);
+
+        $membership = GroupMembership::create(456, $createData);
+
+        $this->assertInstanceOf(GroupMembership::class, $membership);
+        $this->assertEquals(123, $membership->id);
+        $this->assertEquals(789, $membership->userId);
+    }
+
+    public function testCreateWithDTO(): void
+    {
+        $dto = new CreateGroupMembershipDTO(['user_id' => 789]);
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'user_id' => 789,
+            'workflow_state' => 'accepted'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->willReturn($this->mockResponse);
+
+        $membership = GroupMembership::create(456, $dto);
+
+        $this->assertInstanceOf(GroupMembership::class, $membership);
+        $this->assertEquals(789, $membership->userId);
+    }
+
+    public function testUpdate(): void
+    {
+        $updateData = ['workflow_state' => 'accepted', 'moderator' => true];
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'user_id' => 789,
+            'workflow_state' => 'accepted',
+            'moderator' => true
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('groups/456/memberships/123', $this->callback(function ($options) {
+                return isset($options['multipart']) && is_array($options['multipart']);
+            }))
+            ->willReturn($this->mockResponse);
+
+        $membership = GroupMembership::update(456, 123, $updateData);
+
+        $this->assertInstanceOf(GroupMembership::class, $membership);
+        $this->assertTrue($membership->moderator);
+        $this->assertEquals('accepted', $membership->workflowState);
+    }
+
+    public function testDelete(): void
+    {
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('groups/456/memberships/123')
+            ->willReturn($this->mockResponse);
+
+        $result = GroupMembership::deleteMembership(456, 123);
+
+        $this->assertTrue($result);
+    }
+
+
+    public function testAccept(): void
+    {
+        $membership = new GroupMembership([
+            'id' => 123,
+            'group_id' => 456,
+            'workflow_state' => 'invited'
+        ]);
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'workflow_state' => 'accepted'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('groups/456/memberships/123', $this->callback(function ($options) {
+                $multipart = $options['multipart'];
+                return $multipart[0]['name'] === 'workflow_state' &&
+                       $multipart[0]['contents'] === 'accepted';
+            }))
+            ->willReturn($this->mockResponse);
+
+        $result = $membership->accept();
+
+        $this->assertTrue($result);
+        $this->assertEquals('accepted', $membership->workflowState);
+    }
+
+    public function testReject(): void
+    {
+        $membership = new GroupMembership([
+            'id' => 123,
+            'group_id' => 456,
+            'workflow_state' => 'invited'
+        ]);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('groups/456/memberships/123')
+            ->willReturn($this->mockResponse);
+
+        $result = $membership->reject();
+
+        $this->assertTrue($result);
+    }
+
+    public function testMakeModerator(): void
+    {
+        $membership = new GroupMembership([
+            'id' => 123,
+            'group_id' => 456,
+            'moderator' => false
+        ]);
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'moderator' => true
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('groups/456/memberships/123', $this->callback(function ($options) {
+                $multipart = $options['multipart'];
+                return $multipart[0]['name'] === 'moderator' &&
+                       $multipart[0]['contents'] === 'true';
+            }))
+            ->willReturn($this->mockResponse);
+
+        $result = $membership->makeModerator();
+
+        $this->assertTrue($result);
+        $this->assertTrue($membership->moderator);
+    }
+
+    public function testRemoveModerator(): void
+    {
+        $membership = new GroupMembership([
+            'id' => 123,
+            'group_id' => 456,
+            'moderator' => true
+        ]);
+        
+        $responseData = [
+            'id' => 123,
+            'group_id' => 456,
+            'moderator' => false
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('groups/456/memberships/123', $this->callback(function ($options) {
+                $multipart = $options['multipart'];
+                return $multipart[0]['name'] === 'moderator' &&
+                       $multipart[0]['contents'] === 'false';
+            }))
+            ->willReturn($this->mockResponse);
+
+        $result = $membership->removeModerator();
+
+        $this->assertTrue($result);
+        $this->assertFalse($membership->moderator);
+    }
+
+    public function testLeave(): void
+    {
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('groups/456/memberships/self')
+            ->willReturn($this->mockResponse);
+
+        $result = GroupMembership::leave(456);
+
+        $this->assertTrue($result);
+    }
+
+    public function testGetUser(): void
+    {
+        $userData = [
+            'id' => 789,
+            'name' => 'Test User'
+        ];
+        
+        $membership = new GroupMembership([
+            'id' => 123,
+            'user_id' => 789,
+            'user' => $userData
+        ]);
+        
+        $user = $membership->getUser();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals(789, $user->id);
+        $this->assertEquals('Test User', $user->name);
+    }
+
+    public function testGetUserFetchesFromAPI(): void
+    {
+        $membership = new GroupMembership([
+            'id' => 123,
+            'user_id' => 789
+        ]);
+        
+        $userData = [
+            'id' => 789,
+            'name' => 'API User'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($userData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('/users/789')
+            ->willReturn($this->mockResponse);
+        
+        $user = $membership->getUser();
+
+        $this->assertInstanceOf(User::class, $user);
+        $this->assertEquals(789, $user->id);
+        $this->assertEquals('API User', $user->name);
+    }
+
+    public function testGetUserReturnsNullWithoutUserId(): void
+    {
+        $membership = new GroupMembership(['id' => 123]);
+        
+        $user = $membership->getUser();
+
+        $this->assertNull($user);
+    }
+
+}

--- a/tests/Api/Groups/GroupTest.php
+++ b/tests/Api/Groups/GroupTest.php
@@ -1,0 +1,509 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Api\Groups;
+
+use CanvasLMS\Api\Groups\Group;
+use CanvasLMS\Api\Groups\GroupMembership;
+use CanvasLMS\Dto\Groups\CreateGroupDTO;
+use CanvasLMS\Dto\Groups\UpdateGroupDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class GroupTest extends TestCase
+{
+    private HttpClientInterface $mockHttpClient;
+    private ResponseInterface $mockResponse;
+    private StreamInterface $mockStream;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        $this->mockResponse = $this->createMock(ResponseInterface::class);
+        $this->mockStream = $this->createMock(StreamInterface::class);
+        
+        Group::setApiClient($this->mockHttpClient);
+        \CanvasLMS\Config::setAccountId(1);
+    }
+
+    public function testConstructor(): void
+    {
+        $data = [
+            'id' => 123,
+            'name' => 'Test Group',
+            'description' => 'Test Description',
+            'is_public' => true,
+            'followed_by_user' => false,
+            'join_level' => 'invitation_only',
+            'members_count' => 10,
+            'avatar_url' => 'https://example.com/avatar.png',
+            'context_type' => 'Course',
+            'course_id' => 456,
+            'role' => 'communities',
+            'group_category_id' => 789,
+            'sis_group_id' => 'SIS123',
+            'sis_import_id' => 999,
+            'storage_quota_mb' => 50,
+            'permissions' => ['create_discussion_topic' => true],
+            'has_submission' => true,
+            'context_name' => 'Test Course',
+            'users' => [['id' => 1, 'name' => 'User 1']],
+            'non_collaborative' => false
+        ];
+
+        $group = new Group($data);
+
+        $this->assertEquals(123, $group->id);
+        $this->assertEquals('Test Group', $group->name);
+        $this->assertEquals('Test Description', $group->description);
+        $this->assertTrue($group->isPublic);
+        $this->assertFalse($group->followedByUser);
+        $this->assertEquals('invitation_only', $group->joinLevel);
+        $this->assertEquals(10, $group->membersCount);
+        $this->assertEquals('Test Course', $group->contextName);
+        $this->assertIsArray($group->users);
+        $this->assertFalse($group->nonCollaborative);
+    }
+
+    public function testFind(): void
+    {
+        $groupData = [
+            'id' => 123,
+            'name' => 'Test Group',
+            'description' => 'Test Description'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($groupData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('groups/123')
+            ->willReturn($this->mockResponse);
+
+        $group = Group::find(123);
+
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertEquals(123, $group->id);
+        $this->assertEquals('Test Group', $group->name);
+    }
+
+    public function testFetchAll(): void
+    {
+        $groupsData = [
+            ['id' => 1, 'name' => 'Group 1'],
+            ['id' => 2, 'name' => 'Group 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($groupsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('accounts/1/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $groups = Group::fetchAll();
+
+        $this->assertIsArray($groups);
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+        $this->assertEquals('Group 1', $groups[0]->name);
+    }
+
+    public function testFetchAllPaginated(): void
+    {
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('accounts/1/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $result = Group::fetchAllPaginated();
+
+        $this->assertSame($mockPaginatedResponse, $result);
+    }
+
+    public function testCreate(): void
+    {
+        $createData = [
+            'name' => 'New Group',
+            'description' => 'New Description',
+            'is_public' => true,
+            'join_level' => 'parent_context_auto_join'
+        ];
+
+        $responseData = array_merge($createData, ['id' => 123]);
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with($this->stringContains('groups'), $this->callback(function ($options) {
+                return isset($options['multipart']) && is_array($options['multipart']);
+            }))
+            ->willReturn($this->mockResponse);
+
+        $group = Group::create($createData);
+
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertEquals(123, $group->id);
+        $this->assertEquals('New Group', $group->name);
+    }
+
+    public function testUpdate(): void
+    {
+        $updateData = [
+            'name' => 'Updated Group',
+            'description' => 'Updated Description'
+        ];
+
+        $responseData = array_merge($updateData, ['id' => 123]);
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('put')
+            ->with('groups/123', $this->callback(function ($options) {
+                return isset($options['multipart']) && is_array($options['multipart']);
+            }))
+            ->willReturn($this->mockResponse);
+
+        $group = Group::update(123, $updateData);
+
+        $this->assertInstanceOf(Group::class, $group);
+        $this->assertEquals('Updated Group', $group->name);
+    }
+
+    public function testDelete(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('groups/123')
+            ->willReturn($this->mockResponse);
+
+        $result = $group->delete();
+
+        $this->assertTrue($result);
+    }
+
+    public function testSave(): void
+    {
+        $group = new Group(['name' => 'Test Group']);
+        
+        $responseData = [
+            'id' => 123,
+            'name' => 'Test Group'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->willReturn($this->mockResponse);
+
+        $result = $group->save();
+
+        $this->assertTrue($result);
+        $this->assertEquals(123, $group->id);
+    }
+
+    public function testMembers(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $membersData = [
+            ['id' => 1, 'name' => 'User 1'],
+            ['id' => 2, 'name' => 'User 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->method('fetchAllPages')
+            ->willReturn($membersData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('groups/123/users', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $members = $group->members();
+
+        $this->assertIsArray($members);
+        $this->assertCount(2, $members);
+    }
+
+    public function testActivityStream(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $activityData = [
+            ['id' => 1, 'type' => 'Discussion'],
+            ['id' => 2, 'type' => 'Announcement']
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($activityData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('groups/123/activity_stream')
+            ->willReturn($this->mockResponse);
+
+        $activities = $group->activityStream();
+
+        $this->assertIsArray($activities);
+        $this->assertCount(2, $activities);
+    }
+
+    public function testActivityStreamSummary(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $summaryData = ['unread_count' => 5];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($summaryData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('groups/123/activity_stream/summary')
+            ->willReturn($this->mockResponse);
+
+        $summary = $group->activityStreamSummary();
+
+        $this->assertIsArray($summary);
+        $this->assertEquals(5, $summary['unread_count']);
+    }
+
+    public function testPermissions(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $permissionsData = [
+            'create_discussion_topic' => true,
+            'create_announcement' => false
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($permissionsData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->with('groups/123/permissions')
+            ->willReturn($this->mockResponse);
+
+        $permissions = $group->permissions();
+
+        $this->assertIsArray($permissions);
+        $this->assertTrue($permissions['create_discussion_topic']);
+        $this->assertFalse($permissions['create_announcement']);
+    }
+
+    public function testCreateMembership(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $membershipData = [
+            'id' => 456,
+            'group_id' => 123,
+            'user_id' => 789,
+            'workflow_state' => 'accepted'
+        ];
+
+        $this->mockStream->method('getContents')
+            ->willReturn(json_encode($membershipData));
+        
+        $this->mockResponse->method('getBody')
+            ->willReturn($this->mockStream);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('groups/123/memberships', $this->anything())
+            ->willReturn($this->mockResponse);
+
+        $membership = $group->createMembership(['user_id' => 789]);
+
+        $this->assertInstanceOf(GroupMembership::class, $membership);
+        $this->assertEquals(456, $membership->id);
+    }
+
+    public function testMemberships(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $membershipsData = [
+            ['id' => 1, 'user_id' => 100],
+            ['id' => 2, 'user_id' => 200]
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($membershipsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('groups/123/memberships', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $memberships = $group->memberships();
+
+        $this->assertIsArray($memberships);
+        $this->assertCount(2, $memberships);
+        $this->assertInstanceOf(GroupMembership::class, $memberships[0]);
+    }
+
+    public function testInvite(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('post')
+            ->with('groups/123/invite', $this->callback(function ($options) {
+                return isset($options['multipart']) && 
+                       is_array($options['multipart']) &&
+                       count($options['multipart']) === 1 &&
+                       $options['multipart'][0]['name'] === 'invitees[]' &&
+                       $options['multipart'][0]['contents'] === 'test@example.com';
+            }))
+            ->willReturn($this->mockResponse);
+
+        $result = $group->invite(['test@example.com']);
+
+        $this->assertTrue($result);
+    }
+
+    public function testRemoveUser(): void
+    {
+        $group = new Group(['id' => 123]);
+        
+        // Mock finding the membership
+        $membershipData = [
+            'id' => 456,
+            'user_id' => 789,
+            'group_id' => 123,
+            'workflow_state' => 'accepted'
+        ];
+        
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn([$membershipData]);
+        
+        // Mock fetching memberships
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('groups/123/memberships', ['query' => ['filter_states[]' => 'accepted']])
+            ->willReturn($mockPaginatedResponse);
+        
+        // Mock deleting the membership
+        $this->mockHttpClient->expects($this->once())
+            ->method('delete')
+            ->with('groups/123/memberships/456')
+            ->willReturn($this->mockResponse);
+
+        $result = $group->removeUser(789);
+
+        $this->assertTrue($result);
+    }
+
+    public function testFetchByContext(): void
+    {
+        $groupsData = [
+            ['id' => 1, 'name' => 'Course Group 1'],
+            ['id' => 2, 'name' => 'Course Group 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->method('fetchAllPages')
+            ->willReturn($groupsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/456/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $groups = Group::fetchByContext('courses', 456);
+
+        $this->assertIsArray($groups);
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+    }
+
+    public function testFetchUserGroups(): void
+    {
+        $groupsData = [
+            ['id' => 1, 'name' => 'User Group 1'],
+            ['id' => 2, 'name' => 'User Group 2']
+        ];
+
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->method('fetchAllPages')
+            ->willReturn($groupsData);
+        
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('users/123/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $groups = Group::fetchUserGroups(123);
+
+        $this->assertIsArray($groups);
+        $this->assertCount(2, $groups);
+    }
+
+
+    public function testGettersAndSetters(): void
+    {
+        $group = new Group([]);
+        
+        $group->contextName = 'New Context';
+        $this->assertEquals('New Context', $group->contextName);
+        
+        $group->users = [['id' => 1], ['id' => 2]];
+        $this->assertCount(2, $group->users);
+        
+        $group->nonCollaborative = true;
+        $this->assertTrue($group->nonCollaborative);
+        
+        $group->followedByUser = true;
+        $this->assertTrue($group->followedByUser);
+    }
+}

--- a/tests/Api/Users/UserRelationshipTest.php
+++ b/tests/Api/Users/UserRelationshipTest.php
@@ -13,6 +13,7 @@ use CanvasLMS\Api\Submissions\Submission;
 use CanvasLMS\Api\Assignments\Assignment;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Pagination\PaginatedResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -140,20 +141,17 @@ class UserRelationshipTest extends TestCase
             ]
         ];
 
-        // Set up mock expectations
-        $this->mockStream->method('getContents')
-            ->willReturn(json_encode($groupsData));
-        
-        $this->mockStream->method('__toString')
-            ->willReturn(json_encode($groupsData));
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('fetchAllPages')
+            ->willReturn($groupsData);
 
-        $this->mockResponse->method('getBody')
-            ->willReturn($this->mockStream);
-
+        // Set up mock expectations for paginated request
         $this->mockHttpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('users/100/groups', ['query' => []])
-            ->willReturn($this->mockResponse);
+            ->willReturn($mockPaginatedResponse);
 
         // Test the method
         $groups = $user->groups();

--- a/tests/Dto/GroupCategories/CreateGroupCategoryDTOTest.php
+++ b/tests/Dto/GroupCategories/CreateGroupCategoryDTOTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Dto\GroupCategories;
+
+use CanvasLMS\Dto\GroupCategories\CreateGroupCategoryDTO;
+use PHPUnit\Framework\TestCase;
+
+class CreateGroupCategoryDTOTest extends TestCase
+{
+    public function testConstructorWithEmptyData(): void
+    {
+        $dto = new CreateGroupCategoryDTO([]);
+        
+        $this->assertNull($dto->name);
+        $this->assertNull($dto->selfSignup);
+        $this->assertNull($dto->autoLeader);
+        $this->assertNull($dto->groupLimit);
+        $this->assertNull($dto->sisGroupCategoryId);
+        $this->assertNull($dto->createGroupCount);
+        $this->assertNull($dto->splitGroupCount);
+    }
+
+    public function testConstructorWithData(): void
+    {
+        $data = [
+            'name' => 'Test Category',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'random',
+            'group_limit' => 5,
+            'sis_group_category_id' => 'SIS123',
+            'create_group_count' => 3,
+            'split_group_count' => 'request'
+        ];
+
+        $dto = new CreateGroupCategoryDTO($data);
+
+        $this->assertEquals('Test Category', $dto->name);
+        $this->assertEquals('enabled', $dto->selfSignup);
+        $this->assertEquals('random', $dto->autoLeader);
+        $this->assertEquals(5, $dto->groupLimit);
+        $this->assertEquals('SIS123', $dto->sisGroupCategoryId);
+        $this->assertEquals(3, $dto->createGroupCount);
+        $this->assertEquals('request', $dto->splitGroupCount);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $dto = new CreateGroupCategoryDTO([]);
+
+        $dto->name = 'Updated Category';
+        $this->assertEquals('Updated Category', $dto->name);
+
+        $dto->selfSignup = 'restricted';
+        $this->assertEquals('restricted', $dto->selfSignup);
+
+        $dto->autoLeader = 'first';
+        $this->assertEquals('first', $dto->autoLeader);
+
+        $dto->groupLimit = 10;
+        $this->assertEquals(10, $dto->groupLimit);
+
+        $dto->sisGroupCategoryId = 'NEW_SIS';
+        $this->assertEquals('NEW_SIS', $dto->sisGroupCategoryId);
+
+        $dto->createGroupCount = 5;
+        $this->assertEquals(5, $dto->createGroupCount);
+
+        $dto->splitGroupCount = 'request';
+        $this->assertEquals('request', $dto->splitGroupCount);
+    }
+
+    public function testToArray(): void
+    {
+        $data = [
+            'name' => 'Test Category',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'random',
+            'group_limit' => 5,
+            'sis_group_category_id' => 'SIS123',
+            'create_group_count' => 3,
+            'split_group_count' => 'request'
+        ];
+
+        $dto = new CreateGroupCategoryDTO($data);
+        $array = $dto->toArray();
+
+        $expected = [
+            'name' => 'Test Category',
+            'selfSignup' => 'enabled',
+            'autoLeader' => 'random',
+            'groupLimit' => 5,
+            'sisGroupCategoryId' => 'SIS123',
+            'createGroupCount' => 3,
+            'splitGroupCount' => 'request'
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
+    public function testToApiArray(): void
+    {
+        $dto = new CreateGroupCategoryDTO([
+            'name' => 'Test Category',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'random',
+            'group_limit' => 5,
+            'sis_group_category_id' => 'SIS123',
+            'create_group_count' => 3,
+            'split_group_count' => 'request'
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(7, $apiArray);
+
+        // Check multipart format
+        $nameField = array_filter($apiArray, fn($field) => $field['name'] === 'name');
+        $this->assertCount(1, $nameField);
+        $this->assertEquals('Test Category', reset($nameField)['contents']);
+
+        $selfSignupField = array_filter($apiArray, fn($field) => $field['name'] === 'self_signup');
+        $this->assertCount(1, $selfSignupField);
+        $this->assertEquals('enabled', reset($selfSignupField)['contents']);
+
+        $autoLeaderField = array_filter($apiArray, fn($field) => $field['name'] === 'auto_leader');
+        $this->assertCount(1, $autoLeaderField);
+        $this->assertEquals('random', reset($autoLeaderField)['contents']);
+
+        $groupLimitField = array_filter($apiArray, fn($field) => $field['name'] === 'group_limit');
+        $this->assertCount(1, $groupLimitField);
+        $this->assertEquals('5', reset($groupLimitField)['contents']);
+    }
+
+    public function testToApiArrayExcludesNullValues(): void
+    {
+        $dto = new CreateGroupCategoryDTO(['name' => 'Test Category']);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(1, $apiArray);
+        $this->assertEquals('name', $apiArray[0]['name']);
+        $this->assertEquals('Test Category', $apiArray[0]['contents']);
+    }
+
+
+    public function testSelfSignupValues(): void
+    {
+        $validValues = ['enabled', 'restricted', null];
+        
+        foreach ($validValues as $value) {
+            $dto = new CreateGroupCategoryDTO(['self_signup' => $value]);
+            $this->assertEquals($value, $dto->selfSignup);
+        }
+    }
+
+    public function testAutoLeaderValues(): void
+    {
+        $validValues = ['first', 'random', null];
+        
+        foreach ($validValues as $value) {
+            $dto = new CreateGroupCategoryDTO(['auto_leader' => $value]);
+            $this->assertEquals($value, $dto->autoLeader);
+        }
+    }
+
+    public function testNumericFieldConversion(): void
+    {
+        $dto = new CreateGroupCategoryDTO([
+            'group_limit' => '10',
+            'create_group_count' => '5'
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $groupLimitField = array_filter($apiArray, fn($field) => $field['name'] === 'group_limit');
+        $this->assertEquals('10', reset($groupLimitField)['contents']);
+
+        $createGroupCountField = array_filter($apiArray, fn($field) => $field['name'] === 'create_group_count');
+        $this->assertEquals('5', reset($createGroupCountField)['contents']);
+    }
+
+    public function testSnakeCaseConversion(): void
+    {
+        $dto = new CreateGroupCategoryDTO([
+            'self_signup' => 'enabled',
+            'auto_leader' => 'first',
+            'group_limit' => 5,
+            'sis_group_category_id' => 'SIS123',
+            'create_group_count' => 3,
+            'split_group_count' => 'request'
+        ]);
+
+        $apiArray = $dto->toApiArray();
+        
+        $fieldNames = array_column($apiArray, 'name');
+        
+        $this->assertContains('self_signup', $fieldNames);
+        $this->assertContains('auto_leader', $fieldNames);
+        $this->assertContains('group_limit', $fieldNames);
+        $this->assertContains('sis_group_category_id', $fieldNames);
+        $this->assertContains('create_group_count', $fieldNames);
+        $this->assertContains('split_group_count', $fieldNames);
+    }
+}

--- a/tests/Dto/GroupCategories/UpdateGroupCategoryDTOTest.php
+++ b/tests/Dto/GroupCategories/UpdateGroupCategoryDTOTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Dto\GroupCategories;
+
+use CanvasLMS\Dto\GroupCategories\UpdateGroupCategoryDTO;
+use PHPUnit\Framework\TestCase;
+
+class UpdateGroupCategoryDTOTest extends TestCase
+{
+    public function testConstructorWithEmptyData(): void
+    {
+        $dto = new UpdateGroupCategoryDTO([]);
+        
+        $this->assertNull($dto->name);
+        $this->assertNull($dto->selfSignup);
+        $this->assertNull($dto->autoLeader);
+        $this->assertNull($dto->groupLimit);
+        $this->assertNull($dto->sisGroupCategoryId);
+        $this->assertNull($dto->createGroupCount);
+        $this->assertNull($dto->splitGroupCount);
+    }
+
+    public function testConstructorWithData(): void
+    {
+        $data = [
+            'name' => 'Updated Category',
+            'self_signup' => 'disabled',
+            'auto_leader' => 'first',
+            'group_limit' => 8,
+            'sis_group_category_id' => 'UPDATED_SIS',
+            'create_group_count' => 4,
+            'split_group_count' => 'request'
+        ];
+
+        $dto = new UpdateGroupCategoryDTO($data);
+
+        $this->assertEquals('Updated Category', $dto->name);
+        $this->assertEquals('disabled', $dto->selfSignup);
+        $this->assertEquals('first', $dto->autoLeader);
+        $this->assertEquals(8, $dto->groupLimit);
+        $this->assertEquals('UPDATED_SIS', $dto->sisGroupCategoryId);
+        $this->assertEquals(4, $dto->createGroupCount);
+        $this->assertEquals('request', $dto->splitGroupCount);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $dto = new UpdateGroupCategoryDTO([]);
+
+        $dto->name = 'New Name';
+        $this->assertEquals('New Name', $dto->name);
+
+        $dto->selfSignup = 'enabled';
+        $this->assertEquals('enabled', $dto->selfSignup);
+
+        $dto->autoLeader = 'random';
+        $this->assertEquals('random', $dto->autoLeader);
+
+        $dto->groupLimit = 15;
+        $this->assertEquals(15, $dto->groupLimit);
+
+        $dto->sisGroupCategoryId = 'NEW_ID';
+        $this->assertEquals('NEW_ID', $dto->sisGroupCategoryId);
+
+        $dto->createGroupCount = 6;
+        $this->assertEquals(6, $dto->createGroupCount);
+
+        $dto->splitGroupCount = 'request';
+        $this->assertEquals('request', $dto->splitGroupCount);
+    }
+
+    public function testToArray(): void
+    {
+        $data = [
+            'name' => 'Updated Category',
+            'self_signup' => 'restricted',
+            'auto_leader' => 'first',
+            'group_limit' => 10
+        ];
+
+        $dto = new UpdateGroupCategoryDTO($data);
+        $array = $dto->toArray();
+
+        $this->assertEquals($data['name'], $array['name']);
+        $this->assertEquals($data['self_signup'], $array['selfSignup']);
+        $this->assertEquals($data['auto_leader'], $array['autoLeader']);
+        $this->assertEquals($data['group_limit'], $array['groupLimit']);
+    }
+
+    public function testToApiArray(): void
+    {
+        $dto = new UpdateGroupCategoryDTO([
+            'name' => 'Updated Category',
+            'self_signup' => 'restricted',
+            'auto_leader' => 'first',
+            'group_limit' => 10
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(4, $apiArray);
+
+        // Check multipart format
+        $nameField = array_filter($apiArray, fn($field) => $field['name'] === 'name');
+        $this->assertCount(1, $nameField);
+        $this->assertEquals('Updated Category', reset($nameField)['contents']);
+
+        $selfSignupField = array_filter($apiArray, fn($field) => $field['name'] === 'self_signup');
+        $this->assertCount(1, $selfSignupField);
+        $this->assertEquals('restricted', reset($selfSignupField)['contents']);
+
+        $autoLeaderField = array_filter($apiArray, fn($field) => $field['name'] === 'auto_leader');
+        $this->assertCount(1, $autoLeaderField);
+        $this->assertEquals('first', reset($autoLeaderField)['contents']);
+
+        $groupLimitField = array_filter($apiArray, fn($field) => $field['name'] === 'group_limit');
+        $this->assertCount(1, $groupLimitField);
+        $this->assertEquals('10', reset($groupLimitField)['contents']);
+    }
+
+    public function testToApiArrayExcludesNullValues(): void
+    {
+        $dto = new UpdateGroupCategoryDTO(['name' => 'Updated Name']);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(1, $apiArray);
+        $this->assertEquals('name', $apiArray[0]['name']);
+        $this->assertEquals('Updated Name', $apiArray[0]['contents']);
+    }
+
+
+    public function testPartialUpdate(): void
+    {
+        // Update DTOs should allow partial updates
+        $dto = new UpdateGroupCategoryDTO([
+            'name' => 'Only Update Name'
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertCount(1, $apiArray);
+        $this->assertEquals('name', $apiArray[0]['name']);
+        $this->assertEquals('Only Update Name', $apiArray[0]['contents']);
+    }
+
+    public function testSelfSignupDisabled(): void
+    {
+        $dto = new UpdateGroupCategoryDTO(['self_signup' => 'disabled']);
+        
+        $apiArray = $dto->toApiArray();
+        
+        $selfSignupField = array_filter($apiArray, fn($field) => $field['name'] === 'self_signup');
+        $this->assertEquals('disabled', reset($selfSignupField)['contents']);
+    }
+
+    public function testRemoveGroupLimit(): void
+    {
+        // Setting group_limit to 0 removes the limit
+        $dto = new UpdateGroupCategoryDTO(['group_limit' => 0]);
+        
+        $apiArray = $dto->toApiArray();
+        
+        $groupLimitField = array_filter($apiArray, fn($field) => $field['name'] === 'group_limit');
+        $this->assertEquals('0', reset($groupLimitField)['contents']);
+    }
+
+    public function testAllFieldsUpdate(): void
+    {
+        $dto = new UpdateGroupCategoryDTO([
+            'name' => 'Complete Update',
+            'self_signup' => 'enabled',
+            'auto_leader' => 'random',
+            'group_limit' => 20,
+            'sis_group_category_id' => 'COMPLETE_SIS',
+            'create_group_count' => 10,
+            'split_group_count' => 'request'
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertCount(7, $apiArray);
+        
+        $fieldNames = array_column($apiArray, 'name');
+        $this->assertContains('name', $fieldNames);
+        $this->assertContains('self_signup', $fieldNames);
+        $this->assertContains('auto_leader', $fieldNames);
+        $this->assertContains('group_limit', $fieldNames);
+        $this->assertContains('sis_group_category_id', $fieldNames);
+        $this->assertContains('create_group_count', $fieldNames);
+        $this->assertContains('split_group_count', $fieldNames);
+    }
+}

--- a/tests/Dto/Groups/CreateGroupMembershipDTOTest.php
+++ b/tests/Dto/Groups/CreateGroupMembershipDTOTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Dto\Groups;
+
+use CanvasLMS\Dto\Groups\CreateGroupMembershipDTO;
+use PHPUnit\Framework\TestCase;
+
+class CreateGroupMembershipDTOTest extends TestCase
+{
+    public function testConstructorWithEmptyData(): void
+    {
+        $dto = new CreateGroupMembershipDTO([]);
+        
+        $this->assertNull($dto->userId);
+        $this->assertNull($dto->workflowState);
+        $this->assertNull($dto->moderator);
+    }
+
+    public function testConstructorWithData(): void
+    {
+        $data = [
+            'user_id' => 123,
+            'workflow_state' => 'accepted',
+            'moderator' => true
+        ];
+
+        $dto = new CreateGroupMembershipDTO($data);
+
+        $this->assertEquals(123, $dto->userId);
+        $this->assertEquals('accepted', $dto->workflowState);
+        $this->assertTrue($dto->moderator);
+    }
+
+    public function testSettersAndGetters(): void
+    {
+        $dto = new CreateGroupMembershipDTO([]);
+
+        $dto->userId = 456;
+        $this->assertEquals(456, $dto->userId);
+
+        $dto->workflowState = 'invited';
+        $this->assertEquals('invited', $dto->workflowState);
+
+        $dto->moderator = false;
+        $this->assertFalse($dto->moderator);
+    }
+
+    public function testToArray(): void
+    {
+        $data = [
+            'user_id' => 789,
+            'workflow_state' => 'requested',
+            'moderator' => true
+        ];
+
+        $dto = new CreateGroupMembershipDTO($data);
+        $array = $dto->toArray();
+
+        $this->assertEquals([
+            'userId' => 789,
+            'workflowState' => 'requested',
+            'moderator' => true
+        ], $array);
+    }
+
+    public function testToApiArray(): void
+    {
+        $dto = new CreateGroupMembershipDTO([
+            'user_id' => 123,
+            'workflow_state' => 'accepted',
+            'moderator' => true
+        ]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(3, $apiArray);
+
+        // Check multipart format
+        $userIdField = array_filter($apiArray, fn($field) => $field['name'] === 'user_id');
+        $this->assertCount(1, $userIdField);
+        $this->assertEquals('123', reset($userIdField)['contents']);
+
+        $workflowStateField = array_filter($apiArray, fn($field) => $field['name'] === 'workflow_state');
+        $this->assertCount(1, $workflowStateField);
+        $this->assertEquals('accepted', reset($workflowStateField)['contents']);
+
+        $moderatorField = array_filter($apiArray, fn($field) => $field['name'] === 'moderator');
+        $this->assertCount(1, $moderatorField);
+        $this->assertEquals('true', reset($moderatorField)['contents']);
+    }
+
+    public function testToApiArrayExcludesNullValues(): void
+    {
+        $dto = new CreateGroupMembershipDTO(['user_id' => 456]);
+
+        $apiArray = $dto->toApiArray();
+
+        $this->assertIsArray($apiArray);
+        $this->assertCount(1, $apiArray);
+        $this->assertEquals('user_id', $apiArray[0]['name']);
+        $this->assertEquals('456', $apiArray[0]['contents']);
+    }
+
+
+    public function testBooleanConversion(): void
+    {
+        // Test true boolean
+        $dto = new CreateGroupMembershipDTO(['moderator' => true]);
+        $apiArray = $dto->toApiArray();
+        $moderatorField = array_filter($apiArray, fn($field) => $field['name'] === 'moderator');
+        $this->assertEquals('true', reset($moderatorField)['contents']);
+
+        // Test false boolean
+        $dto = new CreateGroupMembershipDTO(['moderator' => false]);
+        $apiArray = $dto->toApiArray();
+        $moderatorField = array_filter($apiArray, fn($field) => $field['name'] === 'moderator');
+        $this->assertEquals('false', reset($moderatorField)['contents']);
+    }
+
+    public function testWorkflowStateValues(): void
+    {
+        $validStates = ['accepted', 'invited', 'requested', 'deleted'];
+        
+        foreach ($validStates as $state) {
+            $dto = new CreateGroupMembershipDTO(['workflow_state' => $state]);
+            $this->assertEquals($state, $dto->workflowState);
+            
+            $apiArray = $dto->toApiArray();
+            $stateField = array_filter($apiArray, fn($field) => $field['name'] === 'workflow_state');
+            $this->assertEquals($state, reset($stateField)['contents']);
+        }
+    }
+
+    public function testUserIdConversion(): void
+    {
+        // Test integer user_id
+        $dto = new CreateGroupMembershipDTO(['user_id' => 123]);
+        $apiArray = $dto->toApiArray();
+        $userIdField = array_filter($apiArray, fn($field) => $field['name'] === 'user_id');
+        $this->assertEquals('123', reset($userIdField)['contents']);
+
+        // Test string user_id
+        $dto = new CreateGroupMembershipDTO(['user_id' => '456']);
+        $apiArray = $dto->toApiArray();
+        $userIdField = array_filter($apiArray, fn($field) => $field['name'] === 'user_id');
+        $this->assertEquals('456', reset($userIdField)['contents']);
+    }
+
+    public function testMinimalMembership(): void
+    {
+        // Only user_id is typically required
+        $dto = new CreateGroupMembershipDTO(['user_id' => 789]);
+        
+        $apiArray = $dto->toApiArray();
+        
+        $this->assertCount(1, $apiArray);
+        $this->assertEquals('user_id', $apiArray[0]['name']);
+        $this->assertEquals('789', $apiArray[0]['contents']);
+    }
+
+    public function testFullMembership(): void
+    {
+        $dto = new CreateGroupMembershipDTO([
+            'user_id' => 999,
+            'workflow_state' => 'invited',
+            'moderator' => true
+        ]);
+        
+        $apiArray = $dto->toApiArray();
+        
+        $this->assertCount(3, $apiArray);
+        
+        $fieldNames = array_column($apiArray, 'name');
+        $this->assertContains('user_id', $fieldNames);
+        $this->assertContains('workflow_state', $fieldNames);
+        $this->assertContains('moderator', $fieldNames);
+    }
+}


### PR DESCRIPTION
## Summary
This PR completes the implementation of the Canvas LMS Groups API, providing comprehensive support for group collaboration features including group management, categories, and memberships.

## What's Included
- **Group Management**: Full CRUD operations for creating, reading, updating, and deleting groups
- **Group Categories**: Support for organizing groups into categories with self-signup and auto-leadership features
- **Group Memberships**: Complete membership management including invitations, permissions, and moderation
- **Relationship Methods**: Integration with Course and User classes for seamless access to group data
- **Advanced Features**: Activity streams, file management, permissions, and discussion boards
- **Pagination Support**: Full pagination using PaginatedResponse for all list operations
- **Type Safety**: DTOs for all create/update operations with proper data transformation

## Implementation Details
### New API Classes
- `Group`: Core group operations with Active Record pattern
- `GroupCategory`: Category management with account/course context support
- `GroupMembership`: Membership handling with workflow states

### New DTOs
- `CreateGroupDTO`, `UpdateGroupDTO`: Group data transformation
- `CreateGroupCategoryDTO`, `UpdateGroupCategoryDTO`: Category data handling
- `CreateGroupMembershipDTO`: Membership creation support

### Integration Points
- **Course Class**: Added `groups()`, `createGroup()`, `createGroupCategory()` methods
- **User Class**: Added `groups()` method for accessing user's groups

## Testing
- Comprehensive unit tests for all API classes
- Full DTO test coverage
- Integration tests for relationship methods
- All tests passing with proper mocking

## Code Quality
- ✅ PSR-12 coding standards compliant
- ✅ PHPStan level 6 static analysis passes
- ✅ Follows established SDK patterns
- ✅ Proper error handling and validation

## Usage Examples
```php
// Create a group category
$category = GroupCategory::create([
    'name' => 'Project Teams',
    'self_signup' => 'enabled',
    'group_limit' => 5
]);

// Create a group
$group = Group::create([
    'name' => 'Team Alpha',
    'description' => 'Working on feature X',
    'group_category_id' => $category->id
]);

// Add members
$membership = GroupMembership::create($group->id, [
    'user_id' => 123,
    'moderator' => true
]);

// Access from course
$course = Course::find(456);
$groups = $course->groups();
```

## Breaking Changes
None - this is a new feature addition.

## Related Issues
- Closes #63: Complete Groups API with student collaboration features
- Implements full Canvas Groups API specification

## Checklist
- [x] Code follows project conventions
- [x] Tests written and passing
- [x] Documentation updated
- [x] No breaking changes
- [x] Ready for review