### PR TITLE
feat: add support for current user endpoints using Canvas self pattern (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added relationship methods to Course and User classes for group-related operations
   - Full support for student group collaboration workflows and self-signup groups
   - Comprehensive test coverage for all group-related functionality
+- Support for current user endpoints using Canvas "self" pattern (#87)
+  - Added `User::self()` static method to get instance for current authenticated user
+  - Implemented "self" support for Canvas API endpoints that actually support it:
+    - `getActivityStream()` - Get current user's activity stream
+    - `getTodo()` - Get current user's todo items
+    - `getProfile()` - Get current user's profile
+    - `groups()` - Get current user's groups (special handling for /users/self/groups)
+  - Other User methods require numeric user ID and throw exception when ID not set
+  - Added comprehensive tests for self pattern functionality
+  - No breaking changes - existing code continues to work unchanged
 
 ### Fixed
 - Fixed hardcoded account ID in Course::create() method to use configured account ID from Config class (#84)

--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ $submission->grade([
 ]);
 ```
 
+### Working with Current User
+
+```php
+use CanvasLMS\Api\Users\User;
+
+// Get current authenticated user instance
+$currentUser = User::self();
+
+// Canvas supports 'self' for these endpoints:
+$profile = $currentUser->getProfile();
+$activityStream = $currentUser->getActivityStream();
+$todoItems = $currentUser->getTodo();
+$groups = $currentUser->groups();
+
+// Other methods require explicit user ID
+$user = User::find(123);
+$enrollments = $user->enrollments();
+$courses = $user->courses();
+```
+
 ### File Uploads
 
 ```php
@@ -250,6 +270,24 @@ $course = Course::find(123);
 $students = $course->getStudents();
 $assignments = $course->getAssignments();
 $modules = $course->getModules();
+```
+
+### Context Management
+
+```php
+// Account-as-Default Convention
+// Resources default to account context when accessed directly
+$groups = Group::fetchAll();  // Uses Config::getAccountId()
+$rubrics = Rubric::fetchAll(); // Account-level rubrics
+
+// Course-specific access via Course instance
+$course = Course::find(123);
+$courseGroups = $course->getGroups();
+$courseRubrics = $course->getRubrics();
+
+// User-specific access via User instance
+$user = User::find(456);
+$userGroups = $user->getGroups();
 ```
 
 ## 🧪 Testing

--- a/tests/Api/Users/UserTest.php
+++ b/tests/Api/Users/UserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Api\Users;
 
 use CanvasLMS\Api\Users\User;
 use CanvasLMS\Api\Enrollments\Enrollment;
+use CanvasLMS\Api\Groups\Group;
 use GuzzleHttp\Psr7\Response;
 use CanvasLMS\Http\HttpClient;
 use PHPUnit\Framework\TestCase;
@@ -368,6 +369,187 @@ class UserTest extends TestCase
 
         $this->assertNull($user->getEffectiveLocale());
         $this->assertNull($user->getCanUpdateName());
+    }
+
+    // Tests for User::self() pattern
+
+    /**
+     * Test User::self() returns a User instance without ID
+     */
+    public function testSelfReturnsUserInstanceWithoutId(): void
+    {
+        $currentUser = User::self();
+        
+        $this->assertInstanceOf(User::class, $currentUser);
+        $this->assertFalse(isset($currentUser->id), 'self() should return a User instance without ID set');
+    }
+
+    /**
+     * Test getProfile uses 'self' when ID is not set
+     */
+    public function testGetProfileUsesSelfWhenNoId(): void
+    {
+        $profileData = [
+            'id' => 123,
+            'name' => 'Current User',
+            'short_name' => 'Current',
+            'login_id' => 'current@example.com'
+        ];
+        
+        $response = new Response(200, [], json_encode($profileData));
+        
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with('/users/self/profile')
+            ->willReturn($response);
+        
+        $currentUser = User::self();
+        $profile = $currentUser->getProfile();
+        
+        $this->assertEquals('Current User', $profile->name);
+    }
+
+    /**
+     * Test getMissingSubmissions throws exception when ID is not set
+     */
+    public function testGetMissingSubmissionsThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to fetch missing submissions');
+        
+        $currentUser = User::self();
+        $currentUser->getMissingSubmissions();
+    }
+
+    /**
+     * Test setCustomData throws exception when ID is not set
+     */
+    public function testSetCustomDataThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to set custom data');
+        
+        $currentUser = User::self();
+        $currentUser->setCustomData('namespace', ['data' => 'value']);
+    }
+
+    /**
+     * Test getCustomData throws exception when ID is not set
+     */
+    public function testGetCustomDataThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to get custom data');
+        
+        $currentUser = User::self();
+        $currentUser->getCustomData('namespace');
+    }
+
+    /**
+     * Test courses() throws exception when ID is not set
+     */
+    public function testCoursesThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to get courses');
+        
+        $currentUser = User::self();
+        $currentUser->courses();
+    }
+
+    /**
+     * Test that methods still work with explicit user ID
+     */
+    public function testMethodsStillWorkWithExplicitUserId(): void
+    {
+        $userId = 456;
+        $userData = ['id' => $userId, 'name' => 'Specific User'];
+        $profileData = ['id' => $userId, 'name' => 'Specific User', 'short_name' => 'Specific'];
+        
+        // First mock for User::find()
+        $userResponse = new Response(200, [], json_encode($userData));
+        // Second mock for getProfile()
+        $profileResponse = new Response(200, [], json_encode($profileData));
+        
+        $this->httpClientMock
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnCallback(function ($path) use ($userResponse, $profileResponse) {
+                if ($path === '/users/456') {
+                    return $userResponse;
+                } elseif ($path === '/users/456/profile') {
+                    return $profileResponse;
+                }
+            });
+        
+        $user = User::find($userId);
+        $this->assertEquals($userId, $user->getId());
+        
+        $profile = $user->getProfile();
+        $this->assertEquals('Specific User', $profile->name);
+    }
+
+    /**
+     * Test getCalendarEvents throws exception when ID is not set
+     */
+    public function testGetCalendarEventsThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to get calendar events');
+        
+        $currentUser = User::self();
+        $currentUser->getCalendarEvents();
+    }
+
+    /**
+     * Test split throws exception when ID is not set
+     */
+    public function testSplitThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to split user');
+        
+        $currentUser = User::self();
+        $currentUser->split();
+    }
+
+    /**
+     * Test groups() uses 'self' endpoint for current user
+     */
+    public function testGroupsMethodUsesSelfForCurrentUser(): void
+    {
+        $groupsData = [
+            ['id' => 1, 'name' => 'Group 1'],
+            ['id' => 2, 'name' => 'Group 2']
+        ];
+        
+        $response = new Response(200, [], json_encode($groupsData));
+        
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('get')
+            ->with('users/self/groups', $this->anything())
+            ->willReturn($response);
+        
+        $currentUser = User::self();
+        $groups = $currentUser->groups();
+        
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(Group::class, $groups[0]);
+        $this->assertEquals('Group 1', $groups[0]->name);
+    }
+
+    /**
+     * Test files() throws exception when ID is not set
+     */
+    public function testFilesThrowsExceptionWhenNoId(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('User ID is required to get files');
+        
+        $currentUser = User::self();
+        $currentUser->files();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
## Summary
- Add `User::self()` static method to get instance for current authenticated user
- Implement self support for Canvas API endpoints that actually support it:
  - `getActivityStream()` uses /users/self/activity_stream
  - `getTodo()` uses /users/self/todo
  - `getProfile()` uses /users/self/profile
  - `groups()` has special handling for /users/self/groups
- Other User methods require numeric user ID and throw exception when ID not set
- No breaking changes - existing code continues to work unchanged

## Details
This PR implements support for Canvas LMS's "self" pattern which allows accessing current user data without knowing the user ID. This is particularly useful for building applications where users need to access their own data.

### Key Changes:
1. Added `User::self()` static method that returns a User instance without an ID
2. Modified specific methods to support the self pattern where Canvas API actually supports it
3. Fixed property initialization checks using `isset()` to avoid PHP errors
4. Added comprehensive tests for all self pattern functionality
5. Updated documentation with usage examples in README and accurate CHANGELOG

### Important Discovery:
During implementation, I discovered that Canvas API only supports "self" for specific endpoints, not all user endpoints. The implementation was corrected to only support self where Canvas actually documents it.

## Test Plan
- [x] All existing tests pass
- [x] New tests added for self pattern functionality
- [x] Manual testing of self endpoints
- [x] Documentation updated
- [x] No breaking changes verified

Closes #87