### PR TITLE
feat: implement Course Reports API for asynchronous report generation (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Course Reports API implementation (#124)
+  - New `CourseReports` class for managing asynchronous course report generation
+  - Support for all Canvas report types (grade export, student assignment data, etc.)
+  - Three main operations: create reports, check status, get last report status
+  - Course-context pattern with `setCourse()` and `checkCourse()` methods
+  - Status checking helper methods: `isCompleted()`, `isRunning()`, `isFailed()`, `isReady()`
+  - Progress tracking with `getProgress()` and human-readable status descriptions
+  - Canvas API endpoints: POST/GET for report generation and status checking
+  - Course class integration with convenience methods: `createReport()`, `getReport()`, `getLastReport()`
+  - Full test coverage with 34 unit tests covering all functionality and edge cases
+  - PSR-12 compliant code with PHPStan level 6 static analysis passing
 - Developer Keys API implementation (#128)
   - New `DeveloperKey` class for managing Canvas API keys used for OAuth access
   - Full CRUD operations: create, read, update, delete with mixed endpoint routing

--- a/src/Api/CourseReports/CourseReports.php
+++ b/src/Api/CourseReports/CourseReports.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Api\CourseReports;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Courses\Course;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginatedResponse;
+
+/**
+ * Canvas Course Reports API
+ *
+ * Manages course report generation and status tracking in Canvas LMS.
+ * Reports are asynchronous operations that generate downloadable files
+ * containing course data such as grades, student activity, assignments, etc.
+ *
+ * @see https://canvas.instructure.com/doc/api/course_reports.html
+ */
+class CourseReports extends AbstractBaseApi
+{
+    /**
+     * Course context for report operations
+     */
+    protected static ?Course $course = null;
+
+    /**
+     * Report ID
+     */
+    public ?int $id = null;
+
+    /**
+     * Report status (complete, running, failed, etc.)
+     */
+    public ?string $status = null;
+
+    /**
+     * URL to download the completed report file
+     */
+    public ?string $fileUrl = null;
+
+    /**
+     * Report attachment details
+     */
+    public mixed $attachment = null;
+
+    /**
+     * Report creation timestamp
+     */
+    public ?string $createdAt = null;
+
+    /**
+     * Report start timestamp
+     */
+    public ?string $startedAt = null;
+
+    /**
+     * Report completion timestamp
+     */
+    public ?string $endedAt = null;
+
+    /**
+     * Parameters used to generate the report
+     * @var array<string, mixed>|null
+     */
+    public ?array $parameters = null;
+
+    /**
+     * Report generation progress (0-100)
+     */
+    public ?int $progress = null;
+
+    /**
+     * Set the course context for report operations
+     *
+     * @param Course $course Course instance to operate on
+     */
+    public static function setCourse(Course $course): void
+    {
+        self::$course = $course;
+    }
+
+    /**
+     * Check if course context is set and valid
+     *
+     * @return bool True if course context is valid
+     * @throws CanvasApiException If course context is not set or invalid
+     */
+    public static function checkCourse(): bool
+    {
+        if (!isset(self::$course) || !isset(self::$course->id)) {
+            throw new CanvasApiException('Course context is required for course reports operations');
+        }
+
+        return true;
+    }
+
+    /**
+     * Start generating a new report for the course
+     *
+     * @param string $reportType Type of report to generate (e.g., 'grade_export', 'student_assignment_data')
+     * @param array<string, mixed> $parameters Additional parameters for report generation
+     * @return self New CourseReports instance with report details
+     * @throws CanvasApiException If course context not set or API call fails
+     */
+    public static function create(string $reportType, array $parameters = []): self
+    {
+        self::checkCourse();
+
+        $endpoint = sprintf('courses/%d/reports/%s', self::$course->id, $reportType);
+
+        self::checkApiClient();
+
+        $response = self::$apiClient->post($endpoint, [
+            'form_params' => $parameters
+        ]);
+
+        $reportData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($reportData);
+    }
+
+    /**
+     * Interface-required find method (not supported for course reports)
+     * Use getReport() method instead with report type and ID
+     *
+     * @param int $id Report ID (not used)
+     * @return static Never returns, always throws exception
+     * @throws CanvasApiException Always thrown - use getReport() instead
+     */
+    public static function find(int $id): static
+    {
+        throw new CanvasApiException(
+            'Course reports cannot be found by ID alone. Use getReport($reportType, $reportId) instead.'
+        );
+    }
+
+    /**
+     * Get the status of a specific report
+     *
+     * @param string $reportType Type of report to check
+     * @param int $reportId ID of the specific report
+     * @return self CourseReports instance with report status
+     * @throws CanvasApiException If course context not set or API call fails
+     */
+    public static function getReport(string $reportType, int $reportId): self
+    {
+        self::checkCourse();
+
+        $endpoint = sprintf('courses/%d/reports/%s/%d', self::$course->id, $reportType, $reportId);
+
+        self::checkApiClient();
+
+        $response = self::$apiClient->get($endpoint);
+        $reportData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($reportData);
+    }
+
+    /**
+     * Get the status of the last report of the specified type
+     *
+     * @param string $reportType Type of report to check
+     * @return self CourseReports instance with last report status
+     * @throws CanvasApiException If course context not set or API call fails
+     */
+    public static function last(string $reportType): self
+    {
+        self::checkCourse();
+
+        $endpoint = sprintf('courses/%d/reports/%s', self::$course->id, $reportType);
+
+        self::checkApiClient();
+
+        $response = self::$apiClient->get($endpoint);
+        $reportData = json_decode($response->getBody()->getContents(), true);
+
+        return new self($reportData);
+    }
+
+    /**
+     * Check if the report generation is completed
+     *
+     * @return bool True if report status is 'complete'
+     */
+    public function isCompleted(): bool
+    {
+        return $this->status === 'complete';
+    }
+
+    /**
+     * Check if the report generation is currently running
+     *
+     * @return bool True if report status is 'running'
+     */
+    public function isRunning(): bool
+    {
+        return $this->status === 'running';
+    }
+
+    /**
+     * Check if the report generation failed
+     *
+     * @return bool True if report status is 'failed'
+     */
+    public function isFailed(): bool
+    {
+        return $this->status === 'failed';
+    }
+
+    /**
+     * Check if the report is ready for download
+     *
+     * @return bool True if report is completed and has a download URL
+     */
+    public function isReady(): bool
+    {
+        return $this->isCompleted() && !empty($this->fileUrl);
+    }
+
+    /**
+     * Get the report progress as a percentage
+     *
+     * @return int Progress percentage (0-100)
+     */
+    public function getProgress(): int
+    {
+        return $this->progress ?? 0;
+    }
+
+    /**
+     * Get a human-readable status description
+     *
+     * @return string Status description
+     */
+    public function getStatusDescription(): string
+    {
+        return match ($this->status) {
+            'complete' => 'Report generation completed successfully',
+            'running' => 'Report generation in progress',
+            'failed' => 'Report generation failed',
+            'queued' => 'Report generation queued',
+            default => 'Unknown status: ' . ($this->status ?? 'null')
+        };
+    }
+
+    /**
+     * Convert the report data to array format
+     *
+     * @return array<string, mixed> Report data as associative array
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'status' => $this->status,
+            'file_url' => $this->fileUrl,
+            'attachment' => $this->attachment,
+            'created_at' => $this->createdAt,
+            'started_at' => $this->startedAt,
+            'ended_at' => $this->endedAt,
+            'parameters' => $this->parameters,
+            'progress' => $this->progress,
+        ];
+    }
+
+    /**
+     * Methods not supported for Course Reports API
+     * Course reports cannot be updated through the API
+     */
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function update(int $id, array $data): self
+    {
+        throw new CanvasApiException('Course reports cannot be updated');
+    }
+
+    public function save(): bool
+    {
+        throw new CanvasApiException('Course reports cannot be updated');
+    }
+
+    public static function delete(int $id): bool
+    {
+        throw new CanvasApiException('Course reports cannot be deleted');
+    }
+
+    public function destroy(): bool
+    {
+        throw new CanvasApiException('Course reports cannot be deleted');
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @throws CanvasApiException Always thrown
+     */
+    public static function fetchAll(array $params = []): PaginatedResponse
+    {
+        throw new CanvasApiException('Use specific report type methods (last, getReport) instead of fetchAll');
+    }
+
+    /**
+     * Get the base API endpoint for reports (requires course context)
+     *
+     * @return string The API endpoint pattern
+     */
+    protected static function getEndpoint(): string
+    {
+        return 'courses/reports';
+    }
+}

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -3611,6 +3611,59 @@ class Course extends AbstractBaseApi
     }
 
     /**
+     * Start generating a new report for this course
+     *
+     * @param string $reportType Type of report to generate (e.g., 'grade_export', 'student_assignment_data')
+     * @param array<string, mixed> $parameters Additional parameters for report generation
+     * @return \CanvasLMS\Api\CourseReports\CourseReports New report instance with status
+     * @throws CanvasApiException
+     */
+    public function createReport(string $reportType, array $parameters = []): \CanvasLMS\Api\CourseReports\CourseReports
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to create reports');
+        }
+
+        \CanvasLMS\Api\CourseReports\CourseReports::setCourse($this);
+        return \CanvasLMS\Api\CourseReports\CourseReports::create($reportType, $parameters);
+    }
+
+    /**
+     * Get the status of a specific report for this course
+     *
+     * @param string $reportType Type of report to check
+     * @param int $reportId ID of the specific report
+     * @return \CanvasLMS\Api\CourseReports\CourseReports Report instance with current status
+     * @throws CanvasApiException
+     */
+    public function getReport(string $reportType, int $reportId): \CanvasLMS\Api\CourseReports\CourseReports
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to get report status');
+        }
+
+        \CanvasLMS\Api\CourseReports\CourseReports::setCourse($this);
+        return \CanvasLMS\Api\CourseReports\CourseReports::getReport($reportType, $reportId);
+    }
+
+    /**
+     * Get the status of the last report of the specified type for this course
+     *
+     * @param string $reportType Type of report to check
+     * @return \CanvasLMS\Api\CourseReports\CourseReports Last report instance with status
+     * @throws CanvasApiException
+     */
+    public function getLastReport(string $reportType): \CanvasLMS\Api\CourseReports\CourseReports
+    {
+        if (!$this->id) {
+            throw new CanvasApiException('Course ID is required to get last report status');
+        }
+
+        \CanvasLMS\Api\CourseReports\CourseReports::setCourse($this);
+        return \CanvasLMS\Api\CourseReports\CourseReports::last($reportType);
+    }
+
+    /**
      * Get the API endpoint for this resource
      * @return string
      */

--- a/tests/Api/CourseReports/CourseReportsTest.php
+++ b/tests/Api/CourseReports/CourseReportsTest.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\CourseReports;
+
+use CanvasLMS\Api\CourseReports\CourseReports;
+use CanvasLMS\Api\Courses\Course;
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+class CourseReportsTest extends TestCase
+{
+    private HttpClientInterface $httpClient;
+    private Course $course;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        CourseReports::setApiClient($this->httpClient);
+
+        // Create a mock course
+        $this->course = new Course(['id' => 123, 'name' => 'Test Course']);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset static properties to avoid test interference
+        $reflection = new \ReflectionClass(CourseReports::class);
+        $courseProperty = $reflection->getProperty('course');
+        $courseProperty->setAccessible(true);
+        $courseProperty->setValue(null, null);
+    }
+
+    public function testSetCourse(): void
+    {
+        CourseReports::setCourse($this->course);
+        
+        $this->assertTrue(CourseReports::checkCourse());
+    }
+
+    public function testCheckCourseThrowsExceptionWhenNotSet(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course context is required for course reports operations');
+        
+        CourseReports::checkCourse();
+    }
+
+    public function testCheckCourseThrowsExceptionWhenCourseHasNoId(): void
+    {
+        $courseWithoutId = new Course(['name' => 'Test Course']);
+        CourseReports::setCourse($courseWithoutId);
+        
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course context is required for course reports operations');
+        
+        CourseReports::checkCourse();
+    }
+
+    public function testCreateReport(): void
+    {
+        CourseReports::setCourse($this->course);
+
+        $reportData = [
+            'id' => 456,
+            'status' => 'running',
+            'progress' => 25,
+            'created_at' => '2024-01-15T10:00:00Z',
+            'started_at' => '2024-01-15T10:01:00Z',
+            'parameters' => ['enrollment_term_id' => 789]
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+
+        $streamMock->expects($this->once())
+            ->method('getContents')
+            ->willReturn(json_encode($reportData));
+
+        $responseMock->expects($this->once())
+            ->method('getBody')
+            ->willReturn($streamMock);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('post')
+            ->with('courses/123/reports/grade_export', [
+                'form_params' => ['enrollment_term_id' => 789]
+            ])
+            ->willReturn($responseMock);
+
+        $report = CourseReports::create('grade_export', ['enrollment_term_id' => 789]);
+
+        $this->assertInstanceOf(CourseReports::class, $report);
+        $this->assertEquals(456, $report->id);
+        $this->assertEquals('running', $report->status);
+        $this->assertEquals(25, $report->progress);
+        $this->assertEquals('2024-01-15T10:00:00Z', $report->createdAt);
+        $this->assertEquals('2024-01-15T10:01:00Z', $report->startedAt);
+        $this->assertEquals(['enrollment_term_id' => 789], $report->parameters);
+    }
+
+    public function testCreateReportThrowsExceptionWithoutCourse(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course context is required for course reports operations');
+        
+        CourseReports::create('grade_export');
+    }
+
+    public function testGetReport(): void
+    {
+        CourseReports::setCourse($this->course);
+
+        $reportData = [
+            'id' => 456,
+            'status' => 'complete',
+            'file_url' => 'https://canvas.example.com/files/report.csv',
+            'progress' => 100,
+            'created_at' => '2024-01-15T10:00:00Z',
+            'started_at' => '2024-01-15T10:01:00Z',
+            'ended_at' => '2024-01-15T10:05:00Z',
+            'attachment' => ['id' => 789, 'filename' => 'grade_export.csv']
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+
+        $streamMock->expects($this->once())
+            ->method('getContents')
+            ->willReturn(json_encode($reportData));
+
+        $responseMock->expects($this->once())
+            ->method('getBody')
+            ->willReturn($streamMock);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('courses/123/reports/grade_export/456')
+            ->willReturn($responseMock);
+
+        $report = CourseReports::getReport('grade_export', 456);
+
+        $this->assertInstanceOf(CourseReports::class, $report);
+        $this->assertEquals(456, $report->id);
+        $this->assertEquals('complete', $report->status);
+        $this->assertEquals('https://canvas.example.com/files/report.csv', $report->fileUrl);
+        $this->assertEquals(100, $report->progress);
+        $this->assertEquals('2024-01-15T10:05:00Z', $report->endedAt);
+        $this->assertIsArray($report->attachment);
+        $this->assertEquals(789, $report->attachment['id']);
+    }
+
+    public function testGetReportThrowsExceptionWithoutCourse(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course context is required for course reports operations');
+        
+        CourseReports::getReport('grade_export', 456);
+    }
+
+    public function testFindMethodThrowsException(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course reports cannot be found by ID alone. Use getReport($reportType, $reportId) instead.');
+        
+        CourseReports::find(123);
+    }
+
+    public function testLastReport(): void
+    {
+        CourseReports::setCourse($this->course);
+
+        $reportData = [
+            'id' => 789,
+            'status' => 'failed',
+            'progress' => 50,
+            'created_at' => '2024-01-15T09:00:00Z',
+            'started_at' => '2024-01-15T09:01:00Z',
+            'ended_at' => '2024-01-15T09:03:00Z'
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+
+        $streamMock->expects($this->once())
+            ->method('getContents')
+            ->willReturn(json_encode($reportData));
+
+        $responseMock->expects($this->once())
+            ->method('getBody')
+            ->willReturn($streamMock);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('get')
+            ->with('courses/123/reports/student_assignment_data')
+            ->willReturn($responseMock);
+
+        $report = CourseReports::last('student_assignment_data');
+
+        $this->assertInstanceOf(CourseReports::class, $report);
+        $this->assertEquals(789, $report->id);
+        $this->assertEquals('failed', $report->status);
+        $this->assertEquals(50, $report->progress);
+        $this->assertEquals('2024-01-15T09:03:00Z', $report->endedAt);
+    }
+
+    public function testLastReportThrowsExceptionWithoutCourse(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course context is required for course reports operations');
+        
+        CourseReports::last('student_assignment_data');
+    }
+
+    public function testIsCompletedTrue(): void
+    {
+        $report = new CourseReports(['status' => 'complete']);
+        $this->assertTrue($report->isCompleted());
+    }
+
+    public function testIsCompletedFalse(): void
+    {
+        $report = new CourseReports(['status' => 'running']);
+        $this->assertFalse($report->isCompleted());
+    }
+
+    public function testIsRunningTrue(): void
+    {
+        $report = new CourseReports(['status' => 'running']);
+        $this->assertTrue($report->isRunning());
+    }
+
+    public function testIsRunningFalse(): void
+    {
+        $report = new CourseReports(['status' => 'complete']);
+        $this->assertFalse($report->isRunning());
+    }
+
+    public function testIsFailedTrue(): void
+    {
+        $report = new CourseReports(['status' => 'failed']);
+        $this->assertTrue($report->isFailed());
+    }
+
+    public function testIsFailedFalse(): void
+    {
+        $report = new CourseReports(['status' => 'complete']);
+        $this->assertFalse($report->isFailed());
+    }
+
+    public function testIsReadyWhenCompleteWithFile(): void
+    {
+        $report = new CourseReports([
+            'status' => 'complete',
+            'file_url' => 'https://canvas.example.com/files/report.csv'
+        ]);
+        $this->assertTrue($report->isReady());
+    }
+
+    public function testIsReadyWhenCompleteWithoutFile(): void
+    {
+        $report = new CourseReports(['status' => 'complete']);
+        $this->assertFalse($report->isReady());
+    }
+
+    public function testIsReadyWhenNotComplete(): void
+    {
+        $report = new CourseReports([
+            'status' => 'running',
+            'file_url' => 'https://canvas.example.com/files/report.csv'
+        ]);
+        $this->assertFalse($report->isReady());
+    }
+
+    public function testGetProgressWithValue(): void
+    {
+        $report = new CourseReports(['progress' => 75]);
+        $this->assertEquals(75, $report->getProgress());
+    }
+
+    public function testGetProgressWithoutValue(): void
+    {
+        $report = new CourseReports([]);
+        $this->assertEquals(0, $report->getProgress());
+    }
+
+    public function testGetStatusDescriptionComplete(): void
+    {
+        $report = new CourseReports(['status' => 'complete']);
+        $this->assertEquals('Report generation completed successfully', $report->getStatusDescription());
+    }
+
+    public function testGetStatusDescriptionRunning(): void
+    {
+        $report = new CourseReports(['status' => 'running']);
+        $this->assertEquals('Report generation in progress', $report->getStatusDescription());
+    }
+
+    public function testGetStatusDescriptionFailed(): void
+    {
+        $report = new CourseReports(['status' => 'failed']);
+        $this->assertEquals('Report generation failed', $report->getStatusDescription());
+    }
+
+    public function testGetStatusDescriptionQueued(): void
+    {
+        $report = new CourseReports(['status' => 'queued']);
+        $this->assertEquals('Report generation queued', $report->getStatusDescription());
+    }
+
+    public function testGetStatusDescriptionUnknown(): void
+    {
+        $report = new CourseReports(['status' => 'unknown_status']);
+        $this->assertEquals('Unknown status: unknown_status', $report->getStatusDescription());
+    }
+
+    public function testGetStatusDescriptionNull(): void
+    {
+        $report = new CourseReports([]);
+        $this->assertEquals('Unknown status: null', $report->getStatusDescription());
+    }
+
+    public function testToArray(): void
+    {
+        $reportData = [
+            'id' => 123,
+            'status' => 'complete',
+            'file_url' => 'https://canvas.example.com/files/report.csv',
+            'attachment' => ['id' => 456],
+            'created_at' => '2024-01-15T10:00:00Z',
+            'started_at' => '2024-01-15T10:01:00Z',
+            'ended_at' => '2024-01-15T10:05:00Z',
+            'parameters' => ['term_id' => 789],
+            'progress' => 100
+        ];
+
+        $report = new CourseReports($reportData);
+        $array = $report->toArray();
+
+        $expected = [
+            'id' => 123,
+            'status' => 'complete',
+            'file_url' => 'https://canvas.example.com/files/report.csv',
+            'attachment' => ['id' => 456],
+            'created_at' => '2024-01-15T10:00:00Z',
+            'started_at' => '2024-01-15T10:01:00Z',
+            'ended_at' => '2024-01-15T10:05:00Z',
+            'parameters' => ['term_id' => 789],
+            'progress' => 100
+        ];
+
+        $this->assertEquals($expected, $array);
+    }
+
+    public function testUnsupportedUpdateMethod(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course reports cannot be updated');
+        
+        CourseReports::update(123, []);
+    }
+
+    public function testUnsupportedSaveMethod(): void
+    {
+        $report = new CourseReports(['id' => 123]);
+        
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course reports cannot be updated');
+        
+        $report->save();
+    }
+
+    public function testUnsupportedDeleteMethod(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course reports cannot be deleted');
+        
+        CourseReports::delete(123);
+    }
+
+    public function testUnsupportedDestroyMethod(): void
+    {
+        $report = new CourseReports(['id' => 123]);
+        
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Course reports cannot be deleted');
+        
+        $report->destroy();
+    }
+
+    public function testUnsupportedFetchAllMethod(): void
+    {
+        $this->expectException(CanvasApiException::class);
+        $this->expectExceptionMessage('Use specific report type methods (last, getReport) instead of fetchAll');
+        
+        CourseReports::fetchAll();
+    }
+
+    public function testPropertyConversionFromSnakeCaseToCamelCase(): void
+    {
+        $apiResponse = [
+            'id' => 123,
+            'status' => 'complete',
+            'file_url' => 'https://canvas.example.com/files/report.csv',
+            'created_at' => '2024-01-15T10:00:00Z',
+            'started_at' => '2024-01-15T10:01:00Z',
+            'ended_at' => '2024-01-15T10:05:00Z'
+        ];
+
+        $report = new CourseReports($apiResponse);
+
+        // Verify snake_case properties are converted to camelCase
+        $this->assertEquals('https://canvas.example.com/files/report.csv', $report->fileUrl);
+        $this->assertEquals('2024-01-15T10:00:00Z', $report->createdAt);
+        $this->assertEquals('2024-01-15T10:01:00Z', $report->startedAt);
+        $this->assertEquals('2024-01-15T10:05:00Z', $report->endedAt);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Canvas Course Reports API for asynchronous report generation and status tracking
- New CourseReports class following established SDK patterns with course-context management
- Three main API operations: create reports, check status, get last report status
- Comprehensive status checking and progress monitoring helpers
- Full Course class integration with convenience methods

## Features Implemented
- **CourseReports API Class**: Complete implementation with course-context pattern using `setCourse()` and `checkCourse()` methods
- **Report Operations**: Support for creating reports (`create()`), checking specific report status (`getReport()`), and getting last report (`last()`)
- **Status Helpers**: Methods for checking completion (`isCompleted()`), running state (`isRunning()`), failure (`isFailed()`), and readiness (`isReady()`)
- **Progress Tracking**: Get progress percentage and human-readable status descriptions
- **Course Integration**: Added `createReport()`, `getReport()`, and `getLastReport()` convenience methods to Course class
- **Canvas API Support**: Handles all Canvas report types (grade export, student assignment data, etc.)

## Test Coverage
- 34 comprehensive unit tests covering all functionality and edge cases
- Full HTTP client mocking with proper ResponseInterface handling
- Tests for course context management, API operations, helper methods, and error conditions
- 74 total assertions ensuring robust functionality

## Quality Assurance
- ✅ PSR-12 coding standards compliance
- ✅ PHPStan level 6 static analysis passing
- ✅ Complete PHPUnit test suite passing
- ✅ CHANGELOG.md updated with detailed feature documentation

## Usage Examples
```php
// Set course context and create a grade export report
$course = Course::find(123);
CourseReports::setCourse($course);
$report = CourseReports::create('grade_export', ['enrollment_term_id' => 456]);

// Or use Course class convenience method
$report = $course->createReport('student_assignment_data');

// Check report status
if ($report->isCompleted() && $report->isReady()) {
    $downloadUrl = $report->fileUrl;
    echo "Report ready: " . $downloadUrl;
} elseif ($report->isRunning()) {
    echo "Progress: " . $report->getProgress() . "%";
}

// Get last report of a specific type
$lastReport = $course->getLastReport('grade_export');
```

## API Endpoints Supported
- `POST /api/v1/courses/:course_id/reports/:report_type` - Start new report generation
- `GET /api/v1/courses/:course_id/reports/:report_type/:id` - Get specific report status  
- `GET /api/v1/courses/:course_id/reports/:report_type` - Get last report status

## Test Plan
- [x] All unit tests pass (34 tests, 74 assertions)
- [x] PSR-12 coding standards compliance verified
- [x] PHPStan level 6 static analysis passes
- [x] Course context management works correctly
- [x] API operations function as expected
- [x] Helper methods provide accurate status information
- [x] Course class integration methods work seamlessly
- [x] Error handling for missing context and invalid operations
- [x] Property conversion from snake_case to camelCase works properly