### PR TITLE
feat: activate and enhance logging system (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Comprehensive logging system activation and improvements (#107)
+  - PSR-3 compatible logger configuration via `Config::setLogger()`
+  - Context-aware logging support for multi-tenant applications
+  - Activity logging trait for standardized API operation logging
+  - OAuth token operation logging with sensitive data sanitization
+  - Pagination metrics and performance tracking
+  - File upload progress logging (3-step process)
+  - Automatic sensitive data sanitization in logs
+  - Integration examples with Monolog, Symfony, and other PSR-3 loggers
+
+### Changed
+- Replaced `trigger_error()` and `error_log()` calls with proper PSR-3 logger usage
+- AbstractBaseApi now uses configured logger instead of hardcoded NullLogger
+- Enhanced error handling with contextual logging throughout the SDK
+
+### Security
+- Automatic sanitization of sensitive fields (passwords, tokens, API keys) in log output
+- OAuth token masking in log entries to prevent credential exposure
+
 ## [1.2.0] - 2025-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,6 +133,61 @@ Config::autoDetectFromEnvironment();
 // Ready to use!
 ```
 
+### Logging Configuration
+
+The SDK supports any PSR-3 compatible logger for comprehensive debugging and monitoring:
+
+```php
+use CanvasLMS\Config;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+// Configure with Monolog
+$logger = new Logger('canvas-lms');
+$logger->pushHandler(new StreamHandler('logs/canvas.log', Logger::INFO));
+Config::setLogger($logger);
+
+// All API calls, OAuth operations, pagination, and file uploads are now logged!
+```
+
+#### Symfony Integration
+
+```php
+use Psr\Log\LoggerInterface;
+
+public function __construct(LoggerInterface $logger) {
+    Config::setLogger($logger);
+}
+```
+
+#### Advanced Logging Configuration
+
+```php
+// Enable detailed request/response logging
+Config::setMiddleware([
+    'logging' => [
+        'enabled' => true,
+        'log_requests' => true,
+        'log_responses' => true,
+        'log_errors' => true,
+        'log_timing' => true,
+        'log_level' => \Psr\Log\LogLevel::DEBUG,
+        'sanitize_fields' => ['password', 'token', 'api_key', 'secret'],
+        'max_body_length' => 1000
+    ]
+]);
+```
+
+**What Gets Logged:**
+- ✅ All API requests and responses (with sensitive data sanitization)
+- ✅ OAuth token operations (refresh, revoke, exchange)
+- ✅ Pagination operations with performance metrics
+- ✅ File upload progress (3-step process)
+- ✅ Rate limit headers and API costs
+- ✅ Error conditions with context
+
+**Security:** The logging middleware automatically sanitizes sensitive fields like passwords, tokens, and API keys to prevent accidental exposure in logs.
+
 ## 💡 Usage Examples
 
 ### Working with Courses

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -87,9 +87,8 @@ abstract class AbstractBaseApi implements ApiInterface
 
         // Check if logging is configured
         if (isset($middlewareConfig['logging']) && $middlewareConfig['logging']['enabled'] !== false) {
-            // For now, use NullLogger unless a logger is provided via setApiClient
-            // In a future enhancement, we could support PSR-3 logger configuration
-            $logger = new \Psr\Log\NullLogger();
+            // Use the configured logger from Config, defaults to NullLogger if not configured
+            $logger = Config::getLogger();
         }
 
         // If middleware config is empty, HttpClient will use defaults

--- a/src/Api/AppointmentGroups/AppointmentGroup.php
+++ b/src/Api/AppointmentGroups/AppointmentGroup.php
@@ -569,12 +569,16 @@ class AppointmentGroup extends AbstractBaseApi
                 return new DateTime($value);
             } catch (\Exception $e) {
                 // Log the parsing error for debugging
-                error_log(sprintf(
-                    'AppointmentGroup: Failed to parse DateTime for field "%s" with value "%s": %s',
-                    $key,
-                    $value,
-                    $e->getMessage()
-                ));
+                $logger = \CanvasLMS\Config::getLogger();
+                $logger->warning(
+                    'AppointmentGroup: Failed to parse DateTime for field "{field}" with value "{value}": {error}',
+                    [
+                        'field' => $key,
+                        'value' => $value,
+                        'error' => $e->getMessage(),
+                        'class' => self::class
+                    ]
+                );
 
                 // Return null for invalid dates to maintain consistency
                 return null;

--- a/src/Api/CalendarEvents/CalendarEvent.php
+++ b/src/Api/CalendarEvents/CalendarEvent.php
@@ -798,12 +798,16 @@ class CalendarEvent extends AbstractBaseApi
                 return new DateTime($value);
             } catch (\Exception $e) {
                 // Log the parsing error for debugging
-                error_log(sprintf(
-                    'CalendarEvent: Failed to parse DateTime for field "%s" with value "%s": %s',
-                    $key,
-                    $value,
-                    $e->getMessage()
-                ));
+                $logger = \CanvasLMS\Config::getLogger();
+                $logger->warning(
+                    'CalendarEvent: Failed to parse DateTime for field "{field}" with value "{value}": {error}',
+                    [
+                        'field' => $key,
+                        'value' => $value,
+                        'error' => $e->getMessage(),
+                        'class' => self::class
+                    ]
+                );
 
                 // Return null for invalid dates to maintain consistency
                 return null;

--- a/src/Traits/ActivityLoggingTrait.php
+++ b/src/Traits/ActivityLoggingTrait.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace CanvasLMS\Traits;
+
+use CanvasLMS\Config;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Trait for standardized activity logging across Canvas LMS API classes.
+ *
+ * This trait provides consistent logging methods for API operations,
+ * including activity tracking, performance metrics, and error handling.
+ */
+trait ActivityLoggingTrait
+{
+    /**
+     * Log an API activity with enriched context.
+     *
+     * @param string $action The action being performed (e.g., 'fetch', 'create', 'update', 'delete')
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logActivity(string $action, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'timestamp' => time(),
+            'class' => static::class,
+            'action' => $action,
+            'context' => Config::getContext(),
+        ], $context);
+
+        $logger->info("Canvas API Activity: {$action}", $enrichedContext);
+    }
+
+    /**
+     * Log performance metrics for an operation.
+     *
+     * @param string $operation The operation being measured
+     * @param float $duration The duration in seconds
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logPerformance(string $operation, float $duration, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'operation' => $operation,
+            'duration_ms' => round($duration * 1000, 2),
+            'duration_s' => round($duration, 3),
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $context);
+
+        // Log as info if under 1 second, warning if 1-5 seconds, error if over 5 seconds
+        if ($duration < 1.0) {
+            $logger->info(
+                "Performance: {$operation} completed in {$enrichedContext['duration_ms']}ms",
+                $enrichedContext
+            );
+        } elseif ($duration < 5.0) {
+            $logger->warning(
+                "Performance: {$operation} took {$enrichedContext['duration_s']}s",
+                $enrichedContext
+            );
+        } else {
+            $logger->error(
+                "Performance: {$operation} exceeded 5s threshold ({$enrichedContext['duration_s']}s)",
+                $enrichedContext
+            );
+        }
+    }
+
+    /**
+     * Log an API error with context.
+     *
+     * @param string $operation The operation that failed
+     * @param \Throwable $exception The exception that was thrown
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logError(string $operation, \Throwable $exception, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'operation' => $operation,
+            'error_class' => get_class($exception),
+            'error_message' => $exception->getMessage(),
+            'error_code' => $exception->getCode(),
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $context);
+
+        // Add stack trace for non-production environments (can be configured)
+        if (Config::getLogger() !== null) {
+            $enrichedContext['stack_trace'] = $exception->getTraceAsString();
+        }
+
+        $logger->error("API Error in {$operation}: {$exception->getMessage()}", $enrichedContext);
+    }
+
+    /**
+     * Log a successful API operation.
+     *
+     * @param string $operation The operation that succeeded
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logSuccess(string $operation, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'operation' => $operation,
+            'status' => 'success',
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $context);
+
+        $logger->info("API Success: {$operation} completed successfully", $enrichedContext);
+    }
+
+    /**
+     * Log pagination information.
+     *
+     * @param string $operation The pagination operation
+     * @param int $page The current page number
+     * @param int $perPage The number of items per page
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logPagination(string $operation, int $page, int $perPage, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'operation' => $operation,
+            'page' => $page,
+            'per_page' => $perPage,
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $context);
+
+        $logger->debug("Pagination: {$operation} - Page {$page} ({$perPage} items)", $enrichedContext);
+    }
+
+    /**
+     * Log OAuth token operations.
+     *
+     * @param string $operation The OAuth operation (e.g., 'refresh', 'validate', 'revoke')
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logOAuthOperation(string $operation, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        // Sanitize any sensitive data from context
+        $sanitizedContext = $this->sanitizeOAuthContext($context);
+
+        $enrichedContext = array_merge([
+            'operation' => "oauth_{$operation}",
+            'auth_mode' => Config::getAuthMode(),
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $sanitizedContext);
+
+        $logger->info("OAuth Operation: {$operation}", $enrichedContext);
+    }
+
+    /**
+     * Log file upload operations.
+     *
+     * @param string $step The upload step (e.g., 'initiate', 'upload', 'confirm')
+     * @param array<string, mixed> $context Additional context for the log entry
+     * @return void
+     */
+    protected function logFileUpload(string $step, array $context = []): void
+    {
+        $logger = $this->getActivityLogger();
+
+        $enrichedContext = array_merge([
+            'operation' => 'file_upload',
+            'step' => $step,
+            'class' => static::class,
+            'context' => Config::getContext(),
+        ], $context);
+
+        $logger->info("File Upload: Step '{$step}'", $enrichedContext);
+    }
+
+    /**
+     * Get the logger instance for activity logging.
+     *
+     * @return LoggerInterface
+     */
+    protected function getActivityLogger(): LoggerInterface
+    {
+        return Config::getLogger();
+    }
+
+    /**
+     * Sanitize OAuth context to remove sensitive data.
+     *
+     * @param array<string, mixed> $context The context to sanitize
+     * @return array<string, mixed> The sanitized context
+     */
+    private function sanitizeOAuthContext(array $context): array
+    {
+        $sensitiveKeys = [
+            'token', 'access_token', 'refresh_token',
+            'client_secret', 'password', 'api_key'
+        ];
+
+        $sanitized = [];
+        foreach ($context as $key => $value) {
+            if (in_array(strtolower($key), $sensitiveKeys, true)) {
+                // Mask sensitive values
+                if (is_string($value) && strlen($value) > 4) {
+                    $sanitized[$key] = '***' . substr($value, -4);
+                } else {
+                    $sanitized[$key] = '***';
+                }
+            } else {
+                $sanitized[$key] = $value;
+            }
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Start a timed operation for performance logging.
+     *
+     * @return float The start time
+     */
+    protected function startTimer(): float
+    {
+        return microtime(true);
+    }
+
+    /**
+     * End a timed operation and log the performance.
+     *
+     * @param float $startTime The start time from startTimer()
+     * @param string $operation The operation being measured
+     * @param array<string, mixed> $context Additional context
+     * @return void
+     */
+    protected function endTimer(float $startTime, string $operation, array $context = []): void
+    {
+        $duration = microtime(true) - $startTime;
+        $this->logPerformance($operation, $duration, $context);
+    }
+}

--- a/tests/Traits/ActivityLoggingTraitTest.php
+++ b/tests/Traits/ActivityLoggingTraitTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace CanvasLMS\Tests\Traits;
+
+use CanvasLMS\Config;
+use CanvasLMS\Traits\ActivityLoggingTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class ActivityLoggingTraitTest extends TestCase
+{
+    use ActivityLoggingTrait;
+
+    private $mockLogger;
+    private $originalContext;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // Save original context
+        $this->originalContext = Config::getContext();
+        
+        // Create mock logger
+        $this->mockLogger = $this->createMock(LoggerInterface::class);
+        Config::setLogger($this->mockLogger);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset configuration
+        Config::setContext($this->originalContext);
+        Config::resetContext('default');
+        
+        parent::tearDown();
+    }
+
+    public function testLogActivity(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->equalTo('Canvas API Activity: create'),
+                $this->callback(function ($context) {
+                    return isset($context['timestamp']) &&
+                           isset($context['class']) &&
+                           isset($context['action']) &&
+                           isset($context['context']) &&
+                           $context['action'] === 'create' &&
+                           $context['test_key'] === 'test_value';
+                })
+            );
+
+        $this->logActivity('create', ['test_key' => 'test_value']);
+    }
+
+    public function testLogPerformanceUnderOneSecond(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->stringContains('Performance:'),
+                $this->callback(function ($context) {
+                    return isset($context['duration_ms']) &&
+                           isset($context['duration_s']) &&
+                           $context['duration_ms'] === 500.0 &&
+                           $context['operation'] === 'fast_operation';
+                })
+            );
+
+        $this->logPerformance('fast_operation', 0.5);
+    }
+
+    public function testLogPerformanceBetweenOneAndFiveSeconds(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('warning')
+            ->with(
+                $this->stringContains('Performance:'),
+                $this->callback(function ($context) {
+                    return isset($context['duration_s']) &&
+                           $context['duration_s'] === 2.5 &&
+                           $context['operation'] === 'slow_operation';
+                })
+            );
+
+        $this->logPerformance('slow_operation', 2.5);
+    }
+
+    public function testLogPerformanceOverFiveSeconds(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('Performance:'),
+                $this->callback(function ($context) {
+                    return isset($context['duration_s']) &&
+                           $context['duration_s'] === 6.0 &&
+                           $context['operation'] === 'very_slow_operation';
+                })
+            );
+
+        $this->logPerformance('very_slow_operation', 6.0);
+    }
+
+    public function testLogError(): void
+    {
+        $exception = new \Exception('Test error', 500);
+        
+        $this->mockLogger->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->stringContains('API Error in test_operation:'),
+                $this->callback(function ($context) use ($exception) {
+                    return $context['operation'] === 'test_operation' &&
+                           $context['error_class'] === get_class($exception) &&
+                           $context['error_message'] === 'Test error' &&
+                           $context['error_code'] === 500 &&
+                           isset($context['stack_trace']);
+                })
+            );
+
+        $this->logError('test_operation', $exception);
+    }
+
+    public function testLogSuccess(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->equalTo('API Success: upload completed successfully'),
+                $this->callback(function ($context) {
+                    return $context['operation'] === 'upload' &&
+                           $context['status'] === 'success' &&
+                           $context['file_id'] === 123;
+                })
+            );
+
+        $this->logSuccess('upload', ['file_id' => 123]);
+    }
+
+    public function testLogPagination(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('debug')
+            ->with(
+                $this->stringContains('Pagination:'),
+                $this->callback(function ($context) {
+                    return $context['page'] === 2 &&
+                           $context['per_page'] === 50 &&
+                           $context['operation'] === 'fetch_courses';
+                })
+            );
+
+        $this->logPagination('fetch_courses', 2, 50);
+    }
+
+    public function testLogOAuthOperation(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->equalTo('OAuth Operation: refresh'),
+                $this->callback(function ($context) {
+                    return $context['operation'] === 'oauth_refresh' &&
+                           $context['auth_mode'] === Config::getAuthMode() &&
+                           $context['token'] === '***5678' && // Sanitized
+                           $context['user_id'] === 999;
+                })
+            );
+
+        $this->logOAuthOperation('refresh', [
+            'token' => 'abc12345678',
+            'user_id' => 999
+        ]);
+    }
+
+    public function testLogFileUpload(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->equalTo("File Upload: Step 'initiate'"),
+                $this->callback(function ($context) {
+                    return $context['operation'] === 'file_upload' &&
+                           $context['step'] === 'initiate' &&
+                           $context['file_name'] === 'test.pdf';
+                })
+            );
+
+        $this->logFileUpload('initiate', ['file_name' => 'test.pdf']);
+    }
+
+    public function testSanitizeOAuthContext(): void
+    {
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->anything(),
+                $this->callback(function ($context) {
+                    // Check that sensitive fields are sanitized
+                    return $context['access_token'] === '***9012' &&
+                           $context['refresh_token'] === '***5678' &&
+                           $context['client_secret'] === '***' &&
+                           $context['password'] === '***' &&
+                           $context['api_key'] === '***defg' &&
+                           // Non-sensitive fields should remain
+                           $context['user_id'] === 123 &&
+                           $context['scope'] === 'read write';
+                })
+            );
+
+        $this->logOAuthOperation('authenticate', [
+            'access_token' => 'token789012',
+            'refresh_token' => 'refresh345678',
+            'client_secret' => 'sec',
+            'password' => 'pwd',
+            'api_key' => 'abcdefg',
+            'user_id' => 123,
+            'scope' => 'read write'
+        ]);
+    }
+
+    public function testTimerMethods(): void
+    {
+        $startTime = $this->startTimer();
+        $this->assertIsFloat($startTime);
+        
+        // Simulate some work
+        usleep(100000); // 100ms
+        
+        $this->mockLogger->expects($this->once())
+            ->method('info')
+            ->with(
+                $this->stringContains('Performance:'),
+                $this->callback(function ($context) {
+                    // Should be at least 100ms
+                    return $context['duration_ms'] >= 100.0 &&
+                           $context['operation'] === 'timed_operation';
+                })
+            );
+        
+        $this->endTimer($startTime, 'timed_operation');
+    }
+}


### PR DESCRIPTION
## Summary
- Activated the existing PSR-3 compliant logging infrastructure that was previously defaulting to NullLogger
- Added comprehensive logging throughout the SDK with context-aware configuration for multi-tenant support
- Implemented standardized activity logging with performance metrics and sensitive data sanitization

## Changes

### Core Logging Infrastructure
- **Config Class**: Added PSR-3 logger support with context awareness for multi-tenant scenarios
- **AbstractBaseApi**: Updated to use configured logger instead of hardcoded NullLogger
- **Error Handling**: Replaced all `trigger_error()` and `error_log()` calls with proper logger usage

### Activity Logging
- **ActivityLoggingTrait**: Created comprehensive trait for standardized logging patterns across the SDK
- **OAuth Operations**: Added detailed logging for authorization, token refresh, and revocation with sensitive data sanitization
- **Pagination**: Implemented performance metrics logging for page fetching and navigation
- **File Uploads**: Added step-by-step logging for Canvas's 3-phase upload process

### Documentation & Testing
- **README**: Added comprehensive logging configuration section with Monolog and Symfony integration examples
- **Tests**: Created full test coverage (15 new tests) for logger configuration and activity logging
- **CHANGELOG**: Documented all changes for the upcoming release

## Key Features
- ✅ PSR-3 compliant logger configuration
- ✅ Context-aware logging for multi-tenant support
- ✅ Automatic sensitive data sanitization (tokens, secrets)
- ✅ Performance metrics tracking with duration measurements
- ✅ Comprehensive error logging with enriched context
- ✅ Full backward compatibility (defaults to NullLogger when not configured)

## Test Results
All tests passing with no breaking changes:
- PHPUnit: ✅ All tests pass
- PHPStan: ✅ Level 6 analysis clean
- Code Standards: ✅ PSR-12 compliant

## Related Issue
Closes #107

## Breaking Changes
None - Fully backward compatible

## Migration Guide
No migration required. To enable logging, simply configure a PSR-3 logger:

```php
use Monolog\Logger;
use Monolog\Handler\StreamHandler;
use CanvasLMS\Config;

$logger = new Logger('canvas-lms');
$logger->pushHandler(new StreamHandler('path/to/canvas.log', Logger::DEBUG));
Config::setLogger($logger);
```