### PR TITLE
feat: Add MediaObjects API implementation (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- MediaObjects API implementation (#47)
+  - New `MediaObject` class for managing media objects and tracks in Canvas
+  - Support for media objects in global, course, and group contexts
+  - Media attachments endpoints for parallel attachment-based operations
+  - Media tracks management (captions/subtitles) with SRT and WEBVTT format support
+  - `UpdateMediaObjectDTO` for updating media object titles
+  - `UpdateMediaTracksDTO` for managing media tracks with validation
+  - `MediaTrack` and `MediaSource` data objects for structured data handling
+  - Course and Group integration via `mediaObjects()` and `mediaAttachments()` methods
+  - Support for 12 Canvas API endpoints covering all media operations
+  - Comprehensive test coverage for API operations and DTOs
+
 - Announcements API implementation (#41)
   - New `Announcement` class extending `DiscussionTopic` with announcement-specific features
   - Automatic filtering for announcements only (adds `only_announcements=true`)

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -3500,6 +3500,36 @@ class Course extends AbstractBaseApi
     }
 
     /**
+     * Get media objects for this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\MediaObjects\MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public function mediaObjects(array $params = []): array
+    {
+        if (!isset($this->id) || !$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch media objects');
+        }
+        return \CanvasLMS\Api\MediaObjects\MediaObject::fetchByCourse($this->id, $params);
+    }
+
+    /**
+     * Get media attachments for this course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\MediaObjects\MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public function mediaAttachments(array $params = []): array
+    {
+        if (!isset($this->id) || !$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch media attachments');
+        }
+        return \CanvasLMS\Api\MediaObjects\MediaObject::fetchAttachmentsByCourse($this->id, $params);
+    }
+
+    /**
      * Get the API endpoint for this resource
      * @return string
      */

--- a/src/Api/Groups/Group.php
+++ b/src/Api/Groups/Group.php
@@ -924,4 +924,34 @@ class Group extends AbstractBaseApi
 
         return $migration;
     }
+
+    /**
+     * Get media objects for this group
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\MediaObjects\MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public function mediaObjects(array $params = []): array
+    {
+        if (!isset($this->id) || !$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch media objects');
+        }
+        return \CanvasLMS\Api\MediaObjects\MediaObject::fetchByGroup($this->id, $params);
+    }
+
+    /**
+     * Get media attachments for this group
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<\CanvasLMS\Api\MediaObjects\MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public function mediaAttachments(array $params = []): array
+    {
+        if (!isset($this->id) || !$this->id) {
+            throw new CanvasApiException('Group ID is required to fetch media attachments');
+        }
+        return \CanvasLMS\Api\MediaObjects\MediaObject::fetchAttachmentsByGroup($this->id, $params);
+    }
 }

--- a/src/Api/MediaObjects/MediaObject.php
+++ b/src/Api/MediaObjects/MediaObject.php
@@ -1,0 +1,438 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Api\MediaObjects;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Config;
+use CanvasLMS\Dto\MediaObjects\UpdateMediaObjectDTO;
+use CanvasLMS\Dto\MediaObjects\UpdateMediaTracksDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Objects\MediaTrack;
+use CanvasLMS\Objects\MediaSource;
+
+/**
+ * MediaObject API
+ *
+ * Provides functionality for managing media objects and their tracks in Canvas LMS
+ *
+ * @package CanvasLMS\Api\MediaObjects
+ */
+class MediaObject extends AbstractBaseApi
+{
+    /**
+     * Whether the current user can upload media_tracks (subtitles) to this Media Object
+     */
+    public ?bool $canAddCaptions = null;
+
+    /**
+     * Custom title entered by the user
+     */
+    public ?string $userEnteredTitle = null;
+
+    /**
+     * The display title of the media object
+     */
+    public ?string $title = null;
+
+    /**
+     * The unique identifier for the media object
+     */
+    public ?string $mediaId = null;
+
+    /**
+     * The type of media (video, audio)
+     */
+    public ?string $mediaType = null;
+
+    /**
+     * Array of MediaTrack objects associated with this media
+     * @var array<MediaTrack>|null
+     */
+    public ?array $mediaTracks = null;
+
+    /**
+     * Array of MediaSource objects with different encodings
+     * @var array<MediaSource>|null
+     */
+    public ?array $mediaSources = null;
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        // Parse media tracks if present
+        if (isset($data['media_tracks']) && is_array($data['media_tracks'])) {
+            $this->mediaTracks = array_map(
+                fn($track) => new MediaTrack($track),
+                $data['media_tracks']
+            );
+        }
+
+        // Parse media sources if present
+        if (isset($data['media_sources']) && is_array($data['media_sources'])) {
+            $this->mediaSources = array_map(
+                fn($source) => new MediaSource($source),
+                $data['media_sources']
+            );
+        }
+    }
+
+    /**
+     * Fetch all media objects (global context)
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchAll(array $params = []): array
+    {
+        $response = self::$apiClient->get('/media_objects', ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch all media attachments (global context)
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchAttachments(array $params = []): array
+    {
+        $response = self::$apiClient->get('/media_attachments', ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch media objects for a specific course
+     *
+     * @param int $courseId The course ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchByCourse(int $courseId, array $params = []): array
+    {
+        $response = self::$apiClient->get("/courses/{$courseId}/media_objects", ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch media attachments for a specific course
+     *
+     * @param int $courseId The course ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchAttachmentsByCourse(int $courseId, array $params = []): array
+    {
+        $response = self::$apiClient->get("/courses/{$courseId}/media_attachments", ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch media objects for a specific group
+     *
+     * @param int $groupId The group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchByGroup(int $groupId, array $params = []): array
+    {
+        $response = self::$apiClient->get("/groups/{$groupId}/media_objects", ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Fetch media attachments for a specific group
+     *
+     * @param int $groupId The group ID
+     * @param array<string, mixed> $params Query parameters
+     * @return array<MediaObject> Array of MediaObject instances
+     * @throws CanvasApiException
+     */
+    public static function fetchAttachmentsByGroup(int $groupId, array $params = []): array
+    {
+        $response = self::$apiClient->get("/groups/{$groupId}/media_attachments", ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($data['media_objects'])) {
+            return array_map(fn($item) => new self($item), $data['media_objects']);
+        }
+
+        return [];
+    }
+
+    /**
+     * Find a specific media object by ID
+     * Note: Canvas API doesn't support direct media object retrieval
+     *
+     * @param int $id The media object ID (not used - Canvas doesn't support this)
+     * @return self
+     * @throws CanvasApiException Always throws as Canvas doesn't support this operation
+     */
+    public static function find(int $id): self
+    {
+        throw new CanvasApiException('Direct media object retrieval is not supported by Canvas API');
+    }
+
+    /**
+     * Update the media object
+     *
+     * @param array<string, mixed>|UpdateMediaObjectDTO $data Update data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public function update(array|UpdateMediaObjectDTO $data): self
+    {
+        if (!$this->mediaId) {
+            throw new CanvasApiException('Media object ID is required for update');
+        }
+
+        if (is_array($data)) {
+            $data = UpdateMediaObjectDTO::fromArray($data);
+        }
+
+        $response = self::$apiClient->put(
+            "/media_objects/{$this->mediaId}",
+            ['json' => $data->toArray()]
+        );
+
+        $responseData = json_decode($response->getBody()->getContents(), true);
+
+        // Update current instance with new data
+        foreach ($responseData as $key => $value) {
+            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Update the media object by attachment ID
+     *
+     * @param int $attachmentId The attachment ID
+     * @param array<string, mixed>|UpdateMediaObjectDTO $data Update data
+     * @return self
+     * @throws CanvasApiException
+     */
+    public function updateByAttachment(int $attachmentId, array|UpdateMediaObjectDTO $data): self
+    {
+        if (is_array($data)) {
+            $data = UpdateMediaObjectDTO::fromArray($data);
+        }
+
+        $response = self::$apiClient->put(
+            "/media_attachments/{$attachmentId}",
+            ['json' => $data->toArray()]
+        );
+
+        $responseData = json_decode($response->getBody()->getContents(), true);
+
+        // Update current instance with new data
+        foreach ($responseData as $key => $value) {
+            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get media tracks for this media object
+     *
+     * @param array<string, mixed> $params Query parameters (include[] options)
+     * @return array<MediaTrack> Array of MediaTrack objects
+     * @throws CanvasApiException
+     */
+    public function getTracks(array $params = []): array
+    {
+        if (!$this->mediaId) {
+            throw new CanvasApiException('Media object ID is required to get tracks');
+        }
+
+        $response = self::$apiClient->get(
+            "/media_objects/{$this->mediaId}/media_tracks",
+            ['query' => $params]
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn($track) => new MediaTrack($track), $data);
+    }
+
+    /**
+     * Get media tracks by attachment ID
+     *
+     * @param int $attachmentId The attachment ID
+     * @param array<string, mixed> $params Query parameters (include[] options)
+     * @return array<MediaTrack> Array of MediaTrack objects
+     * @throws CanvasApiException
+     */
+    public function getTracksByAttachment(int $attachmentId, array $params = []): array
+    {
+        $response = self::$apiClient->get(
+            "/media_attachments/{$attachmentId}/media_tracks",
+            ['query' => $params]
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn($track) => new MediaTrack($track), $data);
+    }
+
+    /**
+     * Update media tracks for this media object
+     *
+     * @param array<array<string, mixed>>|UpdateMediaTracksDTO $tracks Track data
+     * @param array<string, mixed> $params Query parameters (include[] options)
+     * @return array<MediaTrack> Array of MediaTrack objects
+     * @throws CanvasApiException
+     */
+    public function updateTracks(array|UpdateMediaTracksDTO $tracks, array $params = []): array
+    {
+        if (!$this->mediaId) {
+            throw new CanvasApiException('Media object ID is required to update tracks');
+        }
+
+        if (is_array($tracks)) {
+            // If it's a simple array, assume it's the tracks array
+            $tracks = new UpdateMediaTracksDTO($tracks);
+        }
+
+        $response = self::$apiClient->put(
+            "/media_objects/{$this->mediaId}/media_tracks",
+            [
+                'json' => $tracks->toArray(),
+                'query' => $params
+            ]
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        // Update current instance's tracks
+        $this->mediaTracks = array_map(fn($track) => new MediaTrack($track), $data);
+
+        return $this->mediaTracks;
+    }
+
+    /**
+     * Update media tracks by attachment ID
+     *
+     * @param int $attachmentId The attachment ID
+     * @param array<array<string, mixed>>|UpdateMediaTracksDTO $tracks Track data
+     * @param array<string, mixed> $params Query parameters (include[] options)
+     * @return array<MediaTrack> Array of MediaTrack objects
+     * @throws CanvasApiException
+     */
+    public function updateTracksByAttachment(
+        int $attachmentId,
+        array|UpdateMediaTracksDTO $tracks,
+        array $params = []
+    ): array {
+        if (is_array($tracks)) {
+            // If it's a simple array, assume it's the tracks array
+            $tracks = new UpdateMediaTracksDTO($tracks);
+        }
+
+        $response = self::$apiClient->put(
+            "/media_attachments/{$attachmentId}/media_tracks",
+            [
+                'json' => $tracks->toArray(),
+                'query' => $params
+            ]
+        );
+
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return array_map(fn($track) => new MediaTrack($track), $data);
+    }
+
+    /**
+     * Convert the MediaObject to an array
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'can_add_captions' => $this->canAddCaptions,
+            'user_entered_title' => $this->userEnteredTitle,
+            'title' => $this->title,
+            'media_id' => $this->mediaId,
+            'media_type' => $this->mediaType,
+        ];
+
+        if ($this->mediaTracks !== null) {
+            $data['media_tracks'] = array_map(
+                fn($track) => $track->toArray(),
+                $this->mediaTracks
+            );
+        }
+
+        if ($this->mediaSources !== null) {
+            $data['media_sources'] = array_map(
+                fn($source) => $source->toArray(),
+                $this->mediaSources
+            );
+        }
+
+        return array_filter($data, fn($value) => !is_null($value));
+    }
+
+    /**
+     * Get the endpoint for this API resource
+     * MediaObjects don't have a single endpoint, so this throws an exception
+     *
+     * @return string
+     * @throws CanvasApiException
+     */
+    protected static function getEndpoint(): string
+    {
+        throw new CanvasApiException('MediaObject does not have a single endpoint');
+    }
+}

--- a/src/Dto/MediaObjects/UpdateMediaObjectDTO.php
+++ b/src/Dto/MediaObjects/UpdateMediaObjectDTO.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Dto\MediaObjects;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+use InvalidArgumentException;
+
+/**
+ * UpdateMediaObjectDTO
+ *
+ * Data Transfer Object for updating a MediaObject
+ *
+ * @package CanvasLMS\Dto\MediaObjects
+ */
+class UpdateMediaObjectDTO extends AbstractBaseDto
+{
+    /**
+     * Constructor
+     *
+     * @param string|null $userEnteredTitle The new title for the media object
+     */
+    public function __construct(
+        public ?string $userEnteredTitle = null
+    ) {
+        $this->validate();
+    }
+
+    /**
+     * Validate the DTO data
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validate(): void
+    {
+        // Title is optional but if provided, should not be empty
+        if ($this->userEnteredTitle !== null && trim($this->userEnteredTitle) === '') {
+            throw new InvalidArgumentException('User entered title cannot be empty if provided');
+        }
+    }
+
+    /**
+     * Convert the DTO to an array for API request
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'user_entered_title' => $this->userEnteredTitle,
+        ], fn($value) => !is_null($value));
+    }
+
+    /**
+     * Create DTO from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            userEnteredTitle: $data['user_entered_title'] ?? $data['userEnteredTitle'] ?? null
+        );
+    }
+}

--- a/src/Dto/MediaObjects/UpdateMediaTracksDTO.php
+++ b/src/Dto/MediaObjects/UpdateMediaTracksDTO.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Dto\MediaObjects;
+
+use CanvasLMS\Dto\AbstractBaseDto;
+use InvalidArgumentException;
+
+/**
+ * UpdateMediaTracksDTO
+ *
+ * Data Transfer Object for updating MediaTracks
+ *
+ * @package CanvasLMS\Dto\MediaObjects
+ */
+class UpdateMediaTracksDTO extends AbstractBaseDto
+{
+    /**
+     * Valid track kinds
+     */
+    private const VALID_KINDS = [
+        'subtitles',
+        'captions',
+        'descriptions',
+        'chapters',
+        'metadata'
+    ];
+
+    /** @var array<array<string, mixed>> */
+    public array $tracks = [];
+
+    /**
+     * Constructor
+     *
+     * @param array<array<string, mixed>> $tracks Array of track data
+     */
+    public function __construct(array $tracks = [])
+    {
+        $this->tracks = $tracks;
+        $this->validate();
+    }
+
+    /**
+     * Validate the DTO data
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validate(): void
+    {
+        if (empty($this->tracks)) {
+            // Empty array is valid - it will delete all existing tracks
+            return;
+        }
+
+        foreach ($this->tracks as $index => $track) {
+            // Validate track structure
+            if (!is_array($track)) {
+                throw new InvalidArgumentException("Track at index {$index} must be an array");
+            }
+
+            // Locale is always required
+            if (!isset($track['locale']) || empty($track['locale'])) {
+                throw new InvalidArgumentException("Track at index {$index} must have a locale");
+            }
+
+            // If content is provided, validate it's not empty
+            if (isset($track['content']) && trim($track['content']) === '') {
+                throw new InvalidArgumentException("Track at index {$index} has empty content");
+            }
+
+            // If kind is provided, validate it's valid
+            if (isset($track['kind']) && !in_array($track['kind'], self::VALID_KINDS)) {
+                throw new InvalidArgumentException(
+                    "Track at index {$index} has invalid kind. Valid kinds are: " .
+                    implode(', ', self::VALID_KINDS)
+                );
+            }
+
+            // Validate locale format (basic check for xx or xx-XX format)
+            if (!preg_match('/^[a-z]{2}(-[A-Z]{2})?$/', $track['locale'])) {
+                throw new InvalidArgumentException(
+                    "Track at index {$index} has invalid locale format. " .
+                    "Expected format like 'en' or 'en-US'"
+                );
+            }
+        }
+    }
+
+    /**
+     * Convert the DTO to an array for API request
+     *
+     * @return array<array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        // Return the tracks array directly for the API
+        return $this->tracks;
+    }
+
+    /**
+     * Create DTO from array
+     *
+     * @param array<array<string, mixed>> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        // If data has a 'tracks' key, use it; otherwise assume the whole array is tracks
+        $tracks = isset($data['tracks']) ? $data['tracks'] : $data;
+
+        return new self(tracks: $tracks);
+    }
+
+    /**
+     * Add a track to the DTO
+     *
+     * @param string $locale The locale code
+     * @param string|null $content The track content (SRT format)
+     * @param string|null $kind The track kind
+     * @return self
+     */
+    public function addTrack(string $locale, ?string $content = null, ?string $kind = null): self
+    {
+        $track = ['locale' => $locale];
+
+        if ($content !== null) {
+            $track['content'] = $content;
+        }
+
+        if ($kind !== null) {
+            $track['kind'] = $kind;
+        }
+
+        $this->tracks[] = $track;
+        $this->validate();
+
+        return $this;
+    }
+
+    /**
+     * Clear all tracks
+     *
+     * @return self
+     */
+    public function clearTracks(): self
+    {
+        $this->tracks = [];
+        return $this;
+    }
+}

--- a/src/Objects/MediaSource.php
+++ b/src/Objects/MediaSource.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Objects;
+
+/**
+ * MediaSource Object
+ *
+ * Represents a media source (encoding/flavor) available for a MediaObject
+ *
+ * @package CanvasLMS\Objects
+ */
+class MediaSource
+{
+    /**
+     * Video height in pixels
+     */
+    public ?string $height = null;
+
+    /**
+     * Video width in pixels
+     */
+    public ?string $width = null;
+
+    /**
+     * MIME type of the media file
+     */
+    public ?string $contentType = null;
+
+    /**
+     * Container format (mp4, webm, isom, flash video, etc.)
+     */
+    public ?string $containerFormat = null;
+
+    /**
+     * Direct URL to the media file
+     */
+    public ?string $url = null;
+
+    /**
+     * Bitrate of the encoding
+     */
+    public ?string $bitrate = null;
+
+    /**
+     * File size in bytes
+     */
+    public ?string $size = null;
+
+    /**
+     * Whether this is the original uploaded file ("0" or "1")
+     */
+    public ?string $isOriginal = null;
+
+    /**
+     * File extension (mp4, flv, etc.)
+     */
+    public ?string $fileExt = null;
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $data The data to populate the object
+     */
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $key => $value) {
+            // Convert snake_case to camelCase
+            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
+
+            if (property_exists($this, $key) && !is_null($value)) {
+                $this->{$key} = $value;
+            }
+        }
+    }
+
+    /**
+     * Convert the object to an array
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'height' => $this->height,
+            'width' => $this->width,
+            'content_type' => $this->contentType,
+            'container_format' => $this->containerFormat,
+            'url' => $this->url,
+            'bitrate' => $this->bitrate,
+            'size' => $this->size,
+            'is_original' => $this->isOriginal,
+            'file_ext' => $this->fileExt,
+        ], fn($value) => !is_null($value));
+    }
+}

--- a/src/Objects/MediaTrack.php
+++ b/src/Objects/MediaTrack.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Objects;
+
+/**
+ * MediaTrack Object
+ *
+ * Represents a media track (caption/subtitle) associated with a MediaObject
+ *
+ * @package CanvasLMS\Objects
+ */
+class MediaTrack
+{
+    /**
+     * The Canvas ID of the media track
+     */
+    public ?int $id = null;
+
+    /**
+     * The ID of the user who created the track
+     */
+    public ?int $userId = null;
+
+    /**
+     * The media object ID this track belongs to
+     */
+    public ?string $mediaObjectId = null;
+
+    /**
+     * The type of track (subtitles, captions, descriptions, chapters, metadata)
+     */
+    public ?string $kind = null;
+
+    /**
+     * The language/locale code for the track (e.g., "en", "es", "fr")
+     */
+    public ?string $locale = null;
+
+    /**
+     * The SRT format content of the track
+     */
+    public ?string $content = null;
+
+    /**
+     * The WEBVTT format content of the track
+     */
+    public ?string $webvttContent = null;
+
+    /**
+     * The URL to access the track
+     */
+    public ?string $url = null;
+
+    /**
+     * When the track was created
+     */
+    public ?string $createdAt = null;
+
+    /**
+     * When the track was last updated
+     */
+    public ?string $updatedAt = null;
+
+    /**
+     * Constructor
+     *
+     * @param array<string, mixed> $data The data to populate the object
+     */
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $key => $value) {
+            // Convert snake_case to camelCase
+            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
+
+            if (property_exists($this, $key) && !is_null($value)) {
+                $this->{$key} = $value;
+            }
+        }
+    }
+
+    /**
+     * Convert the object to an array
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'id' => $this->id,
+            'user_id' => $this->userId,
+            'media_object_id' => $this->mediaObjectId,
+            'kind' => $this->kind,
+            'locale' => $this->locale,
+            'content' => $this->content,
+            'webvtt_content' => $this->webvttContent,
+            'url' => $this->url,
+            'created_at' => $this->createdAt,
+            'updated_at' => $this->updatedAt,
+        ], fn($value) => !is_null($value));
+    }
+}

--- a/tests/Api/MediaObjects/MediaObjectTest.php
+++ b/tests/Api/MediaObjects/MediaObjectTest.php
@@ -1,0 +1,706 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\MediaObjects;
+
+use CanvasLMS\Api\MediaObjects\MediaObject;
+use CanvasLMS\Canvas;
+use CanvasLMS\Config;
+use CanvasLMS\Dto\MediaObjects\UpdateMediaObjectDTO;
+use CanvasLMS\Dto\MediaObjects\UpdateMediaTracksDTO;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use CanvasLMS\Objects\MediaTrack;
+use CanvasLMS\Objects\MediaSource;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @covers \CanvasLMS\Api\MediaObjects\MediaObject
+ */
+class MediaObjectTest extends TestCase
+{
+    /**
+     * Set up test environment
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // Set up Config
+        Config::setBaseUrl('https://canvas.example.com/');
+        Config::setApiKey('test-api-key');
+        
+        // Reset HTTP client for each test
+        MediaObject::setApiClient($this->createMock(HttpClientInterface::class));
+    }
+
+    /**
+     * Tear down test environment
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        // Reset the HTTP client
+        MediaObject::setApiClient($this->createMock(HttpClientInterface::class));
+    }
+
+    /**
+     * Set HTTP client mock
+     */
+    private function setHttpClient(HttpClientInterface $client): void
+    {
+        MediaObject::setApiClient($client);
+    }
+
+    /**
+     * Test fetching all media objects (global context)
+     */
+    public function testFetchAll(): void
+    {
+        $mockData = [
+            'media_objects' => [
+                [
+                    'can_add_captions' => true,
+                    'user_entered_title' => 'Test Video',
+                    'title' => 'Test Video',
+                    'media_id' => 'm-test123',
+                    'media_type' => 'video',
+                    'media_tracks' => [],
+                    'media_sources' => []
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with('/media_objects', ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $mediaObjects = MediaObject::fetchAll();
+
+        $this->assertIsArray($mediaObjects);
+        $this->assertCount(1, $mediaObjects);
+        $this->assertInstanceOf(MediaObject::class, $mediaObjects[0]);
+        $this->assertEquals('Test Video', $mediaObjects[0]->title);
+        $this->assertEquals('m-test123', $mediaObjects[0]->mediaId);
+    }
+
+    /**
+     * Test fetching media objects with parameters
+     */
+    public function testFetchAllWithParams(): void
+    {
+        $params = [
+            'sort' => 'title',
+            'order' => 'asc',
+            'exclude[]' => ['sources', 'tracks']
+        ];
+
+        $mockData = ['media_objects' => []];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with('/media_objects', ['query' => $params])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $mediaObjects = MediaObject::fetchAll($params);
+
+        $this->assertIsArray($mediaObjects);
+        $this->assertEmpty($mediaObjects);
+    }
+
+    /**
+     * Test fetching media attachments
+     */
+    public function testFetchAttachments(): void
+    {
+        $mockData = [
+            'media_objects' => [
+                [
+                    'can_add_captions' => true,
+                    'title' => 'Attachment Video',
+                    'media_id' => 'm-attach123',
+                    'media_type' => 'video'
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with('/media_attachments', ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $attachments = MediaObject::fetchAttachments();
+
+        $this->assertIsArray($attachments);
+        $this->assertCount(1, $attachments);
+        $this->assertEquals('Attachment Video', $attachments[0]->title);
+    }
+
+    /**
+     * Test fetching media objects by course
+     */
+    public function testFetchByCourse(): void
+    {
+        $courseId = 123;
+        $mockData = [
+            'media_objects' => [
+                [
+                    'title' => 'Course Video',
+                    'media_id' => 'm-course123',
+                    'media_type' => 'video'
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with("/courses/{$courseId}/media_objects", ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $mediaObjects = MediaObject::fetchByCourse($courseId);
+
+        $this->assertIsArray($mediaObjects);
+        $this->assertCount(1, $mediaObjects);
+        $this->assertEquals('Course Video', $mediaObjects[0]->title);
+    }
+
+    /**
+     * Test fetching media attachments by course
+     */
+    public function testFetchAttachmentsByCourse(): void
+    {
+        $courseId = 123;
+        $mockData = [
+            'media_objects' => [
+                [
+                    'title' => 'Course Attachment',
+                    'media_id' => 'm-courseattach123'
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with("/courses/{$courseId}/media_attachments", ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $attachments = MediaObject::fetchAttachmentsByCourse($courseId);
+
+        $this->assertIsArray($attachments);
+        $this->assertCount(1, $attachments);
+        $this->assertEquals('Course Attachment', $attachments[0]->title);
+    }
+
+    /**
+     * Test fetching media objects by group
+     */
+    public function testFetchByGroup(): void
+    {
+        $groupId = 456;
+        $mockData = [
+            'media_objects' => [
+                [
+                    'title' => 'Group Video',
+                    'media_id' => 'm-group456'
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with("/groups/{$groupId}/media_objects", ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $mediaObjects = MediaObject::fetchByGroup($groupId);
+
+        $this->assertIsArray($mediaObjects);
+        $this->assertCount(1, $mediaObjects);
+        $this->assertEquals('Group Video', $mediaObjects[0]->title);
+    }
+
+    /**
+     * Test fetching media attachments by group
+     */
+    public function testFetchAttachmentsByGroup(): void
+    {
+        $groupId = 456;
+        $mockData = [
+            'media_objects' => [
+                [
+                    'title' => 'Group Attachment',
+                    'media_id' => 'm-groupattach456'
+                ]
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with("/groups/{$groupId}/media_attachments", ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($mockData)));
+
+        $this->setHttpClient($mockClient);
+
+        $attachments = MediaObject::fetchAttachmentsByGroup($groupId);
+
+        $this->assertIsArray($attachments);
+        $this->assertCount(1, $attachments);
+        $this->assertEquals('Group Attachment', $attachments[0]->title);
+    }
+
+    /**
+     * Test that find method throws exception
+     */
+    public function testFindThrowsException(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Direct media object retrieval is not supported by Canvas API');
+
+        MediaObject::find(123);
+    }
+
+
+    /**
+     * Test updating a media object
+     */
+    public function testUpdate(): void
+    {
+        $mediaObject = new MediaObject([
+            'media_id' => 'm-test123',
+            'title' => 'Old Title'
+        ]);
+
+        $updateData = ['userEnteredTitle' => 'New Title'];
+        $responseData = [
+            'user_entered_title' => 'New Title',
+            'title' => 'New Title',
+            'media_id' => 'm-test123'
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                '/media_objects/m-test123',
+                ['json' => ['user_entered_title' => 'New Title']]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->update($updateData);
+
+        $this->assertInstanceOf(MediaObject::class, $result);
+        $this->assertEquals('New Title', $result->userEnteredTitle);
+        $this->assertEquals('New Title', $result->title);
+    }
+
+    /**
+     * Test updating a media object with DTO
+     */
+    public function testUpdateWithDTO(): void
+    {
+        $mediaObject = new MediaObject([
+            'media_id' => 'm-test123'
+        ]);
+
+        $dto = new UpdateMediaObjectDTO('New Title via DTO');
+        $responseData = [
+            'user_entered_title' => 'New Title via DTO',
+            'title' => 'New Title via DTO',
+            'media_id' => 'm-test123'
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                '/media_objects/m-test123',
+                ['json' => ['user_entered_title' => 'New Title via DTO']]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->update($dto);
+
+        $this->assertEquals('New Title via DTO', $result->userEnteredTitle);
+    }
+
+    /**
+     * Test updating without media ID throws exception
+     */
+    public function testUpdateWithoutMediaIdThrowsException(): void
+    {
+        $mediaObject = new MediaObject();
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Media object ID is required for update');
+
+        $mediaObject->update(['userEnteredTitle' => 'New Title']);
+    }
+
+    /**
+     * Test updating by attachment ID
+     */
+    public function testUpdateByAttachment(): void
+    {
+        $mediaObject = new MediaObject();
+        $attachmentId = 789;
+
+        $updateData = ['userEnteredTitle' => 'Updated via Attachment'];
+        $responseData = [
+            'user_entered_title' => 'Updated via Attachment',
+            'title' => 'Updated via Attachment'
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                "/media_attachments/{$attachmentId}",
+                ['json' => ['user_entered_title' => 'Updated via Attachment']]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->updateByAttachment($attachmentId, $updateData);
+
+        $this->assertEquals('Updated via Attachment', $result->userEnteredTitle);
+    }
+
+    /**
+     * Test getting media tracks
+     */
+    public function testGetTracks(): void
+    {
+        $mediaObject = new MediaObject(['media_id' => 'm-test123']);
+
+        $tracksData = [
+            [
+                'id' => 1,
+                'user_id' => 100,
+                'media_object_id' => 'm-test123',
+                'kind' => 'subtitles',
+                'locale' => 'en',
+                'content' => 'Test content'
+            ],
+            [
+                'id' => 2,
+                'kind' => 'captions',
+                'locale' => 'es'
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with('/media_objects/m-test123/media_tracks', ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($tracksData)));
+
+        $this->setHttpClient($mockClient);
+
+        $tracks = $mediaObject->getTracks();
+
+        $this->assertIsArray($tracks);
+        $this->assertCount(2, $tracks);
+        $this->assertInstanceOf(MediaTrack::class, $tracks[0]);
+        $this->assertEquals('subtitles', $tracks[0]->kind);
+        $this->assertEquals('en', $tracks[0]->locale);
+    }
+
+    /**
+     * Test getting tracks without media ID throws exception
+     */
+    public function testGetTracksWithoutMediaIdThrowsException(): void
+    {
+        $mediaObject = new MediaObject();
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Media object ID is required to get tracks');
+
+        $mediaObject->getTracks();
+    }
+
+    /**
+     * Test getting tracks by attachment
+     */
+    public function testGetTracksByAttachment(): void
+    {
+        $mediaObject = new MediaObject();
+        $attachmentId = 999;
+
+        $tracksData = [
+            [
+                'id' => 3,
+                'kind' => 'descriptions',
+                'locale' => 'fr'
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('get')
+            ->with("/media_attachments/{$attachmentId}/media_tracks", ['query' => []])
+            ->willReturn(new Response(200, [], json_encode($tracksData)));
+
+        $this->setHttpClient($mockClient);
+
+        $tracks = $mediaObject->getTracksByAttachment($attachmentId);
+
+        $this->assertIsArray($tracks);
+        $this->assertCount(1, $tracks);
+        $this->assertEquals('descriptions', $tracks[0]->kind);
+    }
+
+    /**
+     * Test updating tracks
+     */
+    public function testUpdateTracks(): void
+    {
+        $mediaObject = new MediaObject(['media_id' => 'm-test123']);
+
+        $tracksToUpdate = [
+            ['locale' => 'en', 'content' => 'English subtitles', 'kind' => 'subtitles'],
+            ['locale' => 'es', 'content' => 'Subtítulos en español', 'kind' => 'subtitles']
+        ];
+
+        $responseData = [
+            [
+                'id' => 10,
+                'locale' => 'en',
+                'kind' => 'subtitles',
+                'content' => 'English subtitles'
+            ],
+            [
+                'id' => 11,
+                'locale' => 'es',
+                'kind' => 'subtitles',
+                'content' => 'Subtítulos en español'
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                '/media_objects/m-test123/media_tracks',
+                [
+                    'json' => $tracksToUpdate,
+                    'query' => []
+                ]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->updateTracks($tracksToUpdate);
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(MediaTrack::class, $result[0]);
+        $this->assertEquals('en', $result[0]->locale);
+        $this->assertIsArray($mediaObject->mediaTracks);
+        $this->assertCount(2, $mediaObject->mediaTracks);
+    }
+
+    /**
+     * Test updating tracks with DTO
+     */
+    public function testUpdateTracksWithDTO(): void
+    {
+        $mediaObject = new MediaObject(['media_id' => 'm-test123']);
+
+        $dto = new UpdateMediaTracksDTO([
+            ['locale' => 'de', 'content' => 'Deutsche Untertitel', 'kind' => 'subtitles']
+        ]);
+
+        $responseData = [
+            [
+                'id' => 12,
+                'locale' => 'de',
+                'kind' => 'subtitles'
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                '/media_objects/m-test123/media_tracks',
+                [
+                    'json' => $dto->toArray(),
+                    'query' => []
+                ]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->updateTracks($dto);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('de', $result[0]->locale);
+    }
+
+    /**
+     * Test updating tracks without media ID throws exception
+     */
+    public function testUpdateTracksWithoutMediaIdThrowsException(): void
+    {
+        $mediaObject = new MediaObject();
+
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Media object ID is required to update tracks');
+
+        $mediaObject->updateTracks([]);
+    }
+
+    /**
+     * Test updating tracks by attachment
+     */
+    public function testUpdateTracksByAttachment(): void
+    {
+        $mediaObject = new MediaObject();
+        $attachmentId = 555;
+
+        $tracksToUpdate = [
+            ['locale' => 'ja', 'kind' => 'captions']
+        ];
+
+        $responseData = [
+            [
+                'id' => 13,
+                'locale' => 'ja',
+                'kind' => 'captions'
+            ]
+        ];
+
+        $mockClient = $this->createMock(HttpClientInterface::class);
+        $mockClient->expects($this->once())
+            ->method('put')
+            ->with(
+                "/media_attachments/{$attachmentId}/media_tracks",
+                [
+                    'json' => $tracksToUpdate,
+                    'query' => []
+                ]
+            )
+            ->willReturn(new Response(200, [], json_encode($responseData)));
+
+        $this->setHttpClient($mockClient);
+
+        $result = $mediaObject->updateTracksByAttachment($attachmentId, $tracksToUpdate);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('ja', $result[0]->locale);
+    }
+
+    /**
+     * Test media tracks parsing in constructor
+     */
+    public function testMediaTracksParsingInConstructor(): void
+    {
+        $data = [
+            'media_id' => 'm-test123',
+            'media_tracks' => [
+                ['id' => 1, 'locale' => 'en', 'kind' => 'subtitles'],
+                ['id' => 2, 'locale' => 'es', 'kind' => 'captions']
+            ]
+        ];
+
+        $mediaObject = new MediaObject($data);
+
+        $this->assertIsArray($mediaObject->mediaTracks);
+        $this->assertCount(2, $mediaObject->mediaTracks);
+        $this->assertInstanceOf(MediaTrack::class, $mediaObject->mediaTracks[0]);
+        $this->assertEquals('en', $mediaObject->mediaTracks[0]->locale);
+    }
+
+    /**
+     * Test media sources parsing in constructor
+     */
+    public function testMediaSourcesParsingInConstructor(): void
+    {
+        $data = [
+            'media_id' => 'm-test123',
+            'media_sources' => [
+                [
+                    'height' => '720',
+                    'width' => '1280',
+                    'content_type' => 'video/mp4',
+                    'url' => 'https://example.com/video.mp4'
+                ],
+                [
+                    'height' => '480',
+                    'width' => '854',
+                    'content_type' => 'video/webm',
+                    'url' => 'https://example.com/video.webm'
+                ]
+            ]
+        ];
+
+        $mediaObject = new MediaObject($data);
+
+        $this->assertIsArray($mediaObject->mediaSources);
+        $this->assertCount(2, $mediaObject->mediaSources);
+        $this->assertInstanceOf(MediaSource::class, $mediaObject->mediaSources[0]);
+        $this->assertEquals('720', $mediaObject->mediaSources[0]->height);
+        $this->assertEquals('video/mp4', $mediaObject->mediaSources[0]->contentType);
+    }
+
+    /**
+     * Test toArray method
+     */
+    public function testToArray(): void
+    {
+        $mediaObject = new MediaObject([
+            'can_add_captions' => true,
+            'user_entered_title' => 'My Video',
+            'title' => 'My Video',
+            'media_id' => 'm-test123',
+            'media_type' => 'video',
+            'media_tracks' => [
+                ['id' => 1, 'locale' => 'en']
+            ],
+            'media_sources' => [
+                ['height' => '720', 'width' => '1280']
+            ]
+        ]);
+
+        $array = $mediaObject->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals(true, $array['can_add_captions']);
+        $this->assertEquals('My Video', $array['user_entered_title']);
+        $this->assertEquals('My Video', $array['title']);
+        $this->assertEquals('m-test123', $array['media_id']);
+        $this->assertEquals('video', $array['media_type']);
+        $this->assertIsArray($array['media_tracks']);
+        $this->assertIsArray($array['media_sources']);
+    }
+}

--- a/tests/Dto/MediaObjects/UpdateMediaObjectDTOTest.php
+++ b/tests/Dto/MediaObjects/UpdateMediaObjectDTOTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dto\MediaObjects;
+
+use CanvasLMS\Dto\MediaObjects\UpdateMediaObjectDTO;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CanvasLMS\Dto\MediaObjects\UpdateMediaObjectDTO
+ */
+class UpdateMediaObjectDTOTest extends TestCase
+{
+    /**
+     * Test creating DTO with valid title
+     */
+    public function testCreateWithValidTitle(): void
+    {
+        $dto = new UpdateMediaObjectDTO('My New Title');
+        
+        $this->assertEquals('My New Title', $dto->userEnteredTitle);
+        
+        $array = $dto->toArray();
+        $this->assertEquals(['user_entered_title' => 'My New Title'], $array);
+    }
+
+    /**
+     * Test creating DTO with null title
+     */
+    public function testCreateWithNullTitle(): void
+    {
+        $dto = new UpdateMediaObjectDTO(null);
+        
+        $this->assertNull($dto->userEnteredTitle);
+        
+        $array = $dto->toArray();
+        $this->assertEmpty($array);
+    }
+
+    /**
+     * Test creating DTO with empty string throws exception
+     */
+    public function testCreateWithEmptyStringThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('User entered title cannot be empty if provided');
+        
+        new UpdateMediaObjectDTO('');
+    }
+
+    /**
+     * Test creating DTO with whitespace-only string throws exception
+     */
+    public function testCreateWithWhitespaceOnlyStringThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('User entered title cannot be empty if provided');
+        
+        new UpdateMediaObjectDTO('   ');
+    }
+
+    /**
+     * Test fromArray with snake_case key
+     */
+    public function testFromArrayWithSnakeCase(): void
+    {
+        $data = ['user_entered_title' => 'Title from Array'];
+        
+        $dto = UpdateMediaObjectDTO::fromArray($data);
+        
+        $this->assertEquals('Title from Array', $dto->userEnteredTitle);
+    }
+
+    /**
+     * Test fromArray with camelCase key
+     */
+    public function testFromArrayWithCamelCase(): void
+    {
+        $data = ['userEnteredTitle' => 'Title from Camel'];
+        
+        $dto = UpdateMediaObjectDTO::fromArray($data);
+        
+        $this->assertEquals('Title from Camel', $dto->userEnteredTitle);
+    }
+
+    /**
+     * Test fromArray with missing key
+     */
+    public function testFromArrayWithMissingKey(): void
+    {
+        $data = [];
+        
+        $dto = UpdateMediaObjectDTO::fromArray($data);
+        
+        $this->assertNull($dto->userEnteredTitle);
+        $this->assertEmpty($dto->toArray());
+    }
+
+    /**
+     * Test fromArray with both snake_case and camelCase (snake_case takes precedence)
+     */
+    public function testFromArrayWithBothFormats(): void
+    {
+        $data = [
+            'user_entered_title' => 'Snake Case Title',
+            'userEnteredTitle' => 'Camel Case Title'
+        ];
+        
+        $dto = UpdateMediaObjectDTO::fromArray($data);
+        
+        // Snake case should take precedence
+        $this->assertEquals('Snake Case Title', $dto->userEnteredTitle);
+    }
+
+    /**
+     * Test toArray filters null values
+     */
+    public function testToArrayFiltersNullValues(): void
+    {
+        $dto = new UpdateMediaObjectDTO(null);
+        
+        $array = $dto->toArray();
+        
+        $this->assertIsArray($array);
+        $this->assertEmpty($array);
+        $this->assertArrayNotHasKey('user_entered_title', $array);
+    }
+
+    /**
+     * Test validation with valid long title
+     */
+    public function testValidLongTitle(): void
+    {
+        $longTitle = str_repeat('a', 1000); // Very long title
+        
+        $dto = new UpdateMediaObjectDTO($longTitle);
+        
+        $this->assertEquals($longTitle, $dto->userEnteredTitle);
+        $array = $dto->toArray();
+        $this->assertEquals($longTitle, $array['user_entered_title']);
+    }
+
+    /**
+     * Test validation with special characters
+     */
+    public function testTitleWithSpecialCharacters(): void
+    {
+        $title = 'Test Title with 特殊文字 and émojis 🎬 and symbols @#$%';
+        
+        $dto = new UpdateMediaObjectDTO($title);
+        
+        $this->assertEquals($title, $dto->userEnteredTitle);
+        $array = $dto->toArray();
+        $this->assertEquals($title, $array['user_entered_title']);
+    }
+}

--- a/tests/Dto/MediaObjects/UpdateMediaTracksDTOTest.php
+++ b/tests/Dto/MediaObjects/UpdateMediaTracksDTOTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Dto\MediaObjects;
+
+use CanvasLMS\Dto\MediaObjects\UpdateMediaTracksDTO;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CanvasLMS\Dto\MediaObjects\UpdateMediaTracksDTO
+ */
+class UpdateMediaTracksDTOTest extends TestCase
+{
+    /**
+     * Test creating DTO with valid tracks
+     */
+    public function testCreateWithValidTracks(): void
+    {
+        $tracks = [
+            ['locale' => 'en', 'content' => 'English content', 'kind' => 'subtitles'],
+            ['locale' => 'es', 'content' => 'Spanish content', 'kind' => 'captions']
+        ];
+
+        $dto = new UpdateMediaTracksDTO($tracks);
+
+        $this->assertEquals($tracks, $dto->tracks);
+        $this->assertEquals($tracks, $dto->toArray());
+    }
+
+    /**
+     * Test creating DTO with empty tracks array
+     */
+    public function testCreateWithEmptyTracks(): void
+    {
+        $dto = new UpdateMediaTracksDTO([]);
+
+        $this->assertEmpty($dto->tracks);
+        $this->assertEmpty($dto->toArray());
+    }
+
+    /**
+     * Test creating DTO with locale-only tracks
+     */
+    public function testCreateWithLocaleOnlyTracks(): void
+    {
+        $tracks = [
+            ['locale' => 'en'],
+            ['locale' => 'fr']
+        ];
+
+        $dto = new UpdateMediaTracksDTO($tracks);
+
+        $this->assertEquals($tracks, $dto->tracks);
+    }
+
+    /**
+     * Test creating DTO without locale throws exception
+     */
+    public function testCreateWithoutLocaleThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 must have a locale');
+
+        new UpdateMediaTracksDTO([
+            ['content' => 'Some content', 'kind' => 'subtitles']
+        ]);
+    }
+
+    /**
+     * Test creating DTO with empty locale throws exception
+     */
+    public function testCreateWithEmptyLocaleThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 must have a locale');
+
+        new UpdateMediaTracksDTO([
+            ['locale' => '', 'content' => 'Content']
+        ]);
+    }
+
+    /**
+     * Test creating DTO with invalid track kind throws exception
+     */
+    public function testCreateWithInvalidKindThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 has invalid kind');
+
+        new UpdateMediaTracksDTO([
+            ['locale' => 'en', 'kind' => 'invalid_kind']
+        ]);
+    }
+
+    /**
+     * Test all valid track kinds
+     */
+    public function testAllValidTrackKinds(): void
+    {
+        $validKinds = ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata'];
+
+        foreach ($validKinds as $kind) {
+            $dto = new UpdateMediaTracksDTO([
+                ['locale' => 'en', 'kind' => $kind]
+            ]);
+
+            $this->assertEquals($kind, $dto->tracks[0]['kind']);
+        }
+    }
+
+    /**
+     * Test creating DTO with empty content throws exception
+     */
+    public function testCreateWithEmptyContentThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 has empty content');
+
+        new UpdateMediaTracksDTO([
+            ['locale' => 'en', 'content' => '']
+        ]);
+    }
+
+    /**
+     * Test creating DTO with whitespace-only content throws exception
+     */
+    public function testCreateWithWhitespaceContentThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 has empty content');
+
+        new UpdateMediaTracksDTO([
+            ['locale' => 'en', 'content' => '   ']
+        ]);
+    }
+
+    /**
+     * Test locale format validation - valid formats
+     */
+    public function testValidLocaleFormats(): void
+    {
+        $validLocales = [
+            'en',
+            'es',
+            'fr',
+            'de',
+            'ja',
+            'zh',
+            'en-US',
+            'es-MX',
+            'fr-CA',
+            'pt-BR'
+        ];
+
+        foreach ($validLocales as $locale) {
+            $dto = new UpdateMediaTracksDTO([
+                ['locale' => $locale]
+            ]);
+
+            $this->assertEquals($locale, $dto->tracks[0]['locale']);
+        }
+    }
+
+    /**
+     * Test locale format validation - invalid formats
+     */
+    public function testInvalidLocaleFormats(): void
+    {
+        $invalidLocales = [
+            'eng',      // Too long
+            'e',        // Too short
+            'EN',       // Wrong case
+            'en_US',    // Wrong separator
+            'en-us',    // Wrong case for country
+            '123',      // Numbers
+            'en-USA',   // Country code too long
+        ];
+
+        foreach ($invalidLocales as $locale) {
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage('invalid locale format');
+
+            new UpdateMediaTracksDTO([
+                ['locale' => $locale]
+            ]);
+        }
+    }
+
+    /**
+     * Test non-array track throws exception
+     */
+    public function testNonArrayTrackThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Track at index 0 must be an array');
+
+        new UpdateMediaTracksDTO(['not_an_array']);
+    }
+
+    /**
+     * Test fromArray with tracks key
+     */
+    public function testFromArrayWithTracksKey(): void
+    {
+        $data = [
+            'tracks' => [
+                ['locale' => 'en', 'content' => 'English'],
+                ['locale' => 'es', 'content' => 'Spanish']
+            ]
+        ];
+
+        $dto = UpdateMediaTracksDTO::fromArray($data);
+
+        $this->assertCount(2, $dto->tracks);
+        $this->assertEquals('en', $dto->tracks[0]['locale']);
+        $this->assertEquals('es', $dto->tracks[1]['locale']);
+    }
+
+    /**
+     * Test fromArray without tracks key
+     */
+    public function testFromArrayWithoutTracksKey(): void
+    {
+        $data = [
+            ['locale' => 'fr', 'content' => 'French'],
+            ['locale' => 'de', 'content' => 'German']
+        ];
+
+        $dto = UpdateMediaTracksDTO::fromArray($data);
+
+        $this->assertCount(2, $dto->tracks);
+        $this->assertEquals('fr', $dto->tracks[0]['locale']);
+        $this->assertEquals('de', $dto->tracks[1]['locale']);
+    }
+
+    /**
+     * Test addTrack method
+     */
+    public function testAddTrack(): void
+    {
+        $dto = new UpdateMediaTracksDTO();
+
+        $dto->addTrack('en', 'English content', 'subtitles');
+        $dto->addTrack('es', 'Spanish content', 'captions');
+        $dto->addTrack('fr'); // No content or kind
+
+        $this->assertCount(3, $dto->tracks);
+        $this->assertEquals('en', $dto->tracks[0]['locale']);
+        $this->assertEquals('English content', $dto->tracks[0]['content']);
+        $this->assertEquals('subtitles', $dto->tracks[0]['kind']);
+        $this->assertEquals('fr', $dto->tracks[2]['locale']);
+        $this->assertArrayNotHasKey('content', $dto->tracks[2]);
+    }
+
+    /**
+     * Test addTrack with invalid kind throws exception
+     */
+    public function testAddTrackWithInvalidKindThrowsException(): void
+    {
+        $dto = new UpdateMediaTracksDTO();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid kind');
+
+        $dto->addTrack('en', 'Content', 'invalid_kind');
+    }
+
+    /**
+     * Test clearTracks method
+     */
+    public function testClearTracks(): void
+    {
+        $dto = new UpdateMediaTracksDTO([
+            ['locale' => 'en'],
+            ['locale' => 'es']
+        ]);
+
+        $this->assertCount(2, $dto->tracks);
+
+        $dto->clearTracks();
+
+        $this->assertEmpty($dto->tracks);
+        $this->assertEmpty($dto->toArray());
+    }
+
+    /**
+     * Test method chaining
+     */
+    public function testMethodChaining(): void
+    {
+        $dto = new UpdateMediaTracksDTO();
+
+        $result = $dto
+            ->addTrack('en', 'English')
+            ->addTrack('es', 'Spanish')
+            ->clearTracks()
+            ->addTrack('fr', 'French');
+
+        $this->assertInstanceOf(UpdateMediaTracksDTO::class, $result);
+        $this->assertCount(1, $dto->tracks);
+        $this->assertEquals('fr', $dto->tracks[0]['locale']);
+    }
+
+    /**
+     * Test toArray returns direct tracks array
+     */
+    public function testToArrayReturnsDirectTracksArray(): void
+    {
+        $tracks = [
+            ['locale' => 'en', 'content' => 'Test'],
+            ['locale' => 'es']
+        ];
+
+        $dto = new UpdateMediaTracksDTO($tracks);
+
+        $array = $dto->toArray();
+
+        $this->assertEquals($tracks, $array);
+        $this->assertNotEquals(['tracks' => $tracks], $array); // Should not wrap in 'tracks' key
+    }
+
+    /**
+     * Test complex WEBVTT content
+     */
+    public function testComplexWebvttContent(): void
+    {
+        $webvttContent = "WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nHello World\n\n2\n00:00:05.000 --> 00:00:10.000\nThis is a test";
+
+        $dto = new UpdateMediaTracksDTO([
+            ['locale' => 'en', 'content' => $webvttContent, 'kind' => 'captions']
+        ]);
+
+        $this->assertEquals($webvttContent, $dto->tracks[0]['content']);
+    }
+}

--- a/tests/Objects/MediaSourceTest.php
+++ b/tests/Objects/MediaSourceTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Objects;
+
+use CanvasLMS\Objects\MediaSource;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CanvasLMS\Objects\MediaSource
+ */
+class MediaSourceTest extends TestCase
+{
+    /**
+     * Test creating MediaSource with all properties
+     */
+    public function testCreateWithAllProperties(): void
+    {
+        $data = [
+            'height' => '720',
+            'width' => '1280',
+            'content_type' => 'video/mp4',
+            'containerFormat' => 'isom',
+            'url' => 'https://example.com/video.mp4',
+            'bitrate' => '2500',
+            'size' => '10485760',
+            'isOriginal' => '1',
+            'fileExt' => 'mp4'
+        ];
+
+        $source = new MediaSource($data);
+
+        $this->assertEquals('720', $source->height);
+        $this->assertEquals('1280', $source->width);
+        $this->assertEquals('video/mp4', $source->contentType);
+        $this->assertEquals('isom', $source->containerFormat);
+        $this->assertEquals('https://example.com/video.mp4', $source->url);
+        $this->assertEquals('2500', $source->bitrate);
+        $this->assertEquals('10485760', $source->size);
+        $this->assertEquals('1', $source->isOriginal);
+        $this->assertEquals('mp4', $source->fileExt);
+    }
+
+    /**
+     * Test creating MediaSource with empty data
+     */
+    public function testCreateWithEmptyData(): void
+    {
+        $source = new MediaSource();
+
+        $this->assertNull($source->height);
+        $this->assertNull($source->width);
+        $this->assertNull($source->contentType);
+        $this->assertNull($source->containerFormat);
+        $this->assertNull($source->url);
+        $this->assertNull($source->bitrate);
+        $this->assertNull($source->size);
+        $this->assertNull($source->isOriginal);
+        $this->assertNull($source->fileExt);
+    }
+
+    /**
+     * Test snake_case to camelCase conversion
+     */
+    public function testSnakeCaseToCamelCaseConversion(): void
+    {
+        $data = [
+            'content_type' => 'video/webm',
+            'file_ext' => 'webm'
+        ];
+
+        $source = new MediaSource($data);
+
+        $this->assertEquals('video/webm', $source->contentType);
+        $this->assertEquals('webm', $source->fileExt);
+    }
+
+    /**
+     * Test toArray method
+     */
+    public function testToArray(): void
+    {
+        $source = new MediaSource([
+            'height' => '480',
+            'width' => '854',
+            'content_type' => 'video/webm',
+            'containerFormat' => 'webm',
+            'url' => 'https://example.com/video.webm',
+            'bitrate' => '1500',
+            'size' => '5242880',
+            'isOriginal' => '0',
+            'fileExt' => 'webm'
+        ]);
+
+        $array = $source->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals('480', $array['height']);
+        $this->assertEquals('854', $array['width']);
+        $this->assertEquals('video/webm', $array['content_type']);
+        $this->assertEquals('webm', $array['container_format']);
+        $this->assertEquals('https://example.com/video.webm', $array['url']);
+        $this->assertEquals('1500', $array['bitrate']);
+        $this->assertEquals('5242880', $array['size']);
+        $this->assertEquals('0', $array['is_original']);
+        $this->assertEquals('webm', $array['file_ext']);
+    }
+
+    /**
+     * Test toArray with partial data
+     */
+    public function testToArrayWithPartialData(): void
+    {
+        $source = new MediaSource([
+            'height' => '1080',
+            'width' => '1920',
+            'content_type' => 'video/mp4',
+            'url' => 'https://example.com/hd.mp4'
+        ]);
+
+        $array = $source->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals('1080', $array['height']);
+        $this->assertEquals('1920', $array['width']);
+        $this->assertEquals('video/mp4', $array['content_type']);
+        $this->assertEquals('https://example.com/hd.mp4', $array['url']);
+        
+        // Should not include null values
+        $this->assertArrayNotHasKey('containerFormat', $array);
+        $this->assertArrayNotHasKey('bitrate', $array);
+        $this->assertArrayNotHasKey('size', $array);
+        $this->assertArrayNotHasKey('isOriginal', $array);
+        $this->assertArrayNotHasKey('fileExt', $array);
+    }
+
+    /**
+     * Test toArray with all null values
+     */
+    public function testToArrayWithAllNullValues(): void
+    {
+        $source = new MediaSource();
+
+        $array = $source->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEmpty($array);
+    }
+
+    /**
+     * Test handling null values in constructor
+     */
+    public function testHandlingNullValuesInConstructor(): void
+    {
+        $data = [
+            'height' => '360',
+            'width' => null,
+            'content_type' => 'video/flv',
+            'url' => null
+        ];
+
+        $source = new MediaSource($data);
+
+        $this->assertEquals('360', $source->height);
+        $this->assertNull($source->width);
+        $this->assertEquals('video/flv', $source->contentType);
+        $this->assertNull($source->url);
+    }
+
+    /**
+     * Test unknown properties are ignored
+     */
+    public function testUnknownPropertiesAreIgnored(): void
+    {
+        $data = [
+            'height' => '240',
+            'unknown_property' => 'should be ignored',
+            'another_unknown' => 456
+        ];
+
+        $source = new MediaSource($data);
+
+        $this->assertEquals('240', $source->height);
+        $this->assertObjectNotHasProperty('unknownProperty', $source);
+        $this->assertObjectNotHasProperty('anotherUnknown', $source);
+    }
+
+    /**
+     * Test various video formats
+     */
+    public function testVariousVideoFormats(): void
+    {
+        $formats = [
+            ['content_type' => 'video/mp4', 'fileExt' => 'mp4', 'containerFormat' => 'isom'],
+            ['content_type' => 'video/webm', 'fileExt' => 'webm', 'containerFormat' => 'webm'],
+            ['content_type' => 'video/x-flv', 'fileExt' => 'flv', 'containerFormat' => 'flash video'],
+            ['content_type' => 'video/ogg', 'fileExt' => 'ogv', 'containerFormat' => 'ogg'],
+            ['content_type' => 'video/quicktime', 'fileExt' => 'mov', 'containerFormat' => 'quicktime']
+        ];
+
+        foreach ($formats as $format) {
+            $source = new MediaSource($format);
+            $this->assertEquals($format['content_type'], $source->contentType);
+            $this->assertEquals($format['fileExt'], $source->fileExt);
+            $this->assertEquals($format['containerFormat'], $source->containerFormat);
+        }
+    }
+
+    /**
+     * Test audio formats
+     */
+    public function testAudioFormats(): void
+    {
+        $formats = [
+            ['content_type' => 'audio/mp3', 'fileExt' => 'mp3'],
+            ['content_type' => 'audio/mpeg', 'fileExt' => 'mp3'],
+            ['content_type' => 'audio/ogg', 'fileExt' => 'ogg'],
+            ['content_type' => 'audio/wav', 'fileExt' => 'wav']
+        ];
+
+        foreach ($formats as $format) {
+            $source = new MediaSource($format);
+            $this->assertEquals($format['content_type'], $source->contentType);
+            $this->assertEquals($format['fileExt'], $source->fileExt);
+        }
+    }
+
+    /**
+     * Test isOriginal values
+     */
+    public function testIsOriginalValues(): void
+    {
+        // Test original file
+        $original = new MediaSource(['isOriginal' => '1']);
+        $this->assertEquals('1', $original->isOriginal);
+
+        // Test transcoded file
+        $transcoded = new MediaSource(['isOriginal' => '0']);
+        $this->assertEquals('0', $transcoded->isOriginal);
+    }
+
+    /**
+     * Test various resolutions
+     */
+    public function testVariousResolutions(): void
+    {
+        $resolutions = [
+            ['height' => '240', 'width' => '320'],   // 240p
+            ['height' => '360', 'width' => '640'],   // 360p
+            ['height' => '480', 'width' => '854'],   // 480p
+            ['height' => '720', 'width' => '1280'],  // 720p HD
+            ['height' => '1080', 'width' => '1920'], // 1080p Full HD
+            ['height' => '1440', 'width' => '2560'], // 1440p 2K
+            ['height' => '2160', 'width' => '3840']  // 2160p 4K
+        ];
+
+        foreach ($resolutions as $resolution) {
+            $source = new MediaSource($resolution);
+            $this->assertEquals($resolution['height'], $source->height);
+            $this->assertEquals($resolution['width'], $source->width);
+        }
+    }
+
+    /**
+     * Test size values (in bytes)
+     */
+    public function testSizeValues(): void
+    {
+        $sizes = [
+            '1024',         // 1 KB
+            '1048576',      // 1 MB
+            '104857600',    // 100 MB
+            '1073741824',   // 1 GB
+        ];
+
+        foreach ($sizes as $size) {
+            $source = new MediaSource(['size' => $size]);
+            $this->assertEquals($size, $source->size);
+        }
+    }
+
+    /**
+     * Test bitrate values
+     */
+    public function testBitrateValues(): void
+    {
+        $bitrates = [
+            '128',   // Low quality audio
+            '320',   // High quality audio
+            '500',   // Low quality video
+            '1500',  // Medium quality video
+            '5000',  // High quality video
+            '10000', // Very high quality video
+        ];
+
+        foreach ($bitrates as $bitrate) {
+            $source = new MediaSource(['bitrate' => $bitrate]);
+            $this->assertEquals($bitrate, $source->bitrate);
+        }
+    }
+}

--- a/tests/Objects/MediaTrackTest.php
+++ b/tests/Objects/MediaTrackTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Objects;
+
+use CanvasLMS\Objects\MediaTrack;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \CanvasLMS\Objects\MediaTrack
+ */
+class MediaTrackTest extends TestCase
+{
+    /**
+     * Test creating MediaTrack with all properties
+     */
+    public function testCreateWithAllProperties(): void
+    {
+        $data = [
+            'id' => 42,
+            'user_id' => 100,
+            'media_object_id' => 'm-test123',
+            'kind' => 'subtitles',
+            'locale' => 'en',
+            'content' => 'Test subtitle content',
+            'webvtt_content' => 'WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nTest',
+            'url' => 'https://example.com/track',
+            'created_at' => '2024-01-15T10:00:00Z',
+            'updated_at' => '2024-01-15T11:00:00Z'
+        ];
+
+        $track = new MediaTrack($data);
+
+        $this->assertEquals(42, $track->id);
+        $this->assertEquals(100, $track->userId);
+        $this->assertEquals('m-test123', $track->mediaObjectId);
+        $this->assertEquals('subtitles', $track->kind);
+        $this->assertEquals('en', $track->locale);
+        $this->assertEquals('Test subtitle content', $track->content);
+        $this->assertEquals('WEBVTT\n\n1\n00:00:00.000 --> 00:00:05.000\nTest', $track->webvttContent);
+        $this->assertEquals('https://example.com/track', $track->url);
+        $this->assertEquals('2024-01-15T10:00:00Z', $track->createdAt);
+        $this->assertEquals('2024-01-15T11:00:00Z', $track->updatedAt);
+    }
+
+    /**
+     * Test creating MediaTrack with empty data
+     */
+    public function testCreateWithEmptyData(): void
+    {
+        $track = new MediaTrack();
+
+        $this->assertNull($track->id);
+        $this->assertNull($track->userId);
+        $this->assertNull($track->mediaObjectId);
+        $this->assertNull($track->kind);
+        $this->assertNull($track->locale);
+        $this->assertNull($track->content);
+        $this->assertNull($track->webvttContent);
+        $this->assertNull($track->url);
+        $this->assertNull($track->createdAt);
+        $this->assertNull($track->updatedAt);
+    }
+
+    /**
+     * Test snake_case to camelCase conversion
+     */
+    public function testSnakeCaseToCamelCaseConversion(): void
+    {
+        $data = [
+            'user_id' => 200,
+            'media_object_id' => 'm-abc456',
+            'webvtt_content' => 'WEBVTT content',
+            'created_at' => '2024-01-01',
+            'updated_at' => '2024-01-02'
+        ];
+
+        $track = new MediaTrack($data);
+
+        $this->assertEquals(200, $track->userId);
+        $this->assertEquals('m-abc456', $track->mediaObjectId);
+        $this->assertEquals('WEBVTT content', $track->webvttContent);
+        $this->assertEquals('2024-01-01', $track->createdAt);
+        $this->assertEquals('2024-01-02', $track->updatedAt);
+    }
+
+    /**
+     * Test toArray method
+     */
+    public function testToArray(): void
+    {
+        $track = new MediaTrack([
+            'id' => 10,
+            'user_id' => 50,
+            'media_object_id' => 'm-xyz',
+            'kind' => 'captions',
+            'locale' => 'es',
+            'content' => 'Spanish captions',
+            'url' => 'https://example.com/es'
+        ]);
+
+        $array = $track->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEquals(10, $array['id']);
+        $this->assertEquals(50, $array['user_id']);
+        $this->assertEquals('m-xyz', $array['media_object_id']);
+        $this->assertEquals('captions', $array['kind']);
+        $this->assertEquals('es', $array['locale']);
+        $this->assertEquals('Spanish captions', $array['content']);
+        $this->assertEquals('https://example.com/es', $array['url']);
+        
+        // Should not include null values
+        $this->assertArrayNotHasKey('webvtt_content', $array);
+        $this->assertArrayNotHasKey('created_at', $array);
+        $this->assertArrayNotHasKey('updated_at', $array);
+    }
+
+    /**
+     * Test toArray with all null values
+     */
+    public function testToArrayWithAllNullValues(): void
+    {
+        $track = new MediaTrack();
+
+        $array = $track->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertEmpty($array);
+    }
+
+    /**
+     * Test handling null values in constructor
+     */
+    public function testHandlingNullValuesInConstructor(): void
+    {
+        $data = [
+            'id' => 1,
+            'user_id' => null,
+            'kind' => 'subtitles',
+            'locale' => null
+        ];
+
+        $track = new MediaTrack($data);
+
+        $this->assertEquals(1, $track->id);
+        $this->assertNull($track->userId);
+        $this->assertEquals('subtitles', $track->kind);
+        $this->assertNull($track->locale);
+    }
+
+    /**
+     * Test unknown properties are ignored
+     */
+    public function testUnknownPropertiesAreIgnored(): void
+    {
+        $data = [
+            'id' => 5,
+            'unknown_property' => 'should be ignored',
+            'another_unknown' => 123
+        ];
+
+        $track = new MediaTrack($data);
+
+        $this->assertEquals(5, $track->id);
+        $this->assertObjectNotHasProperty('unknownProperty', $track);
+        $this->assertObjectNotHasProperty('anotherUnknown', $track);
+    }
+
+    /**
+     * Test all track kinds
+     */
+    public function testAllTrackKinds(): void
+    {
+        $kinds = ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata'];
+
+        foreach ($kinds as $kind) {
+            $track = new MediaTrack(['kind' => $kind]);
+            $this->assertEquals($kind, $track->kind);
+        }
+    }
+
+    /**
+     * Test various locale formats
+     */
+    public function testVariousLocaleFormats(): void
+    {
+        $locales = ['en', 'es', 'fr', 'de', 'ja', 'ko', 'zh', 'ar', 'en-US', 'es-MX', 'pt-BR'];
+
+        foreach ($locales as $locale) {
+            $track = new MediaTrack(['locale' => $locale]);
+            $this->assertEquals($locale, $track->locale);
+        }
+    }
+
+    /**
+     * Test complex WEBVTT content
+     */
+    public function testComplexWebvttContent(): void
+    {
+        $webvttContent = "WEBVTT\n\n" .
+            "NOTE This is a comment\n\n" .
+            "1\n" .
+            "00:00:00.000 --> 00:00:05.000\n" .
+            "Welcome to this video\n\n" .
+            "2\n" .
+            "00:00:05.000 --> 00:00:10.000\n" .
+            "This is the second subtitle\n" .
+            "with multiple lines";
+
+        $track = new MediaTrack(['webvtt_content' => $webvttContent]);
+
+        $this->assertEquals($webvttContent, $track->webvttContent);
+        
+        $array = $track->toArray();
+        $this->assertEquals($webvttContent, $array['webvtt_content']);
+    }
+
+    /**
+     * Test SRT format content
+     */
+    public function testSrtFormatContent(): void
+    {
+        $srtContent = "1\n" .
+            "00:00:00,000 --> 00:00:05,000\n" .
+            "This is SRT format with commas\n\n" .
+            "2\n" .
+            "00:00:05,000 --> 00:00:10,000\n" .
+            "Instead of dots for milliseconds";
+
+        $track = new MediaTrack(['content' => $srtContent]);
+
+        $this->assertEquals($srtContent, $track->content);
+    }
+}


### PR DESCRIPTION
## Summary
- Complete Canvas LMS MediaObjects API implementation with 12 endpoints
- Multi-context support for global, course, and group contexts  
- Media tracks management for captions/subtitles (SRT and WEBVTT formats)
- Comprehensive DTOs with validation for locale, content, and track kinds
- Integration with Course and Group classes for seamless usage

## Test plan
- [x] Full test coverage with 78 tests and 326 assertions
- [x] PHPStan Level 6 compliance with complete type annotations
- [x] PSR-12 coding standards compliance
- [x] All pre-commit hooks pass (coding standards, static analysis, tests)
- [x] Complete quality check: `composer check` passes

## API Coverage
**MediaObjects API (12 endpoints)**:
- `GET /media_objects` - Fetch all media objects (global context)
- `GET /media_attachments` - Fetch all media attachments (global context)
- `GET /courses/:course_id/media_objects` - Fetch course media objects
- `GET /courses/:course_id/media_attachments` - Fetch course media attachments
- `GET /groups/:group_id/media_objects` - Fetch group media objects
- `GET /groups/:group_id/media_attachments` - Fetch group media attachments
- `PUT /media_objects/:media_object_id` - Update media object
- `PUT /media_attachments/:attachment_id` - Update media object by attachment
- `GET /media_objects/:media_object_id/media_tracks` - Get media tracks
- `GET /media_attachments/:attachment_id/media_tracks` - Get tracks by attachment
- `PUT /media_objects/:media_object_id/media_tracks` - Update media tracks
- `PUT /media_attachments/:attachment_id/media_tracks` - Update tracks by attachment

**Integration**:
- Course class: `mediaObjects()` and `mediaAttachments()` methods
- Group class: `mediaObjects()` and `mediaAttachments()` methods

Closes #47