### PR TITLE
refactor: complete pagination API standardization

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,22 +454,27 @@ $assignments = Assignment::get(['per_page' => 100]);     // If you need subset
 $assignments = Assignment::paginate(['per_page' => 100]); // If processing batches
 $assignments = Assignment::all();                         // If you need everything
 
-// 📕 Large datasets (1000+ items): Always paginate
+// 📕 Large datasets (1000+ items): Use paginate() for memory efficiency
 $users = User::paginate(['per_page' => 100]);
 $enrollments = Enrollment::paginate(['per_page' => 500]);
+
+// Note: The SDK includes built-in rate limiting and retry logic,
+// so fetching all pages is safe from an API perspective.
+// The main consideration is memory usage for very large datasets.
 ```
 
-### Relationship Method Note
+### Relationship Methods & Large Datasets
 
-**Important**: When using relationship methods on Course/User/Group instances, they return **first page only** for performance:
+**Important**: Relationship methods on Course/User/Group instances return **ALL pages** for completeness:
 
 ```php
 $course = Course::find(123);
-$modules = $course->modules();      // Returns first page only!
+$modules = $course->modules();      // Returns ALL modules (all pages)
+$enrollments = $course->enrollments(); // Returns ALL enrollments (could be thousands!)
 
-// To get ALL modules for a course:
-Module::setCourse($course);
-$allModules = Module::all();        // Now fetches all pages
+// For large datasets, consider using pagination directly:
+Enrollment::setCourse($course);
+$paginatedEnrollments = Enrollment::paginate(['per_page' => 100]); // Memory efficient
 
 // Or use paginate for control:
 $paginatedModules = Module::paginate(['per_page' => 50]);

--- a/README.md
+++ b/README.md
@@ -284,6 +284,199 @@ foreach ($userIds as $userId) {
 Config::stopMasquerading();
 ```
 
+## 📄 Pagination
+
+Canvas LMS Kit provides three simple, consistent methods for handling paginated data across all resources:
+
+### The Three Methods
+
+```php
+// 1. get() - Fetch first page only (default: 10 items)
+$courses = Course::get();                    // First 10 courses
+$courses = Course::get(['per_page' => 50]); // First 50 courses
+
+// 2. paginate() - Get results with pagination metadata
+$result = Course::paginate(['per_page' => 25]);
+echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
+echo "Total courses: {$result->getTotalCount()}";
+
+// 3. all() - Fetch ALL items from all pages automatically
+$allCourses = Course::all();  // ⚠️ Use with caution on large datasets!
+```
+
+### When to Use Each Method
+
+| Method | Use Case | Memory Usage | API Calls |
+|--------|----------|--------------|-----------|
+| `get()` | Dashboards, quick views, limited displays | Low (1 page) | 1 |
+| `paginate()` | UI tables, batch processing, when you need metadata | Low (1 page) | 1 per page |
+| `all()` | Complete data export, small datasets (< 1000 items) | High (all data) | As many as needed |
+
+### Memory-Safe Processing of Large Datasets
+
+```php
+// ❌ WRONG - May exhaust memory with large datasets
+$allUsers = User::all();  // Could be 50,000+ users!
+foreach ($allUsers as $user) {
+    processUser($user);
+}
+
+// ✅ CORRECT - Process in batches using paginate()
+$page = 1;
+do {
+    $batch = User::paginate(['page' => $page++, 'per_page' => 100]);
+    
+    foreach ($batch->getData() as $user) {
+        processUser($user);
+    }
+    
+    // Optional: Add delay to respect rate limits
+    if ($batch->hasNextPage()) {
+        sleep(1);
+    }
+    
+} while ($batch->hasNextPage());
+```
+
+### Common Pagination Patterns
+
+#### Pattern 1: Building a Paginated UI
+```php
+// In your controller
+$page = $_GET['page'] ?? 1;
+$result = Course::paginate(['page' => $page, 'per_page' => 25]);
+
+// In your view
+foreach ($result->getData() as $course) {
+    echo "<tr><td>{$course->name}</td></tr>";
+}
+
+// Pagination controls
+if ($result->hasPreviousPage()) {
+    echo "<a href='?page=" . ($page - 1) . "'>Previous</a>";
+}
+if ($result->hasNextPage()) {
+    echo "<a href='?page=" . ($page + 1) . "'>Next</a>";
+}
+echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
+```
+
+#### Pattern 2: Exporting All Data
+```php
+// For small datasets (< 1000 items)
+$assignments = Assignment::all(['course_id' => 123]);
+exportToCSV($assignments);
+
+// For large datasets - stream to file
+$csvFile = fopen('enrollments.csv', 'w');
+$page = 1;
+
+do {
+    $batch = Enrollment::paginate(['page' => $page++, 'per_page' => 500]);
+    
+    foreach ($batch->getData() as $enrollment) {
+        fputcsv($csvFile, [
+            $enrollment->userId,
+            $enrollment->courseId,
+            $enrollment->enrollmentState
+        ]);
+    }
+    
+} while ($batch->hasNextPage());
+
+fclose($csvFile);
+```
+
+#### Pattern 3: Finding Specific Items
+```php
+// When you need just a subset
+$recentAssignments = Assignment::get([
+    'per_page' => 10,
+    'order_by' => 'due_at'
+]);
+
+// When searching through all pages
+$found = false;
+$page = 1;
+
+do {
+    $batch = User::paginate([
+        'page' => $page++,
+        'search_term' => 'john.doe@example.com'
+    ]);
+    
+    foreach ($batch->getData() as $user) {
+        if ($user->email === 'john.doe@example.com') {
+            $found = $user;
+            break 2; // Exit both loops
+        }
+    }
+    
+} while ($batch->hasNextPage() && !$found);
+```
+
+### PaginationResult Methods
+
+The `paginate()` method returns a `PaginationResult` object with helpful methods:
+
+```php
+$result = Course::paginate(['per_page' => 20]);
+
+// Data access
+$courses = $result->getData();           // Array of Course objects
+$total = $result->getTotalCount();       // Total number of courses
+
+// Navigation
+$result->hasNextPage();                  // true/false
+$result->hasPreviousPage();              // true/false
+$result->getNextPage();                  // Fetches next page (returns new PaginationResult)
+$result->getPreviousPage();              // Fetches previous page
+
+// Page information
+$result->getCurrentPage();               // Current page number
+$result->getTotalPages();                // Total number of pages
+$result->getPerPage();                   // Items per page
+
+// URL access (for custom implementations)
+$result->getNextUrl();                   // Next page URL
+$result->getPreviousUrl();               // Previous page URL
+```
+
+### Performance Guidelines
+
+```php
+// 📗 Small datasets (< 100 items): Safe to use all()
+$modules = Module::all();
+$sections = Section::all();
+
+// 📙 Medium datasets (100-1000 items): Consider your use case
+$assignments = Assignment::get(['per_page' => 100]);     // If you need subset
+$assignments = Assignment::paginate(['per_page' => 100]); // If processing batches
+$assignments = Assignment::all();                         // If you need everything
+
+// 📕 Large datasets (1000+ items): Always paginate
+$users = User::paginate(['per_page' => 100]);
+$enrollments = Enrollment::paginate(['per_page' => 500]);
+```
+
+### Relationship Method Note
+
+**Important**: When using relationship methods on Course/User/Group instances, they return **first page only** for performance:
+
+```php
+$course = Course::find(123);
+$modules = $course->modules();      // Returns first page only!
+
+// To get ALL modules for a course:
+Module::setCourse($course);
+$allModules = Module::all();        // Now fetches all pages
+
+// Or use paginate for control:
+$paginatedModules = Module::paginate(['per_page' => 50]);
+```
+
+📖 **[View Complete Pagination Guide](https://github.com/jjuanrivvera/canvas-lms-kit/wiki/Pagination-Guide)** for advanced examples and patterns.
+
 ## 💡 Usage Examples
 
 ### Working with Courses

--- a/src/Api/Accounts/Account.php
+++ b/src/Api/Accounts/Account.php
@@ -8,8 +8,6 @@ use CanvasLMS\Api\Courses\Course;
 use CanvasLMS\Dto\Accounts\CreateAccountDTO;
 use CanvasLMS\Dto\Accounts\UpdateAccountDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
-use CanvasLMS\Pagination\PaginationResult;
 use CanvasLMS\Api\CalendarEvents\CalendarEvent;
 use CanvasLMS\Dto\CalendarEvents\CreateCalendarEventDTO;
 use CanvasLMS\Api\Rubrics\Rubric;
@@ -42,7 +40,7 @@ use CanvasLMS\Dto\Rubrics\CreateRubricDTO;
  * $account->save();
  *
  * // Getting sub-accounts (two approaches)
- * $subAccounts = $account->getSubAccounts();  // Instance method
+ * $subAccounts = $account->subAccounts();  // Instance method
  * $subAccounts = Account::fetchSubAccounts(1); // Static method
  *
  * // Getting account settings
@@ -396,7 +394,7 @@ class Account extends AbstractBaseApi
      * @return array<int, self>
      * @throws CanvasApiException
      */
-    public function getSubAccounts(array $params = []): array
+    public function subAccounts(array $params = []): array
     {
         if (!$this->id) {
             throw new CanvasApiException("Account ID is required");
@@ -417,7 +415,7 @@ class Account extends AbstractBaseApi
      * @return self|null
      * @throws CanvasApiException
      */
-    public function getParentAccount(): ?self
+    public function parentAccount(): ?self
     {
         if (!$this->parentAccountId) {
             return null;
@@ -564,7 +562,7 @@ class Account extends AbstractBaseApi
      * @return array<int, Course>
      * @throws CanvasApiException
      */
-    public function getCourses(array $params = []): array
+    public function courses(array $params = []): array
     {
         if (!$this->id) {
             throw new CanvasApiException("Account ID is required");
@@ -653,32 +651,16 @@ class Account extends AbstractBaseApi
      * @return CalendarEvent[]
      * @throws CanvasApiException
      */
-    public function getCalendarEvents(array $params = []): array
+    public function calendarEvents(array $params = []): array
     {
         if (!$this->id) {
             throw new CanvasApiException('Account ID is required to get calendar events');
         }
 
         $params['context_codes'] = [sprintf('account_%d', $this->id)];
-        return CalendarEvent::get($params);
+        return CalendarEvent::all($params);
     }
 
-    /**
-     * Get paginated calendar events for this account
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public function getCalendarEventsPaginated(array $params = []): PaginationResult
-    {
-        if (!$this->id) {
-            throw new CanvasApiException('Account ID is required to get calendar events');
-        }
-
-        $params['context_codes'] = [sprintf('account_%d', $this->id)];
-        return CalendarEvent::paginate($params);
-    }
 
     /**
      * Create a calendar event for this account
@@ -705,7 +687,7 @@ class Account extends AbstractBaseApi
      * @return array<int, Rubric>
      * @throws CanvasApiException
      */
-    public function getRubrics(array $params = []): array
+    public function rubrics(array $params = []): array
     {
         if (!$this->id) {
             throw new CanvasApiException('Account ID is required to get rubrics');
@@ -720,22 +702,6 @@ class Account extends AbstractBaseApi
         }, $responseData);
     }
 
-    /**
-     * Get paginated rubrics for this account
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public function getRubricsPaginated(array $params = []): PaginatedResponse
-    {
-        if (!$this->id) {
-            throw new CanvasApiException('Account ID is required to get rubrics');
-        }
-
-        $endpoint = sprintf('accounts/%d/rubrics', $this->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
 
     /**
      * Create a rubric for this account

--- a/src/Api/Accounts/Account.php
+++ b/src/Api/Accounts/Account.php
@@ -9,6 +9,7 @@ use CanvasLMS\Dto\Accounts\CreateAccountDTO;
 use CanvasLMS\Dto\Accounts\UpdateAccountDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
 use CanvasLMS\Api\CalendarEvents\CalendarEvent;
 use CanvasLMS\Dto\CalendarEvents\CreateCalendarEventDTO;
 use CanvasLMS\Api\Rubrics\Rubric;
@@ -659,24 +660,24 @@ class Account extends AbstractBaseApi
         }
 
         $params['context_codes'] = [sprintf('account_%d', $this->id)];
-        return CalendarEvent::fetchAll($params);
+        return CalendarEvent::get($params);
     }
 
     /**
      * Get paginated calendar events for this account
      *
      * @param array<string, mixed> $params Query parameters
-     * @return PaginatedResponse
+     * @return PaginationResult
      * @throws CanvasApiException
      */
-    public function getCalendarEventsPaginated(array $params = []): PaginatedResponse
+    public function getCalendarEventsPaginated(array $params = []): PaginationResult
     {
         if (!$this->id) {
             throw new CanvasApiException('Account ID is required to get calendar events');
         }
 
         $params['context_codes'] = [sprintf('account_%d', $this->id)];
-        return CalendarEvent::fetchAllPaginated($params);
+        return CalendarEvent::paginate($params);
     }
 
     /**

--- a/src/Api/AppointmentGroups/AppointmentGroup.php
+++ b/src/Api/AppointmentGroups/AppointmentGroup.php
@@ -44,7 +44,7 @@ use CanvasLMS\Pagination\PaginatedResponse;
  * $appointmentGroup = AppointmentGroup::find(543);
  *
  * // Listing appointment groups
- * $groups = AppointmentGroup::fetchAll(['scope' => 'manageable']);
+ * $groups = AppointmentGroup::get(['scope' => 'manageable']);
  *
  * // Publishing an appointment group
  * $appointmentGroup->publish();
@@ -322,7 +322,7 @@ class AppointmentGroup extends AbstractBaseApi
      * @return array<int, self>
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         self::checkApiClient();
         $response = self::$apiClient->get('appointment_groups', ['query' => $params]);
@@ -333,18 +333,6 @@ class AppointmentGroup extends AbstractBaseApi
         }, $data);
     }
 
-    /**
-     * Get paginated appointment groups
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkApiClient();
-        return self::getPaginatedResponse('appointment_groups', $params);
-    }
 
     /**
      * Save the appointment group (create or update)

--- a/src/Api/Assignments/Assignment.php
+++ b/src/Api/Assignments/Assignment.php
@@ -9,11 +9,9 @@ use CanvasLMS\Api\Courses\Course;
 use CanvasLMS\Dto\Assignments\CreateAssignmentDTO;
 use CanvasLMS\Dto\Assignments\UpdateAssignmentDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
 use CanvasLMS\Api\Submissions\Submission;
 use CanvasLMS\Api\Rubrics\Rubric;
 use CanvasLMS\Api\Rubrics\RubricAssociation;
-use CanvasLMS\Pagination\PaginationResult;
 
 /**
  * Canvas LMS Assignments API
@@ -75,7 +73,7 @@ use CanvasLMS\Pagination\PaginationResult;
  */
 class Assignment extends AbstractBaseApi
 {
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Assignment unique identifier
@@ -1271,90 +1269,16 @@ class Assignment extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkCourse();
         self::checkApiClient();
 
         $endpoint = sprintf('courses/%d/assignments/%d', self::$course->id, $id);
-        $response = self::$apiClient->get($endpoint);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
         $assignmentData = json_decode($response->getBody()->getContents(), true);
 
         return new self($assignmentData);
-    }
-
-    /**
-     * Fetch all assignments for the course
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Assignment> Array of Assignment objects
-     * @throws CanvasApiException
-     */
-    public static function fetchAll(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/assignments', self::$course->id);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $assignmentsData = json_decode($response->getBody()->getContents(), true);
-
-        $assignments = [];
-        foreach ($assignmentsData as $assignmentData) {
-            $assignments[] = new self($assignmentData);
-        }
-
-        return $assignments;
-    }
-
-    /**
-     * Fetch all assignments with pagination support
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/assignments', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
-
-    /**
-     * Fetch a single page of assignments
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/assignments', self::$course->id);
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of assignments
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Assignment> Array of Assignment objects from all pages
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/assignments', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
     }
 
     /**
@@ -1536,7 +1460,7 @@ class Assignment extends AbstractBaseApi
 
         Submission::setCourse(self::$course);
         Submission::setAssignment($this);
-        return Submission::fetchAll($params);
+        return Submission::get($params);
     }
 
 

--- a/src/Api/Assignments/Assignment.php
+++ b/src/Api/Assignments/Assignment.php
@@ -1460,7 +1460,7 @@ class Assignment extends AbstractBaseApi
 
         Submission::setCourse(self::$course);
         Submission::setAssignment($this);
-        return Submission::get($params);
+        return Submission::all($params);
     }
 
 
@@ -1471,7 +1471,7 @@ class Assignment extends AbstractBaseApi
      * @return Submission|null
      * @throws CanvasApiException
      */
-    public function getSubmissionForUser(int $userId): ?Submission
+    public function submissionForUser(int $userId): ?Submission
     {
         if (!isset($this->id) || !$this->id) {
             throw new CanvasApiException('Assignment ID is required to fetch submission');

--- a/src/Api/Bookmarks/Bookmark.php
+++ b/src/Api/Bookmarks/Bookmark.php
@@ -72,9 +72,31 @@ class Bookmark extends AbstractBaseApi
      * @param array<string, mixed> $params Query parameters
      * @return array<self>
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
-        return self::get($params);
+        return parent::get($params);
+    }
+
+    /**
+     * Get paginated results with metadata
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return \CanvasLMS\Pagination\PaginationResult
+     */
+    public static function paginate(array $params = []): \CanvasLMS\Pagination\PaginationResult
+    {
+        return parent::paginate($params);
+    }
+
+    /**
+     * Get all pages of results
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<self>
+     */
+    public static function all(array $params = []): array
+    {
+        return parent::all($params);
     }
 
     /**
@@ -83,7 +105,7 @@ class Bookmark extends AbstractBaseApi
      * @param int $id Bookmark ID
      * @return self
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         $response = self::$apiClient->get(
             self::getEndpoint() . '/' . $id

--- a/src/Api/Conferences/Conference.php
+++ b/src/Api/Conferences/Conference.php
@@ -102,7 +102,7 @@ class Conference extends AbstractBaseApi
      * @param array<string, mixed> $params Optional query parameters
      * @return array<Conference> Empty array
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         // Conferences require either course or group context
         // Use fetchByCourse() or fetchByGroup() instead
@@ -171,7 +171,7 @@ class Conference extends AbstractBaseApi
      * @param int $id The conference ID
      * @return self The Conference object
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkApiClient();
 

--- a/src/Api/ContentMigrations/ContentMigration.php
+++ b/src/Api/ContentMigrations/ContentMigration.php
@@ -149,7 +149,7 @@ class ContentMigration extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new CanvasApiException(
             'Direct find() not supported for ContentMigration. Use findByContext() instead.'
@@ -202,7 +202,10 @@ class ContentMigration extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
-        return self::fetchAllPagesAsModels(sprintf('%s/%d/content_migrations', $contextType, $contextId), $params);
+        $endpoint = sprintf('%s/%d/content_migrations', $contextType, $contextId);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        return array_map(fn($data) => new self($data), $allData);
     }
 
     /**

--- a/src/Api/ContentMigrations/MigrationIssue.php
+++ b/src/Api/ContentMigrations/MigrationIssue.php
@@ -9,7 +9,6 @@ use CanvasLMS\Dto\ContentMigrations\UpdateMigrationIssueDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Pagination\PaginatedResponse;
 use DateTime;
-use CanvasLMS\Pagination\PaginationResult;
 
 /**
  * Canvas LMS Migration Issues API
@@ -89,10 +88,10 @@ class MigrationIssue extends AbstractBaseApi
     /**
      * Set the parent content migration
      *
-     * @param ContentMigration $contentMigration
+     * @param ContentMigration $_contentMigration
      * @deprecated This method is no longer used and will be removed in a future version
      */
-    public static function setContentMigration(ContentMigration $contentMigration): void
+    public static function setContentMigration(ContentMigration $_contentMigration): void
     {
         // No-op: This method is deprecated and does nothing
     }
@@ -115,7 +114,7 @@ class MigrationIssue extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new CanvasApiException(
             'Direct find() not supported for MigrationIssue. Use findInMigration() instead.'
@@ -160,10 +159,23 @@ class MigrationIssue extends AbstractBaseApi
      * @return array<MigrationIssue>
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
-            'Direct fetchAll() not supported for MigrationIssue. Use fetchAllInMigration() instead.'
+            'Direct get() not supported for MigrationIssue. Use fetchAllInMigration() instead.'
+        );
+    }
+
+    /**
+     * Get all pages of records (interface method)
+     * @param array<string, mixed> $params
+     * @return array<MigrationIssue>
+     * @throws CanvasApiException
+     */
+    public static function all(array $params = []): array
+    {
+        throw new CanvasApiException(
+            'Direct all() not supported for MigrationIssue. Use allInMigration() instead.'
         );
     }
 
@@ -183,7 +195,7 @@ class MigrationIssue extends AbstractBaseApi
         int $migrationId,
         array $params = []
     ): array {
-        return self::fetchAllPages($contextType, $contextId, $migrationId, $params);
+        return self::allInMigration($contextType, $contextId, $migrationId, $params);
     }
 
     /**
@@ -196,7 +208,7 @@ class MigrationIssue extends AbstractBaseApi
      * @return PaginatedResponse
      * @throws CanvasApiException
      */
-    public static function fetchAllPaginated(
+    public static function paginateInMigration(
         string $contextType,
         int $contextId,
         int $migrationId,
@@ -212,26 +224,6 @@ class MigrationIssue extends AbstractBaseApi
     }
 
     /**
-     * Get a single page of migration issues
-     *
-     * @param string $contextType Context type (accounts, courses, groups, users)
-     * @param int $contextId Context ID
-     * @param int $migrationId Content migration ID
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(
-        string $contextType,
-        int $contextId,
-        int $migrationId,
-        array $params = []
-    ): PaginationResult {
-        $paginatedResponse = self::fetchAllPaginated($contextType, $contextId, $migrationId, $params);
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
      * Get all pages of migration issues
      *
      * @param string $contextType Context type (accounts, courses, groups, users)
@@ -241,7 +233,7 @@ class MigrationIssue extends AbstractBaseApi
      * @return array<MigrationIssue>
      * @throws CanvasApiException
      */
-    public static function fetchAllPages(
+    public static function allInMigration(
         string $contextType,
         int $contextId,
         int $migrationId,
@@ -253,7 +245,9 @@ class MigrationIssue extends AbstractBaseApi
             $contextId,
             $migrationId
         );
-        return self::fetchAllPagesAsModels($endpoint, $params);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        return array_map(fn($data) => new self($data), $allData);
     }
 
     /**
@@ -333,7 +327,7 @@ class MigrationIssue extends AbstractBaseApi
                 $this->workflowState = $updated->getWorkflowState();
                 $this->updatedAt = $updated->getUpdatedAt();
                 return true;
-            } catch (\Exception $e) {
+            } catch (\Exception $_e) {
                 return false;
             }
         }
@@ -377,7 +371,7 @@ class MigrationIssue extends AbstractBaseApi
                 $this->workflowState = $updated->getWorkflowState();
                 $this->updatedAt = $updated->getUpdatedAt();
                 return true;
-            } catch (\Exception $e) {
+            } catch (\Exception $_e) {
                 return false;
             }
         }

--- a/src/Api/Conversations/Conversation.php
+++ b/src/Api/Conversations/Conversation.php
@@ -103,7 +103,7 @@ class Conversation extends AbstractBaseApi
      *                      - include[]: participant_avatars
      * @return array<Conversation> Array of Conversation objects
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         self::checkApiClient();
         $response = self::$apiClient->get(self::$endpoint, $params);

--- a/src/Api/CourseReports/CourseReports.php
+++ b/src/Api/CourseReports/CourseReports.php
@@ -7,7 +7,6 @@ namespace CanvasLMS\Api\CourseReports;
 use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Api\Courses\Course;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
 
 /**
  * Canvas Course Reports API
@@ -129,7 +128,7 @@ class CourseReports extends AbstractBaseApi
      * @return static Never returns, always throws exception
      * @throws CanvasApiException Always thrown - use getReport() instead
      */
-    public static function find(int $id): static
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'Course reports cannot be found by ID alone. Use getReport($reportType, $reportId) instead.'
@@ -295,11 +294,12 @@ class CourseReports extends AbstractBaseApi
 
     /**
      * @param array<string, mixed> $params
+     * @return array<static>
      * @throws CanvasApiException Always thrown
      */
-    public static function fetchAll(array $params = []): PaginatedResponse
+    public static function get(array $params = []): array
     {
-        throw new CanvasApiException('Use specific report type methods (last, getReport) instead of fetchAll');
+        throw new CanvasApiException('Use specific report type methods (last, getReport) instead of get');
     }
 
     /**

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -1414,13 +1414,10 @@ class Course extends AbstractBaseApi
 
         // Set this course as the context and fetch enrollments
         Enrollment::setCourse($this);
-        return Enrollment::get($params);
+        return Enrollment::all($params);
     }
 
     // Enrollment Relationship Methods
-    // NOTE: All relationship methods return FIRST PAGE ONLY for performance.
-    // To get all items, use the static methods with context:
-    // Assignment::setCourse($course); $all = Assignment::all();
 
 
     /**
@@ -2695,17 +2692,12 @@ class Course extends AbstractBaseApi
     // Assignment Relationship Methods
 
     /**
-     * Get assignments for this course (first page only)
+     * Get assignments for this course
      *
-     * NOTE: Returns FIRST PAGE of assignments only for performance.
-     * To get ALL assignments:
-     * ```php
-     * Assignment::setCourse($course);
-     * $allAssignments = Assignment::all();
-     * ```
+     * Returns ALL assignments for this course.
      *
      * @param array<string, mixed> $params Query parameters
-     * @return Assignment[] First page of assignments
+     * @return Assignment[] All assignments
      * @throws CanvasApiException
      */
     public function assignments(array $params = []): array
@@ -2715,7 +2707,7 @@ class Course extends AbstractBaseApi
         }
 
         Assignment::setCourse($this);
-        return Assignment::get($params); // get() returns first page only
+        return Assignment::all($params);
     }
 
 
@@ -2735,7 +2727,7 @@ class Course extends AbstractBaseApi
         }
 
         Module::setCourse($this);
-        return Module::get($params);
+        return Module::all($params);
     }
 
 
@@ -2756,7 +2748,7 @@ class Course extends AbstractBaseApi
         }
 
         Page::setCourse($this);
-        return Page::get($params);
+        return Page::all($params);
     }
 
 
@@ -2776,7 +2768,7 @@ class Course extends AbstractBaseApi
         }
 
         Section::setCourse($this);
-        return Section::get($params);
+        return Section::all($params);
     }
 
 
@@ -2796,16 +2788,13 @@ class Course extends AbstractBaseApi
         }
 
         DiscussionTopic::setCourse($this);
-        return DiscussionTopic::get($params);
+        return DiscussionTopic::all($params);
     }
 
     /**
      * Get announcements for this course
      *
-     * Returns the first page of announcements for performance. To fetch more announcements, use:
-     * - Announcement::paginate() for pagination metadata
-     * - Announcement::all() for all announcements (memory intensive)
-     * - Announcement::paginate() for single page with navigation
+     * Returns ALL announcements for this course.
      *
      * @example
      * ```php
@@ -2817,7 +2806,7 @@ class Course extends AbstractBaseApi
      * ```
      *
      * @param array<string, mixed> $params Query parameters (active_only, etc.)
-     * @return Announcement[] First page of announcements
+     * @return Announcement[] All announcements
      * @throws CanvasApiException
      */
     public function announcements(array $params = []): array
@@ -2827,7 +2816,7 @@ class Course extends AbstractBaseApi
         }
 
         Announcement::setCourse($this);
-        return Announcement::get($params);
+        return Announcement::all($params);
     }
 
 
@@ -2847,7 +2836,7 @@ class Course extends AbstractBaseApi
         }
 
         Quiz::setCourse($this);
-        return Quiz::get($params);
+        return Quiz::all($params);
     }
 
 
@@ -2938,7 +2927,7 @@ class Course extends AbstractBaseApi
         }
 
         Tab::setCourse($this);
-        return Tab::get();
+        return Tab::all();
     }
 
     /**
@@ -3001,7 +2990,7 @@ class Course extends AbstractBaseApi
      * @return \CanvasLMS\Api\FeatureFlags\FeatureFlag
      * @throws CanvasApiException
      */
-    public function getFeatureFlag(string $featureName): \CanvasLMS\Api\FeatureFlags\FeatureFlag
+    public function featureFlag(string $featureName): \CanvasLMS\Api\FeatureFlags\FeatureFlag
     {
         if (!$this->id) {
             throw new CanvasApiException('Course ID is required to get feature flag');
@@ -3212,7 +3201,7 @@ class Course extends AbstractBaseApi
      * @return \CanvasLMS\Api\OutcomeImports\OutcomeImport
      * @throws CanvasApiException
      */
-    public function getOutcomeImportStatus(int|string $importId): \CanvasLMS\Api\OutcomeImports\OutcomeImport
+    public function outcomeImportStatus(int|string $importId): \CanvasLMS\Api\OutcomeImports\OutcomeImport
     {
         if (!$this->id) {
             throw new CanvasApiException('Course ID is required to get import status');

--- a/src/Api/DeveloperKeys/DeveloperKey.php
+++ b/src/Api/DeveloperKeys/DeveloperKey.php
@@ -171,7 +171,7 @@ class DeveloperKey extends AbstractBaseApi
      * @return self The DeveloperKey instance
      * @throws CanvasApiException If key not found
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         $keys = self::get();
 

--- a/src/Api/DiscussionTopics/DiscussionTopic.php
+++ b/src/Api/DiscussionTopics/DiscussionTopic.php
@@ -40,11 +40,11 @@ use CanvasLMS\Pagination\PaginationResult;
  * $discussion = DiscussionTopic::find(456);
  *
  * // List all discussion topics for the course
- * $discussions = DiscussionTopic::fetchAll();
+ * $discussions = DiscussionTopic::get();
  *
  * // Get paginated discussion topics
- * $paginatedDiscussions = DiscussionTopic::fetchAllPaginated();
- * $paginationResult = DiscussionTopic::fetchPage();
+ * $paginatedDiscussions = DiscussionTopic::paginate();
+ * $allDiscussions = DiscussionTopic::all();
  *
  * // Update a discussion topic
  * $updatedDiscussion = DiscussionTopic::update(456, ['title' => 'Updated Discussion Title']);
@@ -75,7 +75,7 @@ use CanvasLMS\Pagination\PaginationResult;
  */
 class DiscussionTopic extends AbstractBaseApi
 {
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Discussion topic unique identifier
@@ -1453,16 +1453,17 @@ class DiscussionTopic extends AbstractBaseApi
      * Find a single discussion topic by ID
      *
      * @param int $id Discussion topic ID
+     * @param array<string, mixed> $params Optional query parameters
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkCourse();
         self::checkApiClient();
 
         $endpoint = sprintf('courses/%d/discussion_topics/%d', self::$course->id, $id);
-        $response = self::$apiClient->get($endpoint);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
         $discussionData = json_decode($response->getBody()->getContents(), true);
 
         return new self($discussionData);
@@ -1475,7 +1476,7 @@ class DiscussionTopic extends AbstractBaseApi
      * @return array<DiscussionTopic> Array of DiscussionTopic objects
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1493,29 +1494,13 @@ class DiscussionTopic extends AbstractBaseApi
     }
 
     /**
-     * Fetch all discussion topics with pagination support
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/discussion_topics', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
-
-    /**
-     * Fetch a single page of discussion topics
+     * Get paginated discussion topics
      *
      * @param array<string, mixed> $params Optional parameters
      * @return PaginationResult
      * @throws CanvasApiException
      */
-    public static function fetchPage(array $params = []): PaginationResult
+    public static function paginate(array $params = []): PaginationResult
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1524,22 +1509,6 @@ class DiscussionTopic extends AbstractBaseApi
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
 
         return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of discussion topics
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<DiscussionTopic> Array of DiscussionTopic objects from all pages
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/discussion_topics', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
     }
 
     /**

--- a/src/Api/Enrollments/Enrollment.php
+++ b/src/Api/Enrollments/Enrollment.php
@@ -11,8 +11,6 @@ use CanvasLMS\Api\Sections\Section;
 use CanvasLMS\Dto\Enrollments\CreateEnrollmentDTO;
 use CanvasLMS\Dto\Enrollments\UpdateEnrollmentDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
-use CanvasLMS\Pagination\PaginationResult;
 
 /**
  * Canvas LMS Enrollment API Class
@@ -82,7 +80,7 @@ use CanvasLMS\Pagination\PaginationResult;
 class Enrollment extends AbstractBaseApi
 {
     // Course context (required pattern)
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     // Core enrollment properties
     public ?int $id = null;
@@ -179,13 +177,13 @@ class Enrollment extends AbstractBaseApi
     /**
      * @return self
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkCourse();
         self::checkApiClient();
 
         $endpoint = sprintf('courses/%d/enrollments/%d', self::$course->id, $id);
-        $response = self::$apiClient->get($endpoint);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
         $data = json_decode((string) $response->getBody(), true);
 
         return new self($data);
@@ -202,7 +200,7 @@ class Enrollment extends AbstractBaseApi
      * @param array<string, mixed> $params
      * @return array<self>
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         self::checkCourse();
         self::checkApiClient();
@@ -219,48 +217,6 @@ class Enrollment extends AbstractBaseApi
         return $enrollments;
     }
 
-    /**
-     * Fetch all enrollments with pagination support
-     */
-    /**
-     * @param mixed[] $params
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/enrollments', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
-
-    /**
-     * Fetch a single page of enrollments
-     */
-    /**
-     * @param mixed[] $params
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        $paginatedResponse = self::fetchAllPaginated($params);
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of enrollments
-     */
-    /**
-     * @param mixed[] $params
-     * @return self[]
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/enrollments', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
-    }
 
     /**
      * Create a new enrollment

--- a/src/Api/ExternalTools/ExternalTool.php
+++ b/src/Api/ExternalTools/ExternalTool.php
@@ -23,7 +23,7 @@ use CanvasLMS\Pagination\PaginatedResponse;
  *
  * ```php
  * // Account context (default)
- * $tools = ExternalTool::fetchAll();
+ * $tools = ExternalTool::get();
  * $tool = ExternalTool::create([
  *     'name' => 'My LTI Tool',
  *     'consumer_key' => 'key123',
@@ -1043,7 +1043,7 @@ class ExternalTool extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         $accountId = Config::getAccountId();
         return self::findByContext('accounts', $accountId, $id);
@@ -1137,7 +1137,10 @@ class ExternalTool extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
-        $tools = self::fetchAllPagesAsModels(sprintf('%s/%d/external_tools', $contextType, $contextId), $params);
+        $endpoint = sprintf('%s/%d/external_tools', $contextType, $contextId);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        $tools = array_map(fn($data) => new self($data), $allData);
 
         // Set context information on each tool
         $singularContext = rtrim($contextType, 's');

--- a/src/Api/ExternalTools/ExternalTool.php
+++ b/src/Api/ExternalTools/ExternalTool.php
@@ -1139,7 +1139,16 @@ class ExternalTool extends AbstractBaseApi
     {
         $endpoint = sprintf('%s/%d/external_tools', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->all();
+
+        $allData = [];
+        do {
+            $data = $paginatedResponse->getJsonData();
+            foreach ($data as $item) {
+                $allData[] = $item;
+            }
+            $paginatedResponse = $paginatedResponse->getNext();
+        } while ($paginatedResponse !== null);
+
         $tools = array_map(fn($data) => new self($data), $allData);
 
         // Set context information on each tool

--- a/src/Api/FeatureFlags/FeatureFlag.php
+++ b/src/Api/FeatureFlags/FeatureFlag.php
@@ -180,7 +180,7 @@ class FeatureFlag
      * @return array<int, self> Array of FeatureFlag objects
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         $accountId = Config::getAccountId();
         return self::fetchByContext('accounts', $accountId, $params);

--- a/src/Api/Files/File.php
+++ b/src/Api/Files/File.php
@@ -7,6 +7,7 @@ use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Config;
 use CanvasLMS\Dto\Files\UploadFileDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Pagination\PaginationResult;
 
 /**
  * File Class
@@ -42,20 +43,15 @@ use CanvasLMS\Exceptions\CanvasApiException;
  * $downloadUrl = $file->getDownloadUrl();
  *
  * // Fetch all files from current user (first page only)
- * $files = File::fetchAll();
+ * $files = File::get();
  *
- * // Fetch files with pagination support
- * $paginatedResponse = File::fetchAllPaginated(['per_page' => 10]);
- * $files = $paginatedResponse->getJsonData();
- * $pagination = $paginatedResponse->toPaginationResult($files);
- *
- * // Fetch a specific page of files
- * $paginationResult = File::fetchPage(['page' => 2, 'per_page' => 10]);
+ * // Get paginated files
+ * $paginationResult = File::paginate(['per_page' => 10]);
  * $files = $paginationResult->getData();
  * $hasNext = $paginationResult->hasNext();
  *
  * // Fetch all files from all pages
- * $allFiles = File::fetchAllPages(['per_page' => 50]);
+ * $allFiles = File::all(['per_page' => 50]);
  * ```
  *
  * @package CanvasLMS\Api\Files
@@ -64,39 +60,39 @@ class File extends AbstractBaseApi
 {
     /**
      * The unique identifier for the file
-     * @var int
+     * @var int|null
      */
-    public int $id;
+    public ?int $id = null;
 
     /**
      * The UUID of the file
-     * @var string
+     * @var string|null
      */
-    public string $uuid;
+    public ?string $uuid = null;
 
     /**
      * The folder_id of the folder containing the file
-     * @var int
+     * @var int|null
      */
-    public int $folderId;
+    public ?int $folderId = null;
 
     /**
      * The display name of the file
-     * @var string
+     * @var string|null
      */
-    public string $displayName;
+    public ?string $displayName = null;
 
     /**
      * The filename of the file
-     * @var string
+     * @var string|null
      */
-    public string $filename;
+    public ?string $filename = null;
 
     /**
      * The content-type of the file
-     * @var string
+     * @var string|null
      */
-    public string $contentType;
+    public ?string $contentType = null;
 
     /**
      * The URL to download the file (not present for file upload requests)
@@ -106,21 +102,21 @@ class File extends AbstractBaseApi
 
     /**
      * The file size in bytes
-     * @var int
+     * @var int|null
      */
-    public int $size;
+    public ?int $size = null;
 
     /**
      * The datetime the file was created
-     * @var string
+     * @var string|null
      */
-    public string $createdAt;
+    public ?string $createdAt = null;
 
     /**
      * The datetime the file was last updated
-     * @var string
+     * @var string|null
      */
-    public string $updatedAt;
+    public ?string $updatedAt = null;
 
     /**
      * The datetime the file will be deleted (not present for file upload requests)
@@ -373,8 +369,11 @@ class File extends AbstractBaseApi
             ]);
 
             $startTime = microtime(true);
-            $uploadResponse = self::$apiClient->post($uploadUrl, [
-                'multipart' => $multipartData
+            // Use rawRequest with skipAuth and skipDomainValidation for external uploads (e.g., S3)
+            $uploadResponse = self::$apiClient->rawRequest($uploadUrl, 'POST', [
+                'multipart' => $multipartData,
+                'skipAuth' => true,  // Don't send Canvas Bearer token to external storage
+                'skipDomainValidation' => true  // Allow external storage URLs
             ]);
             $uploadDuration = microtime(true) - $startTime;
 
@@ -406,7 +405,11 @@ class File extends AbstractBaseApi
         $location = $uploadResponse->getHeader('Location')[0] ?? '';
         if (!empty($location)) {
             $logger->debug('File Upload: Step 3 - Following redirect to confirm upload');
-            $confirmResponse = self::$apiClient->get($location);
+            // Use rawRequest with skipAuth and skipDomainValidation for external redirect URLs
+            $confirmResponse = self::$apiClient->rawRequest($location, 'GET', [
+                'skipAuth' => true,  // Don't send Canvas Bearer token to external location
+                'skipDomainValidation' => true  // Allow external redirect URLs
+            ]);
             $fileData = json_decode($confirmResponse->getBody(), true);
         } else {
             $logger->debug('File Upload: Step 3 - Processing upload response directly');
@@ -420,7 +423,7 @@ class File extends AbstractBaseApi
             'content_type' => $fileData['content-type'] ?? null
         ]);
 
-        return new self($fileData);
+        return new self($fileData ?? []);
     }
 
     /**
@@ -429,7 +432,7 @@ class File extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkApiClient();
 
@@ -472,6 +475,29 @@ class File extends AbstractBaseApi
     }
 
     /**
+     * Get paginated files from current user's personal files.
+     * Overrides base to set context information.
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return PaginationResult
+     */
+    public static function paginate(array $params = []): PaginationResult
+    {
+        $paginatedResponse = parent::getPaginatedResponse(self::getEndpoint(), $params);
+
+        // Convert data to models with context information
+        $data = [];
+        foreach ($paginatedResponse->getJsonData() as $item) {
+            $file = new static($item);
+            $file->contextType = 'user';
+            $file->contextId = null; // 'self' user ID is not known at this point
+            $data[] = $file;
+        }
+
+        return $paginatedResponse->toPaginationResult($data);
+    }
+
+    /**
      * Get all files from current user's personal files.
      * Overrides base to set context information.
      *
@@ -507,7 +533,7 @@ class File extends AbstractBaseApi
     {
         $endpoint = sprintf('%s/%d/files', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         $files = array_map(fn($data) => new self($data), $allData);
 

--- a/src/Api/Files/File.php
+++ b/src/Api/Files/File.php
@@ -533,7 +533,15 @@ class File extends AbstractBaseApi
     {
         $endpoint = sprintf('%s/%d/files', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->all();
+
+        $allData = [];
+        do {
+            $data = $paginatedResponse->getJsonData();
+            foreach ($data as $item) {
+                $allData[] = $item;
+            }
+            $paginatedResponse = $paginatedResponse->getNext();
+        } while ($paginatedResponse !== null);
 
         $files = array_map(fn($data) => new self($data), $allData);
 

--- a/src/Api/GradebookHistory/GradebookHistory.php
+++ b/src/Api/GradebookHistory/GradebookHistory.php
@@ -350,7 +350,7 @@ class GradebookHistory extends AbstractBaseApi
      * @return static
      * @throws CanvasApiException
      */
-    public static function find(int $id): static
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'The Gradebook History API does not support finding individual records by ID. ' .

--- a/src/Api/GroupCategories/GroupCategory.php
+++ b/src/Api/GroupCategories/GroupCategory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CanvasLMS\Api\GroupCategories;
 
 use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Api\Courses\Course;
 use CanvasLMS\Api\Groups\Group;
 use CanvasLMS\Api\Users\User;
 use CanvasLMS\Config;
@@ -26,6 +27,11 @@ use CanvasLMS\Pagination\PaginationResult;
  */
 class GroupCategory extends AbstractBaseApi
 {
+    /**
+     * Course context for group categories
+     */
+    protected static ?Course $course = null;
+
     /**
      * The ID of the group category
      */
@@ -104,7 +110,7 @@ class GroupCategory extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkApiClient();
 
@@ -116,6 +122,22 @@ class GroupCategory extends AbstractBaseApi
     }
 
     /**
+     * Set the course context for group category operations
+     */
+    public static function setCourse(Course $course): void
+    {
+        self::$course = $course;
+    }
+
+    /**
+     * Check if course context is set
+     */
+    public static function checkCourse(): bool
+    {
+        return isset(self::$course);
+    }
+
+    /**
      * Get the endpoint for this resource.
      *
      * @return string
@@ -123,6 +145,10 @@ class GroupCategory extends AbstractBaseApi
      */
     protected static function getEndpoint(): string
     {
+        if (self::checkCourse()) {
+            return sprintf('courses/%d/group_categories', self::$course->getId());
+        }
+
         $accountId = Config::getAccountId();
         return sprintf('accounts/%d/group_categories', $accountId);
     }
@@ -232,7 +258,7 @@ class GroupCategory extends AbstractBaseApi
 
         $endpoint = sprintf('group_categories/%d/groups', $this->id);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         return array_map(fn($data) => new Group($data), $allData);
     }

--- a/src/Api/Groups/Group.php
+++ b/src/Api/Groups/Group.php
@@ -12,7 +12,6 @@ use CanvasLMS\Dto\Groups\CreateGroupMembershipDTO;
 use CanvasLMS\Dto\Groups\UpdateGroupDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Pagination\PaginatedResponse;
-use CanvasLMS\Pagination\PaginationResult;
 use CanvasLMS\Api\ContentMigrations\ContentMigration;
 use CanvasLMS\Dto\ContentMigrations\CreateContentMigrationDTO;
 
@@ -379,21 +378,6 @@ class Group extends AbstractBaseApi
         return array_map(fn($data) => new User($data), $allData);
     }
 
-    /**
-     * Get paginated group members
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public function membersPaginated(array $params = []): PaginatedResponse
-    {
-        if (!$this->id) {
-            throw new CanvasApiException('Group ID is required to fetch group members');
-        }
-
-        return self::getPaginatedResponse(sprintf('groups/%d/users', $this->id), $params);
-    }
 
     /**
      * Add user to group
@@ -408,7 +392,7 @@ class Group extends AbstractBaseApi
         try {
             $membership = $this->createMembership(['user_id' => $userId]);
             return $membership !== null;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -445,21 +429,6 @@ class Group extends AbstractBaseApi
         return GroupMembership::fetchAllForGroup($this->id, $params);
     }
 
-    /**
-     * Get paginated memberships for this group
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public function membershipsPaginated(array $params = []): PaginationResult
-    {
-        if (!$this->id) {
-            throw new CanvasApiException('Group ID is required to fetch memberships');
-        }
-
-        return GroupMembership::paginate(['group_id' => $this->id] + $params);
-    }
 
     /**
      * Invite users to this group

--- a/src/Api/Logins/Login.php
+++ b/src/Api/Logins/Login.php
@@ -74,19 +74,6 @@ class Login extends AbstractBaseApi
         return array_map(fn(array $item) => new self($item), $data);
     }
 
-    /**
-     * Get all logins from all pages (implements ApiInterface)
-     * Uses account context by default
-     *
-     * @param array<string, mixed> $params Optional query parameters
-     * @return array<Login> Array of Login objects
-     */
-    public static function all(array $params = []): array
-    {
-        self::checkApiClient();
-        $endpoint = self::getEndpoint();
-        return self::fetchAllPagesAsModels($endpoint, $params);
-    }
 
     /**
      * Find a specific login by ID (implements ApiInterface)
@@ -95,7 +82,7 @@ class Login extends AbstractBaseApi
      * @param int $id The login ID
      * @return self The Login instance
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         // Canvas doesn't have direct login endpoint by ID
         // We need to fetch all and filter

--- a/src/Api/MediaObjects/MediaObject.php
+++ b/src/Api/MediaObjects/MediaObject.php
@@ -91,7 +91,7 @@ class MediaObject extends AbstractBaseApi
      * @return array<MediaObject> Array of MediaObject instances
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         $response = self::$apiClient->get('/media_objects', ['query' => $params]);
         $data = json_decode($response->getBody()->getContents(), true);
@@ -210,7 +210,7 @@ class MediaObject extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException Always throws as Canvas doesn't support this operation
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new CanvasApiException('Direct media object retrieval is not supported by Canvas API');
     }

--- a/src/Api/Modules/Module.php
+++ b/src/Api/Modules/Module.php
@@ -27,10 +27,10 @@ use CanvasLMS\Pagination\PaginationResult;
  * Module::setCourse($course);
  *
  * // Get all modules for a course (first page only)
- * $modules = Module::fetchAll();
+ * $modules = Module::get();
  *
  * // Get modules with query parameters
- * $modules = Module::fetchAll([
+ * $modules = Module::get([
  *     'include' => ['items', 'content_details'],
  *     'search_term' => 'Introduction',
  *     'student_id' => '123'
@@ -40,17 +40,12 @@ use CanvasLMS\Pagination\PaginationResult;
  * $module = Module::find(1, ['include' => ['items']]);
  *
  * // Fetch modules with pagination support
- * $paginatedResponse = Module::fetchAllPaginated(['per_page' => 10]);
- * $modules = $paginatedResponse->getJsonData();
- * $pagination = $paginatedResponse->toPaginationResult($modules);
- *
- * // Fetch a specific page of modules
- * $paginationResult = Module::fetchPage(['page' => 2, 'per_page' => 10]);
+ * $paginationResult = Module::paginate(['per_page' => 10]);
  * $modules = $paginationResult->getData();
  * $hasNext = $paginationResult->hasNext();
  *
  * // Fetch all modules from all pages
- * $allModules = Module::fetchAllPages(['per_page' => 50]);
+ * $allModules = Module::all(['per_page' => 50]);
  *
  * // Create a new module
  * $module = Module::create([
@@ -122,7 +117,7 @@ class Module extends AbstractBaseApi
      * Course
      * @var Course
      */
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Module constructor.
@@ -283,7 +278,7 @@ class Module extends AbstractBaseApi
      */
     protected static function validatePrerequisitePositions(array $prerequisiteModuleIds, int $position): void
     {
-        $modules = self::fetchAll();
+        $modules = self::get();
         $modulePositions = [];
 
         foreach ($modules as $module) {
@@ -383,67 +378,6 @@ class Module extends AbstractBaseApi
         $moduleData = json_decode($response->getBody()->getContents(), true) ?? [];
 
         return new self($moduleData);
-    }
-
-    /**
-     * Get all modules for a course.
-     * @param mixed[] $params Query parameters (include[], search_term, student_id)
-     * @return mixed[]
-     * @throws CanvasApiException
-     */
-    public static function fetchAll(array $params = []): array
-    {
-        self::checkApiClient();
-        self::checkCourse();
-
-        $response = self::$apiClient->get(sprintf('courses/%d/modules', self::$course->id), [
-            'query' => $params
-        ]);
-
-        $modulesData = json_decode($response->getBody()->getContents(), true) ?? [];
-
-        $modules = [];
-        foreach ($modulesData as $moduleData) {
-            $modules[] = new self($moduleData);
-        }
-
-        return $modules;
-    }
-
-    /**
-     * Fetch modules with pagination support
-     * @param mixed[] $params Query parameters for the request
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        return self::getPaginatedResponse(sprintf('courses/%d/modules', self::$course->id), $params);
-    }
-
-    /**
-     * Fetch modules from a specific page
-     * @param mixed[] $params Query parameters for the request
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        $paginatedResponse = self::fetchAllPaginated($params);
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all modules from all pages
-     * @param mixed[] $params Query parameters for the request
-     * @return Module[]
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        return self::fetchAllPagesAsModels(sprintf('courses/%d/modules', self::$course->id), $params);
     }
 
     /**
@@ -760,7 +694,7 @@ class Module extends AbstractBaseApi
         ModuleItem::setCourse(self::$course);
         ModuleItem::setModule($this);
 
-        return ModuleItem::fetchAll($params);
+        return ModuleItem::get($params);
     }
 
     /**
@@ -911,7 +845,7 @@ class Module extends AbstractBaseApi
      * }
      *
      * // Track progress across all modules
-     * $modules = Module::fetchAll();
+     * $modules = Module::get();
      * foreach ($modules as $module) {
      *     $rate = $module->getCompletionRate();
      *     echo "{$module->name}: {$rate}% complete\n";

--- a/src/Api/Modules/Module.php
+++ b/src/Api/Modules/Module.php
@@ -694,7 +694,7 @@ class Module extends AbstractBaseApi
         ModuleItem::setCourse(self::$course);
         ModuleItem::setModule($this);
 
-        return ModuleItem::get($params);
+        return ModuleItem::all($params);
     }
 
     /**

--- a/src/Api/OutcomeGroups/OutcomeGroup.php
+++ b/src/Api/OutcomeGroups/OutcomeGroup.php
@@ -41,13 +41,26 @@ class OutcomeGroup extends AbstractBaseApi
     public ?int $subgroupsCount = null;
 
     /**
-     * Fetch all outcome groups (defaults to Account context).
+     * Get first page of outcome groups (defaults to Account context).
      *
      * @param array<string, mixed> $params Optional query parameters
      * @return array<int, OutcomeGroup> Array of OutcomeGroup objects
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
+    {
+        return parent::get($params);
+    }
+
+
+    /**
+     * Get paginated outcome groups (defaults to Account context).
+     *
+     * @param array<string, mixed> $params Optional query parameters
+     * @return PaginationResult Paginated result with metadata
+     * @throws CanvasApiException
+     */
+    public static function paginate(array $params = []): PaginationResult
     {
         $accountId = Config::getAccountId();
 
@@ -55,7 +68,7 @@ class OutcomeGroup extends AbstractBaseApi
             throw new CanvasApiException('Account ID must be configured to fetch outcome groups');
         }
 
-        return self::fetchByContext('accounts', $accountId, $params);
+        return self::fetchByContextPaginated('accounts', $accountId, $params);
     }
 
     /**
@@ -68,7 +81,9 @@ class OutcomeGroup extends AbstractBaseApi
     public static function fetchGlobal(array $params = []): array
     {
         $endpoint = 'global/outcome_groups';
-        return self::fetchAllPagesAsModels($endpoint, $params);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        return array_map(fn($data) => new self($data), $allData);
     }
 
     /**
@@ -83,7 +98,9 @@ class OutcomeGroup extends AbstractBaseApi
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
         $endpoint = sprintf('%s/%d/outcome_groups', $contextType, $contextId);
-        return self::fetchAllPagesAsModels($endpoint, $params);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        return array_map(fn($data) => new self($data), $allData);
     }
 
     /**
@@ -112,7 +129,7 @@ class OutcomeGroup extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         $accountId = Config::getAccountId();
 
@@ -343,7 +360,7 @@ class OutcomeGroup extends AbstractBaseApi
         );
 
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         return array_map(fn($data) => new self($data), $allData);
     }
@@ -374,7 +391,7 @@ class OutcomeGroup extends AbstractBaseApi
         }
 
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         // Canvas returns OutcomeLink objects from this endpoint
         return array_map(fn($data) => new OutcomeLink($data), $allData);
@@ -570,7 +587,7 @@ class OutcomeGroup extends AbstractBaseApi
     {
         $endpoint = sprintf('%s/%d/outcome_group_links', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         return array_map(fn($data) => new OutcomeLink($data), $allData);
     }

--- a/src/Api/OutcomeImports/OutcomeImport.php
+++ b/src/Api/OutcomeImports/OutcomeImport.php
@@ -470,7 +470,7 @@ class OutcomeImport extends AbstractBaseApi
      * @return static
      * @throws CanvasApiException
      */
-    public static function find(int $id): static
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'The find() method is not applicable for OutcomeImport. Use getStatus() instead.'
@@ -484,10 +484,10 @@ class OutcomeImport extends AbstractBaseApi
      * @return array<int, static>
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
-            'The fetchAll() method is not applicable for OutcomeImport. Use import() or importFromData() instead.'
+            'The get() method is not applicable for OutcomeImport. Use import() or importFromData() instead.'
         );
     }
 

--- a/src/Api/OutcomeResults/OutcomeResult.php
+++ b/src/Api/OutcomeResults/OutcomeResult.php
@@ -54,7 +54,7 @@ class OutcomeResult extends AbstractBaseApi
      * @return array<int, static> Never returns - always throws exception
      * @throws CanvasApiException Always thrown as method requires context
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
             'OutcomeResult requires context. Use fetchByContext() instead.'
@@ -112,7 +112,7 @@ class OutcomeResult extends AbstractBaseApi
      * @return static Never returns - always throws exception
      * @throws CanvasApiException Always thrown as OutcomeResult doesn't support direct find
      */
-    public static function find(int $id): static
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'OutcomeResult does not support find(). Results are accessed through course or user context.'

--- a/src/Api/Pages/Page.php
+++ b/src/Api/Pages/Page.php
@@ -41,10 +41,10 @@ use CanvasLMS\Pagination\PaginationResult;
  * $page = Page::findByUrl('course-syllabus');
  *
  * // List all pages for the course
- * $pages = Page::fetchAll();
+ * $pages = Page::get();
  *
  * // Get only published pages
- * $publishedPages = Page::fetchAll(['published' => true]);
+ * $publishedPages = Page::get(['published' => true]);
  *
  * // Get the course front page
  * $frontPage = Page::fetchFrontPage();
@@ -73,7 +73,7 @@ use CanvasLMS\Pagination\PaginationResult;
  */
 class Page extends AbstractBaseApi
 {
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Page editing roles constants
@@ -752,10 +752,11 @@ class Page extends AbstractBaseApi
      * Find a single page by ID
      *
      * @param int $id Page ID
+     * @param array<string, mixed> $params Optional query parameters
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkCourse();
         self::checkApiClient();
@@ -811,7 +812,7 @@ class Page extends AbstractBaseApi
      * @return array<Page> Array of Page objects
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         self::checkCourse();
         self::checkApiClient();
@@ -833,55 +834,8 @@ class Page extends AbstractBaseApi
         return $pages;
     }
 
-    /**
-     * Fetch all pages with pagination support
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
 
-        $endpoint = sprintf('courses/%d/pages', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
 
-    /**
-     * Fetch a single page of pages
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/pages', self::$course->id);
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of pages
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Page> Array of Page objects from all pages
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/pages', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
-    }
 
     /**
      * Create a new page

--- a/src/Api/Pages/Page.php
+++ b/src/Api/Pages/Page.php
@@ -1119,32 +1119,6 @@ class Page extends AbstractBaseApi
         return $this;
     }
 
-    /**
-     * Get page revisions
-     *
-     * @return array<PageRevision> Array of PageRevision objects
-     * @throws CanvasApiException
-     */
-    public function getRevisions(): array
-    {
-        if (!$this->url) {
-            throw new CanvasApiException('Page URL is required');
-        }
-
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/pages/%s/revisions', self::$course->id, rawurlencode($this->url));
-        $response = self::$apiClient->get($endpoint);
-        $revisionsData = json_decode($response->getBody()->getContents(), true);
-
-        $revisions = [];
-        foreach ($revisionsData as $revisionData) {
-            $revisions[] = new PageRevision($revisionData);
-        }
-
-        return $revisions;
-    }
 
     /**
      * Duplicate this page
@@ -1177,7 +1151,7 @@ class Page extends AbstractBaseApi
      * @return PageRevision Revision object
      * @throws CanvasApiException
      */
-    public function getRevision(int|string $revisionId, bool $summary = false): PageRevision
+    public function revision(int|string $revisionId, bool $summary = false): PageRevision
     {
         if (!$this->url) {
             throw new CanvasApiException('Page URL is required');
@@ -1271,7 +1245,23 @@ class Page extends AbstractBaseApi
      */
     public function revisions(array $params = []): array
     {
-        return $this->getRevisions();
+        if (!$this->url) {
+            throw new CanvasApiException('Page URL is required');
+        }
+
+        self::checkCourse();
+        self::checkApiClient();
+
+        $endpoint = sprintf('courses/%d/pages/%s/revisions', self::$course->id, rawurlencode($this->url));
+        $response = self::$apiClient->get($endpoint);
+        $revisionsData = json_decode($response->getBody()->getContents(), true);
+
+        $revisions = [];
+        foreach ($revisionsData as $revisionData) {
+            $revisions[] = new PageRevision($revisionData);
+        }
+
+        return $revisions;
     }
 
     /**

--- a/src/Api/Progress/Progress.php
+++ b/src/Api/Progress/Progress.php
@@ -166,7 +166,7 @@ class Progress extends AbstractBaseApi
      * @return Progress
      * @throws CanvasApiException
      */
-    public static function find(int $id): Progress
+    public static function find(int $id, array $params = []): Progress
     {
         self::checkApiClient();
 
@@ -594,7 +594,7 @@ class Progress extends AbstractBaseApi
      * @return Progress[]
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
             'Progress API does not support listing all progress objects. Use find() with specific ID.'

--- a/src/Api/Quizzes/Quiz.php
+++ b/src/Api/Quizzes/Quiz.php
@@ -1269,11 +1269,11 @@ class Quiz extends AbstractBaseApi
      * @return QuizSubmission[] Array of quiz submission instances
      * @throws CanvasApiException If course not set or API error
      */
-    public function getSubmissions(array $params = []): array
+    public function submissions(array $params = []): array
     {
         QuizSubmission::setCourse(self::$course);
         QuizSubmission::setQuiz($this);
-        return QuizSubmission::get($params);
+        return QuizSubmission::all($params);
     }
 
     /**
@@ -1282,7 +1282,7 @@ class Quiz extends AbstractBaseApi
      * @return QuizSubmission|null Quiz submission instance or null if no submission
      * @throws CanvasApiException If course not set or API error
      */
-    public function getCurrentUserSubmission(): ?QuizSubmission
+    public function currentUserSubmission(): ?QuizSubmission
     {
         QuizSubmission::setCourse(self::$course);
         QuizSubmission::setQuiz($this);
@@ -1303,19 +1303,6 @@ class Quiz extends AbstractBaseApi
         return QuizSubmission::start($params);
     }
 
-    /**
-     * Get paginated submissions for this quiz
-     *
-     * @param mixed[] $params Optional parameters for filtering
-     * @return PaginationResult Pagination result with submissions
-     * @throws CanvasApiException If course not set or API error
-     */
-    public function getSubmissionsPaginated(array $params = []): PaginationResult
-    {
-        QuizSubmission::setCourse(self::$course);
-        QuizSubmission::setQuiz($this);
-        return QuizSubmission::paginate($params);
-    }
 
     /**
      * Get the API endpoint for this resource

--- a/src/Api/Quizzes/Quiz.php
+++ b/src/Api/Quizzes/Quiz.php
@@ -41,14 +41,13 @@ use CanvasLMS\Pagination\PaginationResult;
  * $quiz = Quiz::find(456);
  *
  * // List all quizzes for the course
- * $quizzes = Quiz::fetchAll();
+ * $quizzes = Quiz::get();
  *
  * // Get published quizzes only
- * $publishedQuizzes = Quiz::fetchAll(['published' => true]);
+ * $publishedQuizzes = Quiz::get(['published' => true]);
  *
  * // Get paginated quizzes
- * $paginatedQuizzes = Quiz::fetchAllPaginated();
- * $paginationResult = Quiz::fetchPage();
+ * $paginationResult = Quiz::paginate();
  *
  * // Update a quiz
  * $updatedQuiz = Quiz::update(456, ['time_limit' => 90]);
@@ -94,7 +93,7 @@ class Quiz extends AbstractBaseApi
         'until_after_last_attempt'
     ];
 
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Quiz unique identifier
@@ -1059,7 +1058,7 @@ class Quiz extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1069,80 +1068,6 @@ class Quiz extends AbstractBaseApi
         $quizData = json_decode($response->getBody()->getContents(), true);
 
         return new self($quizData);
-    }
-
-    /**
-     * Fetch all quizzes for the course
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Quiz> Array of Quiz objects
-     * @throws CanvasApiException
-     */
-    public static function fetchAll(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/quizzes', self::$course->id);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $quizzesData = json_decode($response->getBody()->getContents(), true);
-
-        $quizzes = [];
-        foreach ($quizzesData as $quizData) {
-            $quizzes[] = new self($quizData);
-        }
-
-        return $quizzes;
-    }
-
-    /**
-     * Fetch all quizzes with pagination support
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/quizzes', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
-
-    /**
-     * Fetch a single page of quizzes
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/quizzes', self::$course->id);
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of quizzes
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Quiz> Array of Quiz objects from all pages
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/quizzes', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
     }
 
     /**
@@ -1348,7 +1273,7 @@ class Quiz extends AbstractBaseApi
     {
         QuizSubmission::setCourse(self::$course);
         QuizSubmission::setQuiz($this);
-        return QuizSubmission::fetchAll($params);
+        return QuizSubmission::get($params);
     }
 
     /**
@@ -1389,7 +1314,7 @@ class Quiz extends AbstractBaseApi
     {
         QuizSubmission::setCourse(self::$course);
         QuizSubmission::setQuiz($this);
-        return QuizSubmission::fetchPage($params);
+        return QuizSubmission::paginate($params);
     }
 
     /**

--- a/src/Api/Rubrics/Rubric.php
+++ b/src/Api/Rubrics/Rubric.php
@@ -24,7 +24,7 @@ use CanvasLMS\Pagination\PaginatedResponse;
  *
  * ```php
  * // Account context (default)
- * $rubrics = Rubric::fetchAll();
+ * $rubrics = Rubric::get();
  * $rubric = Rubric::create([
  *     'title' => 'Account Rubric',
  *     'criteria' => [...]
@@ -410,7 +410,10 @@ class Rubric extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
-        return self::fetchAllPagesAsModels(sprintf('%s/%d/rubrics', $contextType, $contextId), $params);
+        $endpoint = sprintf('%s/%d/rubrics', $contextType, $contextId);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
+        return array_map(fn($data) => new self($data), $allData);
     }
 
 

--- a/src/Api/Rubrics/Rubric.php
+++ b/src/Api/Rubrics/Rubric.php
@@ -412,7 +412,16 @@ class Rubric extends AbstractBaseApi
     {
         $endpoint = sprintf('%s/%d/rubrics', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->all();
+
+        $allData = [];
+        do {
+            $data = $paginatedResponse->getJsonData();
+            foreach ($data as $item) {
+                $allData[] = $item;
+            }
+            $paginatedResponse = $paginatedResponse->getNext();
+        } while ($paginatedResponse !== null);
+
         return array_map(fn($data) => new self($data), $allData);
     }
 

--- a/src/Api/Rubrics/RubricAssessment.php
+++ b/src/Api/Rubrics/RubricAssessment.php
@@ -437,7 +437,7 @@ class RubricAssessment extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new CanvasApiException(
             "Finding individual rubric assessments is not supported by the Canvas API. " .
@@ -454,7 +454,7 @@ class RubricAssessment extends AbstractBaseApi
      * @return array<int, self>
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
             "Fetching all rubric assessments is not supported by the Canvas API. " .

--- a/src/Api/Rubrics/RubricAssociation.php
+++ b/src/Api/Rubrics/RubricAssociation.php
@@ -347,7 +347,7 @@ class RubricAssociation extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new CanvasApiException(
             "Finding individual rubric associations is not supported by the Canvas API. " .
@@ -364,7 +364,7 @@ class RubricAssociation extends AbstractBaseApi
      * @return array<int, self>
      * @throws CanvasApiException
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new CanvasApiException(
             "Fetching all rubric associations is not supported by the Canvas API. " .

--- a/src/Api/Sections/Section.php
+++ b/src/Api/Sections/Section.php
@@ -6,48 +6,158 @@ namespace CanvasLMS\Api\Sections;
 
 use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Api\Courses\Course;
-use CanvasLMS\Api\Enrollments\Enrollment;
 use CanvasLMS\Dto\Sections\CreateSectionDTO;
 use CanvasLMS\Dto\Sections\UpdateSectionDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
-use CanvasLMS\Pagination\PaginationResult;
 
 /**
- * Section API class for managing course sections in Canvas LMS.
+ * Canvas LMS Sections API
+ *
+ * Provides functionality to manage course sections in Canvas LMS.
+ * Sections are ways to divide students in a course into smaller groups.
+ *
+ * Usage Examples:
+ *
+ * ```php
+ * // Set course context (required for all operations)
+ * $course = Course::find(123);
+ * Section::setCourse($course);
+ *
+ * // Get all sections for the course
+ * $sections = Section::get();
+ *
+ * // Get sections with parameters
+ * $sections = Section::get(['include' => ['students', 'enrollments']]);
+ *
+ * // Find a specific section
+ * $section = Section::find(456);
+ *
+ * // Create a new section
+ * $sectionData = [
+ *     'name' => 'Lab Section A',
+ *     'sisSectionId' => 'LAB001',
+ *     'startAt' => '2024-01-15T00:00:00Z',
+ *     'endAt' => '2024-05-15T23:59:59Z'
+ * ];
+ * $section = Section::create($sectionData);
+ *
+ * // Update a section
+ * $updatedSection = Section::update(456, ['name' => 'Updated Lab Section A']);
+ *
+ * // Update using instance method
+ * $section = Section::find(456);
+ * $section->setName('New Section Name');
+ * $success = $section->save();
+ *
+ * // Delete a section
+ * $section = Section::find(456);
+ * $success = $section->delete();
+ * ```
  *
  * @package CanvasLMS\Api\Sections
- * @see https://canvas.instructure.com/doc/api/sections.html
  */
 class Section extends AbstractBaseApi
 {
     protected static ?Course $course = null;
 
-    // Core properties from Canvas API
+    /**
+     * Section unique identifier
+     */
     public ?int $id = null;
+
+    /**
+     * Section name
+     */
     public ?string $name = null;
-    public ?string $sisSectionId = null;
-    public ?string $integrationId = null;
-    public ?int $sisImportId = null;
+
+    /**
+     * Course ID this section belongs to
+     */
     public ?int $courseId = null;
+
+    /**
+     * SIS section ID
+     */
+    public ?string $sisSectionId = null;
+
+    /**
+     * SIS course ID
+     */
     public ?string $sisCourseId = null;
+
+    /**
+     * Integration ID
+     */
+    public ?string $integrationId = null;
+
+    /**
+     * Section start date
+     */
     public ?string $startAt = null;
+
+    /**
+     * Section end date
+     */
     public ?string $endAt = null;
+
+    /**
+     * Whether this section restricts enrollments to students
+     */
     public ?bool $restrictEnrollmentsToSectionDates = null;
+
+    /**
+     * Nonxlist course ID if cross-listed
+     */
     public ?int $nonxlistCourseId = null;
+
+    /**
+     * SIS import ID
+     */
+    public ?int $sisImportId = null;
+
+    /**
+     * Total number of students in this section
+     */
     public ?int $totalStudents = null;
 
-    // Additional properties from includes
-    /** @var array<int, array<string, mixed>>|null */
+    /**
+     * Students array (populated when included)
+     * @var mixed[]|null
+     */
     public ?array $students = null;
-    /** @var array<int, array<string, mixed>>|null */
+
+    /**
+     * Enrollments array (populated when included)
+     * @var array<int, array<string, mixed>>|null
+     */
     public ?array $enrollments = null;
+
+    /**
+     * Grade passback status
+     */
     public ?string $passbackStatus = null;
-    /** @var array<string, bool>|null */
+
+    /**
+     * Section permissions
+     * @var array<string, bool>|null
+     */
     public ?array $permissions = null;
 
     /**
-     * Set the course context for section operations.
+     * Create a new Section instance
+     *
+     * @param array<string, mixed> $data Section data from Canvas API
+     */
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+    }
+
+    /**
+     * Set the course context for section operations
+     *
+     * @param Course $course The course to operate on
+     * @return void
      */
     public static function setCourse(Course $course): void
     {
@@ -55,7 +165,9 @@ class Section extends AbstractBaseApi
     }
 
     /**
-     * Check if course context is set.
+     * Check if course context is set
+     *
+     * @return bool
      * @throws CanvasApiException If course is not set
      */
     public static function checkCourse(): bool
@@ -67,236 +179,183 @@ class Section extends AbstractBaseApi
     }
 
     /**
-     * Get first page of sections
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return array<int, self>
-     * @throws CanvasApiException
-     */
-    public static function get(array $params = []): array
-    {
-        self::checkApiClient();
-
-        self::checkCourse();
-
-        // Validate search_term if provided
-        if (isset($params['search_term']) && strlen($params['search_term']) < 2) {
-            throw new CanvasApiException('search_term must be at least 2 characters');
-        }
-
-        $endpoint = sprintf('courses/%d/sections', self::$course->getId());
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $responseData = json_decode($response->getBody()->getContents(), true);
-
-        return array_map(function ($item) {
-            return new self($item);
-        }, $responseData);
-    }
-
-    /**
-     * Get all sections from all pages
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return array<int, self>
-     * @throws CanvasApiException
-     */
-    public static function all(array $params = []): array
-    {
-        self::checkApiClient();
-
-        self::checkCourse();
-
-        $endpoint = sprintf('courses/%d/sections', self::$course->getId());
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-        $allData = $paginatedResponse->all();
-
-        $sections = [];
-        foreach ($allData as $item) {
-            $sections[] = new self($item);
-        }
-
-        return $sections;
-    }
-
-    /**
-     * Get paginated sections
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function paginate(array $params = []): PaginationResult
-    {
-        self::checkApiClient();
-
-        self::checkCourse();
-
-        $endpoint = sprintf('courses/%d/sections', self::$course->getId());
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-
-        // Convert data to models
-        $data = [];
-        foreach ($paginatedResponse->getJsonData() as $item) {
-            $data[] = new self($item);
-        }
-
-        return $paginatedResponse->toPaginationResult($data);
-    }
-
-    /**
-     * Get a single section by ID.
-     * Supports both course-scoped and direct access endpoints.
+     * Find a single section by ID
      *
      * @param int $id Section ID
-     * @param array<string, mixed> $params Optional parameters (include[])
+     * @param array<string, mixed> $params Optional query parameters
      * @return self
      * @throws CanvasApiException
      */
     public static function find(int $id, array $params = []): self
     {
-        // Use direct endpoint if no course context, otherwise use course-scoped endpoint
-        try {
-            self::checkCourse();
+        self::checkApiClient();
+
+        // Use course context if available, otherwise use direct section endpoint
+        if (isset(self::$course) && isset(self::$course->id)) {
             $endpoint = sprintf('courses/%d/sections/%d', self::$course->id, $id);
-        } catch (CanvasApiException $e) {
+        } else {
             $endpoint = sprintf('sections/%d', $id);
         }
 
         $response = self::$apiClient->get($endpoint, ['query' => $params]);
         $data = json_decode($response->getBody()->getContents(), true);
 
-        $section = new self($data);
-        try {
-            self::checkCourse();
-            $section->courseId = self::$course->id;
-        } catch (CanvasApiException $e) {
-            // No course context, skip setting courseId
-        }
-
-        return $section;
+        return new self($data);
     }
 
+    /**
+     * Get sections for the current course
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<self>
+     * @throws CanvasApiException
+     */
+    public static function get(array $params = []): array
+    {
+        // Validate search_term parameter
+        if (isset($params['search_term']) && strlen($params['search_term']) < 2) {
+            throw new CanvasApiException('search_term must be at least 2 characters');
+        }
 
+        self::checkCourse();
+        self::checkApiClient();
 
+        $endpoint = sprintf('courses/%d/sections', self::$course->id);
+        $response = self::$apiClient->get($endpoint, ['query' => $params]);
+        $data = json_decode($response->getBody()->getContents(), true);
 
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return array_map(fn($item) => new self($item), $data);
+    }
 
     /**
-     * Create a new section.
+     * Get all sections for the current course (paginated)
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return array<self>
+     * @throws CanvasApiException
+     */
+    public static function all(array $params = []): array
+    {
+        self::checkCourse();
+        self::checkApiClient();
+
+        $endpoint = sprintf('courses/%d/sections', self::$course->id);
+        $paginatedResponse = self::$apiClient->getPaginated($endpoint, ['query' => $params]);
+        $data = $paginatedResponse->all();
+
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return array_map(fn($item) => new self($item), $data);
+    }
+
+    /**
+     * Get sections with pagination support
+     *
+     * @param array<string, mixed> $params Query parameters
+     * @return \CanvasLMS\Pagination\PaginationResult
+     * @throws CanvasApiException
+     */
+    public static function paginate(array $params = []): \CanvasLMS\Pagination\PaginationResult
+    {
+        self::checkCourse();
+        self::checkApiClient();
+
+        $endpoint = sprintf('courses/%d/sections', self::$course->id);
+        $paginatedResponse = self::$apiClient->getPaginated($endpoint, ['query' => $params]);
+
+        $data = $paginatedResponse->getJsonData();
+        $sections = array_map(fn($item) => new self($item), $data);
+
+        return $paginatedResponse->toPaginationResult($sections);
+    }
+
+    /**
+     * Create a new section
      *
      * @param array<string, mixed>|CreateSectionDTO $data Section data
-     * @return self
+     * @return self Created Section object
      * @throws CanvasApiException
      */
     public static function create(array|CreateSectionDTO $data): self
     {
-        self::checkCourse(); // Throws exception if course not set
+        self::checkCourse();
+        self::checkApiClient();
 
-        $dto = $data instanceof CreateSectionDTO ? $data : new CreateSectionDTO($data);
-        $apiData = $dto->toApiArray();
+        if (is_array($data)) {
+            $data = new CreateSectionDTO($data);
+        }
 
         $endpoint = sprintf('courses/%d/sections', self::$course->id);
-        $response = self::$apiClient->post($endpoint, ['multipart' => $apiData]);
-        $responseData = json_decode($response->getBody()->getContents(), true);
+        $response = self::$apiClient->post($endpoint, ['multipart' => $data->toApiArray()]);
+        $sectionData = json_decode($response->getBody()->getContents(), true);
 
-        $section = new self($responseData);
-        $section->courseId = self::$course->id;
-        return $section;
+        return new self($sectionData);
     }
 
     /**
-     * Update a section.
+     * Update a section
      *
      * @param int $id Section ID
-     * @param array<string, mixed>|UpdateSectionDTO $data Update data
-     * @return self
+     * @param array<string, mixed>|UpdateSectionDTO $data Section data
+     * @return self Updated Section object
      * @throws CanvasApiException
      */
     public static function update(int $id, array|UpdateSectionDTO $data): self
     {
-        $dto = $data instanceof UpdateSectionDTO ? $data : new UpdateSectionDTO($data);
-        $apiData = $dto->toApiArray();
+        self::checkApiClient();
+
+        if (is_array($data)) {
+            $data = new UpdateSectionDTO($data);
+        }
 
         $endpoint = sprintf('sections/%d', $id);
-        $response = self::$apiClient->put($endpoint, ['multipart' => $apiData]);
-        $responseData = json_decode($response->getBody()->getContents(), true);
+        $response = self::$apiClient->put($endpoint, ['multipart' => $data->toApiArray()]);
+        $sectionData = json_decode($response->getBody()->getContents(), true);
 
-        return new self($responseData);
+        return new self($sectionData);
     }
 
     /**
-     * Cross-list a section to another course.
-     *
-     * @param int $sectionId Section ID to cross-list
-     * @param int $newCourseId Target course ID
-     * @param bool $overrideSisStickiness Override SIS stickiness (default: true)
-     * @return self
-     * @throws CanvasApiException
-     */
-    public static function crossList(int $sectionId, int $newCourseId, bool $overrideSisStickiness = true): self
-    {
-        $endpoint = sprintf('sections/%d/crosslist/%d', $sectionId, $newCourseId);
-
-        // Create multipart format for the parameter
-        $params = [
-            [
-                'name' => 'override_sis_stickiness',
-                'contents' => $overrideSisStickiness ? 'true' : 'false'
-            ]
-        ];
-
-        $response = self::$apiClient->post($endpoint, ['multipart' => $params]);
-        $data = json_decode($response->getBody()->getContents(), true);
-
-        return new self($data);
-    }
-
-    /**
-     * De-cross-list a section, returning it to its original course.
-     *
-     * @param int $sectionId Section ID to de-cross-list
-     * @param bool $overrideSisStickiness Override SIS stickiness (default: true)
-     * @return self
-     * @throws CanvasApiException
-     */
-    public static function deCrossList(int $sectionId, bool $overrideSisStickiness = true): self
-    {
-        $endpoint = sprintf('sections/%d/crosslist', $sectionId);
-        $params = ['override_sis_stickiness' => $overrideSisStickiness];
-
-        $response = self::$apiClient->delete($endpoint, ['query' => $params]);
-        $data = json_decode($response->getBody()->getContents(), true);
-
-        return new self($data);
-    }
-
-    /**
-     * Save the section (create or update).
+     * Save the current section (create or update)
      *
      * @return self
      * @throws CanvasApiException
      */
     public function save(): self
     {
+        // Check for required fields before trying to save
+        if (!$this->id && empty($this->name)) {
+            throw new CanvasApiException('Section name is required');
+        }
+
         if ($this->id) {
             // Update existing section
-            $dto = new UpdateSectionDTO($this->toDtoArray());
-            $updated = self::update($this->id, $dto);
-            $this->populate(get_object_vars($updated));
-        } else {
-            // Create new section
-            if (!self::checkCourse()) {
-                throw new CanvasApiException('Course context is required for creating sections');
+            $updateData = $this->toDtoArray();
+            if (empty($updateData)) {
+                return $this; // Nothing to update
             }
 
-            $dto = new CreateSectionDTO($this->toDtoArray());
-            $created = self::create($dto);
-            $this->populate(get_object_vars($created));
+            $updatedSection = self::update($this->id, $updateData);
+            $this->populate($updatedSection->toArray());
+        } else {
+            // Create new section
+            $createData = $this->toDtoArray();
+
+            $newSection = self::create($createData);
+            $this->populate($newSection->toArray());
         }
+
         return $this;
     }
 
     /**
-     * Delete the section.
+     * Delete the section
      *
      * @return self
      * @throws CanvasApiException
@@ -307,37 +366,153 @@ class Section extends AbstractBaseApi
             throw new CanvasApiException('Section ID is required for deletion');
         }
 
+        self::checkApiClient();
+
+        // Use direct section endpoint for deletion
         $endpoint = sprintf('sections/%d', $this->id);
         self::$apiClient->delete($endpoint);
+
         return $this;
     }
 
     /**
-     * Convert section to array for DTO.
+     * Convert section to array
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'course_id' => $this->courseId,
+            'sis_section_id' => $this->sisSectionId,
+            'sis_course_id' => $this->sisCourseId,
+            'integration_id' => $this->integrationId,
+            'start_at' => $this->startAt,
+            'end_at' => $this->endAt,
+            'restrict_enrollments_to_section_dates' => $this->restrictEnrollmentsToSectionDates,
+            'nonxlist_course_id' => $this->nonxlistCourseId,
+            'sis_import_id' => $this->sisImportId,
+            'total_students' => $this->totalStudents,
+            'students' => $this->students,
+            'enrollments' => $this->enrollments,
+            'passback_status' => $this->passbackStatus,
+            'permissions' => $this->permissions,
+        ];
+    }
+
+    /**
+     * Convert section to DTO array format
      *
      * @return array<string, mixed>
      */
     public function toDtoArray(): array
     {
-        return [
+        return array_filter([
             'name' => $this->name,
             'sis_section_id' => $this->sisSectionId,
             'integration_id' => $this->integrationId,
             'start_at' => $this->startAt,
             'end_at' => $this->endAt,
             'restrict_enrollments_to_section_dates' => $this->restrictEnrollmentsToSectionDates,
-        ];
+        ], fn($value) => $value !== null);
     }
 
-    // Relationship Methods
+    // Getter methods
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getCourseId(): ?int
+    {
+        return $this->courseId;
+    }
+
+    public function getSisSectionId(): ?string
+    {
+        return $this->sisSectionId;
+    }
+
+    public function getIntegrationId(): ?string
+    {
+        return $this->integrationId;
+    }
+
+    public function getStartAt(): ?string
+    {
+        return $this->startAt;
+    }
+
+    public function getEndAt(): ?string
+    {
+        return $this->endAt;
+    }
+
+    public function getRestrictEnrollmentsToSectionDates(): ?bool
+    {
+        return $this->restrictEnrollmentsToSectionDates;
+    }
+
+    public function getNonxlistCourseId(): ?int
+    {
+        return $this->nonxlistCourseId;
+    }
+
+    public function getSisImportId(): ?int
+    {
+        return $this->sisImportId;
+    }
+
+    public function getTotalStudents(): ?int
+    {
+        return $this->totalStudents;
+    }
+
+    // Setter methods
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function setSisSectionId(?string $sisSectionId): void
+    {
+        $this->sisSectionId = $sisSectionId;
+    }
+
+    public function setIntegrationId(?string $integrationId): void
+    {
+        $this->integrationId = $integrationId;
+    }
+
+    public function setStartAt(?string $startAt): void
+    {
+        $this->startAt = $startAt;
+    }
+
+    public function setEndAt(?string $endAt): void
+    {
+        $this->endAt = $endAt;
+    }
+
+    public function setRestrictEnrollmentsToSectionDates(?bool $restrictEnrollmentsToSectionDates): void
+    {
+        $this->restrictEnrollmentsToSectionDates = $restrictEnrollmentsToSectionDates;
+    }
 
     /**
-     * Get the course this section belongs to
+     * Get the associated course for this section
      *
-     * @return Course|null
+     * @return Course
      * @throws CanvasApiException
      */
-    public function course(): ?Course
+    public function course(): Course
     {
         self::checkCourse();
         return self::$course;
@@ -347,30 +522,77 @@ class Section extends AbstractBaseApi
      * Get enrollments for this section
      *
      * @param array<string, mixed> $params Query parameters
-     * @return Enrollment[]
+     * @return array<\CanvasLMS\Api\Enrollments\Enrollment>
      * @throws CanvasApiException
      */
     public function enrollments(array $params = []): array
     {
-        if (!isset($this->id) || !$this->id) {
+        if (!$this->id) {
             throw new CanvasApiException('Section ID is required to fetch enrollments');
         }
 
-        return Enrollment::fetchAllBySection($this->id, $params);
+        return \CanvasLMS\Api\Enrollments\Enrollment::fetchAllBySection($this->id, $params);
     }
-
 
     /**
      * Get student enrollments for this section
      *
      * @param array<string, mixed> $params Query parameters
-     * @return Enrollment[]
+     * @return array<\CanvasLMS\Api\Enrollments\Enrollment>
      * @throws CanvasApiException
      */
     public function students(array $params = []): array
     {
-        $params = array_merge($params, ['type[]' => ['StudentEnrollment']]);
+        $params['type[]'] = ['StudentEnrollment'];
         return $this->enrollments($params);
+    }
+
+    /**
+     * Cross-list a section to another course
+     *
+     * @param int $sectionId Section ID to cross-list
+     * @param int $newCourseId Target course ID
+     * @param bool $overrideSisStickiness Override SIS stickiness
+     * @return self Cross-listed Section object
+     * @throws CanvasApiException
+     */
+    public static function crossList(int $sectionId, int $newCourseId, bool $overrideSisStickiness = true): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('sections/%d/crosslist/%d', $sectionId, $newCourseId);
+        $multipart = [
+            [
+                'name' => 'override_sis_stickiness',
+                'contents' => $overrideSisStickiness ? 'true' : 'false'
+            ]
+        ];
+
+        $response = self::$apiClient->post($endpoint, ['multipart' => $multipart]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new self($data);
+    }
+
+    /**
+     * De-cross-list a section (return it to its original course)
+     *
+     * @param int $sectionId Section ID to de-cross-list
+     * @param bool $overrideSisStickiness Override SIS stickiness
+     * @return self De-cross-listed Section object
+     * @throws CanvasApiException
+     */
+    public static function deCrossList(int $sectionId, bool $overrideSisStickiness = true): self
+    {
+        self::checkApiClient();
+
+        $endpoint = sprintf('sections/%d/crosslist', $sectionId);
+        $queryParams = ['override_sis_stickiness' => $overrideSisStickiness];
+
+        $response = self::$apiClient->delete($endpoint, ['query' => $queryParams]);
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new self($data);
     }
 
     /**

--- a/src/Api/SubmissionComments/SubmissionComment.php
+++ b/src/Api/SubmissionComments/SubmissionComment.php
@@ -58,19 +58,19 @@ class SubmissionComment extends AbstractBaseApi
      * Course context (required)
      * @var Course
      */
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * Assignment context (required)
      * @var Assignment
      */
-    protected static Assignment $assignment;
+    protected static ?Assignment $assignment = null;
 
     /**
      * User ID context (required) - the user whose submission this comment belongs to
      * @var int
      */
-    protected static int $userId;
+    protected static ?int $userId = null;
 
     /**
      * Comment unique identifier
@@ -268,7 +268,7 @@ class SubmissionComment extends AbstractBaseApi
      * Note: Canvas API doesn't provide a direct endpoint for individual comment retrieval
      * @throws Exception
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         throw new Exception(
             'SubmissionComment::find() is not supported by Canvas API. Comments are retrieved through submissions.'
@@ -282,10 +282,10 @@ class SubmissionComment extends AbstractBaseApi
      * @return array<self>
      * @throws Exception
      */
-    public static function fetchAll(array $params = []): array
+    public static function get(array $params = []): array
     {
         throw new Exception(
-            'SubmissionComment::fetchAll() is not supported by Canvas API. Comments are retrieved through submissions.'
+            'SubmissionComment::get() is not supported by Canvas API. Comments are retrieved through submissions.'
         );
     }
 

--- a/src/Api/Tabs/Tab.php
+++ b/src/Api/Tabs/Tab.php
@@ -25,11 +25,10 @@ use CanvasLMS\Pagination\PaginationResult;
  * Tab::setCourse($course);
  *
  * // List all tabs for the course
- * $tabs = Tab::fetchAll();
+ * $tabs = Tab::get();
  *
  * // Get paginated tabs
- * $paginatedTabs = Tab::fetchAllPaginated();
- * $paginationResult = Tab::fetchPage();
+ * $paginationResult = Tab::paginate();
  *
  * // Update a tab
  * $updatedTab = Tab::update('assignments', ['position' => 3, 'hidden' => false]);
@@ -39,7 +38,7 @@ use CanvasLMS\Pagination\PaginationResult;
  * $updatedTab = Tab::update('home', $updateDto);
  *
  * // Update using instance method
- * $tab = Tab::fetchAll()[0];
+ * $tab = Tab::get()[0];
  * $tab->position = 5;
  * $tab->hidden = true;
  * $success = $tab->save();
@@ -49,7 +48,7 @@ use CanvasLMS\Pagination\PaginationResult;
  */
 class Tab extends AbstractBaseApi
 {
-    protected static Course $course;
+    protected static ?Course $course = null;
 
     /**
      * HTML URL of the tab
@@ -270,30 +269,6 @@ class Tab extends AbstractBaseApi
     }
 
     /**
-     * Fetch all tabs for the course
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Tab> Array of Tab objects
-     * @throws CanvasApiException
-     */
-    public static function fetchAll(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/tabs', self::$course->id);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $tabsData = json_decode($response->getBody()->getContents(), true);
-
-        $tabs = [];
-        foreach ($tabsData as $tabData) {
-            $tabs[] = new self($tabData);
-        }
-
-        return $tabs;
-    }
-
-    /**
      * Find a single tab by ID
      *
      * Note: Canvas API doesn't support finding individual tabs by ID.
@@ -303,61 +278,11 @@ class Tab extends AbstractBaseApi
      * @return static
      * @throws CanvasApiException Always throws as this operation is not supported
      */
-    public static function find(int $id): static
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
-            'Canvas API does not support finding individual tabs by ID. Use fetchAll() to retrieve all tabs.'
+            'Canvas API does not support finding individual tabs by ID. Use get() to retrieve all tabs.'
         );
-    }
-
-    /**
-     * Fetch all tabs with pagination support
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/tabs', self::$course->id);
-        return self::getPaginatedResponse($endpoint, $params);
-    }
-
-    /**
-     * Fetch a single page of tabs
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return PaginationResult
-     * @throws CanvasApiException
-     */
-    public static function fetchPage(array $params = []): PaginationResult
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/tabs', self::$course->id);
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
-
-        return self::createPaginationResult($paginatedResponse);
-    }
-
-    /**
-     * Fetch all pages of tabs
-     *
-     * @param array<string, mixed> $params Optional parameters
-     * @return array<Tab> Array of Tab objects from all pages
-     * @throws CanvasApiException
-     */
-    public static function fetchAllPages(array $params = []): array
-    {
-        self::checkCourse();
-        self::checkApiClient();
-
-        $endpoint = sprintf('courses/%d/tabs', self::$course->id);
-        return self::fetchAllPagesAsModels($endpoint, $params);
     }
 
     /**

--- a/src/Api/Users/User.php
+++ b/src/Api/Users/User.php
@@ -341,7 +341,7 @@ class User extends AbstractBaseApi
      * @return self
      * @throws CanvasApiException
      */
-    public static function find(int $id): self
+    public static function find(int $id, array $params = []): self
     {
         self::checkApiClient();
 

--- a/src/Api/Users/User.php
+++ b/src/Api/Users/User.php
@@ -11,7 +11,6 @@ use CanvasLMS\Api\Logins\Login;
 use CanvasLMS\Dto\Users\UpdateUserDTO;
 use CanvasLMS\Dto\Users\CreateUserDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Pagination\PaginatedResponse;
 use CanvasLMS\Objects\ActivityStreamItem;
 use CanvasLMS\Objects\ActivityStreamSummary;
 use CanvasLMS\Objects\TodoItem;
@@ -45,7 +44,7 @@ use CanvasLMS\Dto\ContentMigrations\CreateContentMigrationDTO;
  * ```php
  * // Current user operations (using the self pattern)
  * $currentUser = User::self();
- * $profile = $currentUser->getProfile();
+ * $profile = $currentUser->profile();
  * $courses = $currentUser->courses();
  * $todos = $currentUser->getTodo();        // Short alias
  * $todoItems = $currentUser->getTodoItems(); // Full method name
@@ -251,7 +250,7 @@ class User extends AbstractBaseApi
      * ```php
      * // Get current user's profile
      * $currentUser = User::self();
-     * $profile = $currentUser->getProfile();
+     * $profile = $currentUser->profile();
      *
      * // Get current user's todo items
      * $todos = $currentUser->getTodoItems();
@@ -290,7 +289,7 @@ class User extends AbstractBaseApi
      *
      * // You can then use all User methods with the fetched data
      * $courses = $currentUser->courses();
-     * $profile = $currentUser->getProfile();
+     * $profile = $currentUser->profile();
      * ```
      *
      * @return self A fully populated User instance with all user data
@@ -1185,7 +1184,7 @@ class User extends AbstractBaseApi
      * @return Profile The user's profile
      * @throws CanvasApiException
      */
-    public function getProfile(): Profile
+    public function profile(): Profile
     {
         self::checkApiClient();
 
@@ -1358,7 +1357,7 @@ class User extends AbstractBaseApi
      * @return CourseNickname|null The course nickname or null
      * @throws CanvasApiException
      */
-    public function getCourseNickname(int $courseId): ?CourseNickname
+    public function courseNickname(int $courseId): ?CourseNickname
     {
         self::checkApiClient();
 
@@ -1602,24 +1601,6 @@ class User extends AbstractBaseApi
         }, $data);
     }
 
-    /**
-     * Get paginated calendar events for this user
-     *
-     * @param array<string, mixed> $params Query parameters
-     * @return PaginatedResponse
-     * @throws CanvasApiException
-     */
-    public function getCalendarEventsPaginated(array $params = []): PaginatedResponse
-    {
-        self::checkApiClient();
-
-        if (!isset($this->id)) {
-            throw new CanvasApiException('User ID is required to get calendar events');
-        }
-
-        $endpoint = sprintf('users/%d/calendar_events', $this->id);
-        return CalendarEvent::getPaginatedResponse($endpoint, $params);
-    }
 
     /**
      * Create a calendar event for this user
@@ -1658,12 +1639,12 @@ class User extends AbstractBaseApi
 
         if (!isset($this->id)) {
             // Special case: Canvas supports /users/self/groups endpoint
-            $response = self::$apiClient->get('users/self/groups', ['query' => $params]);
-            $groupsData = json_decode($response->getBody(), true);
+            $paginatedResponse = self::getPaginatedResponse('users/self/groups', $params);
+            $allData = $paginatedResponse->all();
 
             return array_map(function ($groupData) {
                 return new Group($groupData);
-            }, $groupsData);
+            }, $allData);
         }
 
         // For regular users with IDs, use the standard method
@@ -1686,12 +1667,12 @@ class User extends AbstractBaseApi
 
         if (!isset($this->id)) {
             // Special case: Canvas supports /users/self/logins endpoint
-            $response = self::$apiClient->get('users/self/logins', ['query' => $params]);
-            $loginsData = json_decode($response->getBody()->getContents(), true);
+            $paginatedResponse = self::getPaginatedResponse('users/self/logins', $params);
+            $allData = $paginatedResponse->all();
 
             return array_map(function ($loginData) {
                 return new Login($loginData);
-            }, $loginsData);
+            }, $allData);
         }
 
         // For regular users with IDs, use the Login fetchByContext method
@@ -1714,11 +1695,11 @@ class User extends AbstractBaseApi
         }
 
         $endpoint = sprintf('users/%d/courses', $this->id);
-        $response = self::$apiClient->get($endpoint, ['query' => $params]);
-        $coursesData = json_decode($response->getBody(), true);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $allData = $paginatedResponse->all();
 
         $courses = [];
-        foreach ($coursesData as $courseData) {
+        foreach ($allData as $courseData) {
             $courses[] = new Course($courseData);
         }
 
@@ -1781,7 +1762,7 @@ class User extends AbstractBaseApi
      * @return \CanvasLMS\Api\FeatureFlags\FeatureFlag
      * @throws CanvasApiException
      */
-    public function getFeatureFlag(string $featureName): \CanvasLMS\Api\FeatureFlags\FeatureFlag
+    public function featureFlag(string $featureName): \CanvasLMS\Api\FeatureFlags\FeatureFlag
     {
         if (!isset($this->id) || !$this->id) {
             throw new CanvasApiException('User ID is required to get feature flag');

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -445,8 +445,12 @@ class HttpClient implements HttpClientInterface
         $isAbsoluteUrl = filter_var($url, FILTER_VALIDATE_URL) !== false;
 
         if ($isAbsoluteUrl) {
-            // Validate that the URL points to the configured Canvas domain
-            $this->validateCanvasUrl($url);
+            // Skip domain validation for external URLs when skipDomainValidation is set
+            // This is necessary for file uploads to external storage (e.g., S3)
+            if (!isset($options['skipDomainValidation']) || $options['skipDomainValidation'] !== true) {
+                // Validate that the URL points to the configured Canvas domain
+                $this->validateCanvasUrl($url);
+            }
         } else {
             // For relative URLs, prepend base URL (without API version)
             $baseUrl = Config::getBaseUrl();
@@ -478,8 +482,9 @@ class HttpClient implements HttpClientInterface
             }
         }
 
-        // Remove skipAuth from options as it's not a valid HTTP client option
+        // Remove skipAuth and skipDomainValidation from options as they're not valid HTTP client options
         unset($options['skipAuth']);
+        unset($options['skipDomainValidation']);
 
         // Add masquerading parameter if active
         $masqueradeUserId = Config::getMasqueradeUserId();

--- a/src/Interfaces/ApiInterface.php
+++ b/src/Interfaces/ApiInterface.php
@@ -9,14 +9,15 @@ interface ApiInterface
     /**
      * Find a single record by ID
      * @param int $id
+     * @param array<string, mixed> $params Optional query parameters
      * @return static
      * @throws CanvasApiException
      */
-    public static function find(int $id);
+    public static function find(int $id, array $params = []);
 
     /**
      * Get first page of records
-     * @param mixed[] $params
+     * @param array<string, mixed> $params
      * @return static[]
      * @throws CanvasApiException
      */
@@ -24,7 +25,7 @@ interface ApiInterface
 
     /**
      * Get all records from all pages
-     * @param mixed[] $params
+     * @param array<string, mixed> $params
      * @return static[]
      * @throws CanvasApiException
      */

--- a/src/Pagination/PaginatedResponse.php
+++ b/src/Pagination/PaginatedResponse.php
@@ -419,9 +419,20 @@ class PaginatedResponse
     }
 
     /**
+     * Get all data from all pages (new simplified method)
+     *
+     * @return mixed[] Array containing all data from all pages
+     */
+    public function all(): array
+    {
+        return $this->fetchAllPages();
+    }
+
+    /**
      * Fetch all pages starting from current page
      *
      * @return mixed[] Array containing all data from all pages
+     * @deprecated Use all() instead
      */
     public function fetchAllPages(): array
     {

--- a/tests/Api/Accounts/AccountTest.php
+++ b/tests/Api/Accounts/AccountTest.php
@@ -437,7 +437,7 @@ class AccountTest extends TestCase
             ->with($this->equalTo('accounts/1/sub_accounts'))
             ->willReturn($response);
 
-        $subAccounts = $this->account->getSubAccounts();
+        $subAccounts = $this->account->subAccounts();
 
         $this->assertIsArray($subAccounts);
         $this->assertCount(2, $subAccounts);
@@ -467,7 +467,7 @@ class AccountTest extends TestCase
             ->with($this->equalTo('accounts/1'))
             ->willReturn($response);
 
-        $parentAccount = $this->account->getParentAccount();
+        $parentAccount = $this->account->parentAccount();
 
         $this->assertInstanceOf(Account::class, $parentAccount);
         $this->assertEquals(1, $parentAccount->getId());
@@ -482,7 +482,7 @@ class AccountTest extends TestCase
     {
         $this->account->parentAccountId = null;
 
-        $parentAccount = $this->account->getParentAccount();
+        $parentAccount = $this->account->parentAccount();
 
         $this->assertNull($parentAccount);
     }
@@ -625,7 +625,7 @@ class AccountTest extends TestCase
             ->with($this->equalTo('accounts/1/courses'))
             ->willReturn($response);
 
-        $courses = $this->account->getCourses();
+        $courses = $this->account->courses();
 
         $this->assertIsArray($courses);
         $this->assertCount(2, $courses);

--- a/tests/Api/Accounts/AccountTest.php
+++ b/tests/Api/Accounts/AccountTest.php
@@ -260,7 +260,7 @@ class AccountTest extends TestCase
      * Test the fetchAll method
      * @return void
      */
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $expectedResult = [
             ['id' => 1, 'name' => 'Account 1'],
@@ -276,7 +276,7 @@ class AccountTest extends TestCase
             ->with($this->equalTo('accounts'))
             ->willReturn($response);
 
-        $accounts = Account::fetchAll();
+        $accounts = Account::get();
 
         $this->assertIsArray($accounts);
         $this->assertCount(3, $accounts);

--- a/tests/Api/Admins/AdminTest.php
+++ b/tests/Api/Admins/AdminTest.php
@@ -252,7 +252,7 @@ class AdminTest extends TestCase
      * Test the fetchAll method
      * @return void
      */
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $expectedResult = [
             ['id' => 1, 'name' => 'Admin 1', 'role' => 'AccountAdmin'],
@@ -268,7 +268,7 @@ class AdminTest extends TestCase
             ->with($this->equalTo('accounts/1/admins'))
             ->willReturn($response);
 
-        $admins = Admin::fetchAll();
+        $admins = Admin::get();
 
         $this->assertIsArray($admins);
         $this->assertCount(3, $admins);
@@ -443,7 +443,7 @@ class AdminTest extends TestCase
      * Test fetchAll with custom account ID
      * @return void
      */
-    public function testFetchAllWithAccountId(): void
+    public function testGetWithAccountId(): void
     {
         $expectedResult = [
             ['id' => 1, 'name' => 'Admin 1', 'role' => 'AccountAdmin']
@@ -457,7 +457,7 @@ class AdminTest extends TestCase
             ->with($this->equalTo('accounts/5/admins'))
             ->willReturn($response);
 
-        $admins = Admin::fetchAll(['account_id' => 5]);
+        $admins = Admin::get(['account_id' => 5]);
 
         $this->assertIsArray($admins);
         $this->assertCount(1, $admins);
@@ -473,6 +473,6 @@ class AdminTest extends TestCase
         Config::setAccountId(0);
 
         $this->expectException(CanvasApiException::class);
-        Admin::fetchAllPaginated();
+        Admin::paginate();
     }
 }

--- a/tests/Api/Announcements/AnnouncementTest.php
+++ b/tests/Api/Announcements/AnnouncementTest.php
@@ -36,7 +36,7 @@ class AnnouncementTest extends TestCase
         $reflection = new \ReflectionClass(Announcement::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -55,7 +55,7 @@ class AnnouncementTest extends TestCase
         $reflection = new \ReflectionClass(Announcement::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         Announcement::checkCourse();
     }
@@ -93,7 +93,7 @@ class AnnouncementTest extends TestCase
         $this->assertTrue($announcement->getIsAnnouncement());
     }
 
-    public function testFetchAllAddsAnnouncementFilter(): void
+    public function testGetAddsAnnouncementFilter(): void
     {
         $responseData = [
             [
@@ -127,7 +127,7 @@ class AnnouncementTest extends TestCase
             )
             ->willReturn($responseMock);
 
-        $announcements = Announcement::fetchAll();
+        $announcements = Announcement::get();
 
         $this->assertCount(2, $announcements);
         $this->assertInstanceOf(Announcement::class, $announcements[0]);
@@ -136,7 +136,7 @@ class AnnouncementTest extends TestCase
         $this->assertTrue($announcements[0]->getIsAnnouncement());
     }
 
-    public function testFetchAllWithCustomParams(): void
+    public function testGetWithCustomParams(): void
     {
         $responseData = [
             [
@@ -166,7 +166,7 @@ class AnnouncementTest extends TestCase
             )
             ->willReturn($responseMock);
 
-        $announcements = Announcement::fetchAll(['active_only' => true]);
+        $announcements = Announcement::get(['active_only' => true]);
 
         $this->assertCount(1, $announcements);
         $this->assertEquals('Active Announcement', $announcements[0]->getTitle());

--- a/tests/Api/Assignments/AssignmentRelationshipTest.php
+++ b/tests/Api/Assignments/AssignmentRelationshipTest.php
@@ -56,17 +56,17 @@ class AssignmentRelationshipTest extends TestCase
             ['id' => 2, 'user_id' => 101, 'assignment_id' => 456, 'score' => 88],
         ];
 
-        // Set up mock expectations
-        $this->mockStream->method('getContents')
-            ->willReturn(json_encode($submissionsData));
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($submissionsData);
 
-        $this->mockResponse->method('getBody')
-            ->willReturn($this->mockStream);
-
+        // Set up mock expectations for paginated request
         $this->mockHttpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/assignments/456/submissions', ['query' => []])
-            ->willReturn($this->mockResponse);
+            ->willReturn($mockPaginatedResponse);
 
         // Test the method  
         $submissions = $assignment->submissions();
@@ -106,7 +106,7 @@ class AssignmentRelationshipTest extends TestCase
             ->willReturn($this->mockResponse);
 
         // Test the method
-        $submission = $assignment->getSubmissionForUser(100);
+        $submission = $assignment->submissionForUser(100);
 
         // Assertions
         $this->assertInstanceOf(Submission::class, $submission);
@@ -126,7 +126,7 @@ class AssignmentRelationshipTest extends TestCase
             ->willThrowException(new CanvasApiException('404 Not Found'));
 
         // Test the method
-        $submission = $assignment->getSubmissionForUser(100);
+        $submission = $assignment->submissionForUser(100);
 
         // Assertions
         $this->assertNull($submission);
@@ -144,17 +144,17 @@ class AssignmentRelationshipTest extends TestCase
             ['id' => 3, 'user_id' => 102],
         ];
 
-        // Set up mock expectations
-        $this->mockStream->method('getContents')
-            ->willReturn(json_encode($submissionsData));
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($submissionsData);
 
-        $this->mockResponse->method('getBody')
-            ->willReturn($this->mockStream);
-
+        // Set up mock expectations for paginated request
         $this->mockHttpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/assignments/456/submissions', ['query' => ['per_page' => 100]])
-            ->willReturn($this->mockResponse);
+            ->willReturn($mockPaginatedResponse);
 
         // Test the method
         $count = $assignment->getSubmissionCount();

--- a/tests/Api/Assignments/AssignmentTest.php
+++ b/tests/Api/Assignments/AssignmentTest.php
@@ -36,7 +36,7 @@ class AssignmentTest extends TestCase
         $reflection = new \ReflectionClass(Assignment::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -55,7 +55,7 @@ class AssignmentTest extends TestCase
         $reflection = new \ReflectionClass(Assignment::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         Assignment::checkCourse();
     }
@@ -214,7 +214,7 @@ class AssignmentTest extends TestCase
         $this->assertTrue($assignment->getPublished());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -249,7 +249,7 @@ class AssignmentTest extends TestCase
             ->with('courses/123/assignments', ['query' => []])
             ->willReturn($responseMock);
 
-        $assignments = Assignment::fetchAll();
+        $assignments = Assignment::get();
 
         $this->assertCount(2, $assignments);
         $this->assertInstanceOf(Assignment::class, $assignments[0]);
@@ -260,7 +260,7 @@ class AssignmentTest extends TestCase
         $this->assertEquals('Assignment 2', $assignments[1]->getName());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['include' => ['submission'], 'order_by' => 'name'];
         $responseData = [];
@@ -281,14 +281,14 @@ class AssignmentTest extends TestCase
             ->with('courses/123/assignments', ['query' => $params])
             ->willReturn($responseMock);
 
-        $assignments = Assignment::fetchAll($params);
+        $assignments = Assignment::get($params);
 
         $this->assertCount(0, $assignments);
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
-        $this->assertTrue(method_exists(Assignment::class, 'fetchAllPaginated'));
+        $this->assertTrue(method_exists(Assignment::class, 'paginate'));
     }
 
     public function testCreate(): void

--- a/tests/Api/Bookmarks/BookmarkTest.php
+++ b/tests/Api/Bookmarks/BookmarkTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CanvasLMS\Tests\Api\Bookmarks;
 
+use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Api\Bookmarks\Bookmark;
 use CanvasLMS\Dto\Bookmarks\CreateBookmarkDTO;
 use CanvasLMS\Dto\Bookmarks\UpdateBookmarkDTO;
@@ -13,6 +14,7 @@ use CanvasLMS\Pagination\PaginatedResponse;
 use CanvasLMS\Pagination\PaginationResult;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 
 class BookmarkTest extends TestCase
 {
@@ -23,6 +25,15 @@ class BookmarkTest extends TestCase
         parent::setUp();
         $this->httpClientMock = $this->createMock(HttpClientInterface::class);
         Bookmark::setApiClient($this->httpClientMock);
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new ReflectionClass(AbstractBaseApi::class);
+        $property = $reflection->getProperty('apiClient');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+        parent::tearDown();
     }
 
     public function testCreateBookmarkWithArray(): void
@@ -135,7 +146,7 @@ class BookmarkTest extends TestCase
         $this->assertEquals('{"type": "course"}', $bookmark->data);
     }
 
-    public function testFetchAllBookmarks(): void
+    public function testGetBookmarks(): void
     {
         $expectedResponse = [
             [

--- a/tests/Api/ContentMigrations/ContentMigrationTest.php
+++ b/tests/Api/ContentMigrations/ContentMigrationTest.php
@@ -61,7 +61,7 @@ class ContentMigrationTest extends TestCase
         ContentMigration::find(123);
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $migrationsData = [
             ['id' => 1, 'migration_type' => 'course_copy_importer'],
@@ -75,7 +75,7 @@ class ContentMigrationTest extends TestCase
             ->with('accounts/1/content_migrations', ['query' => []])
             ->willReturn($this->mockResponse);
 
-        $migrations = ContentMigration::fetchAll();
+        $migrations = ContentMigration::get();
 
         $this->assertCount(2, $migrations);
         $this->assertInstanceOf(ContentMigration::class, $migrations[0]);
@@ -228,7 +228,7 @@ class ContentMigrationTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')->willReturn($issuesData);
+        $mockPaginatedResponse->method('all')->willReturn($issuesData);
         
         $this->mockClient->method('getPaginated')
             ->with('courses/456/content_migrations/123/migration_issues', ['query' => []])

--- a/tests/Api/ContentMigrations/MigrationIssueTest.php
+++ b/tests/Api/ContentMigrations/MigrationIssueTest.php
@@ -60,13 +60,13 @@ class MigrationIssueTest extends TestCase
         MigrationIssue::find(123);
     }
 
-    public function testFetchAllThrowsException(): void
+    public function testGetThrowsException(): void
     {
         $this->expectException(CanvasApiException::class);
-        MigrationIssue::fetchAll();
+        MigrationIssue::get();
     }
 
-    public function testFetchAllInMigration(): void
+    public function testGetInMigration(): void
     {
         $issuesData = [
             ['id' => 1, 'issue_type' => 'warning', 'workflow_state' => 'active'],
@@ -74,7 +74,7 @@ class MigrationIssueTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')->willReturn($issuesData);
+        $mockPaginatedResponse->method('all')->willReturn($issuesData);
         
         $this->mockClient->method('getPaginated')
             ->with('courses/1/content_migrations/456/migration_issues', ['query' => []])

--- a/tests/Api/Conversations/ConversationTest.php
+++ b/tests/Api/Conversations/ConversationTest.php
@@ -48,7 +48,7 @@ class ConversationTest extends TestCase
     /**
      * Test fetching all conversations
      */
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $mockResponse = $this->createMockResponse([
             [
@@ -78,7 +78,7 @@ class ConversationTest extends TestCase
             ->willReturn($mockResponse);
 
         Conversation::setApiClient($this->httpClientMock);
-        $conversations = Conversation::fetchAll();
+        $conversations = Conversation::get();
 
         $this->assertCount(2, $conversations);
         $this->assertInstanceOf(Conversation::class, $conversations[0]);
@@ -90,7 +90,7 @@ class ConversationTest extends TestCase
     /**
      * Test fetching all conversations with include_all_conversation_ids
      */
-    public function testFetchAllWithAllIds(): void
+    public function testGetWithAllIds(): void
     {
         $mockResponse = $this->createMockResponse([
             'conversations' => [
@@ -110,7 +110,7 @@ class ConversationTest extends TestCase
             ->willReturn($mockResponse);
 
         Conversation::setApiClient($this->httpClientMock);
-        $conversations = Conversation::fetchAll(['include_all_conversation_ids' => true]);
+        $conversations = Conversation::get(['include_all_conversation_ids' => true]);
 
         $this->assertCount(1, $conversations);
         $this->assertEquals(1, $conversations[0]->id);

--- a/tests/Api/CourseReports/CourseReportsTest.php
+++ b/tests/Api/CourseReports/CourseReportsTest.php
@@ -398,9 +398,9 @@ class CourseReportsTest extends TestCase
     public function testUnsupportedFetchAllMethod(): void
     {
         $this->expectException(CanvasApiException::class);
-        $this->expectExceptionMessage('Use specific report type methods (last, getReport) instead of fetchAll');
+        $this->expectExceptionMessage('Use specific report type methods (last, getReport) instead of get');
         
-        CourseReports::fetchAll();
+        CourseReports::get();
     }
 
     public function testPropertyConversionFromSnakeCaseToCamelCase(): void

--- a/tests/Api/Courses/CourseContentMigrationTest.php
+++ b/tests/Api/Courses/CourseContentMigrationTest.php
@@ -41,7 +41,7 @@ class CourseContentMigrationTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')->willReturn($migrationsData);
+        $mockPaginatedResponse->method('all')->willReturn($migrationsData);
         
         $this->mockClient->method('getPaginated')
             ->with('courses/123/content_migrations', ['query' => []])

--- a/tests/Api/Courses/CourseRelationshipTest.php
+++ b/tests/Api/Courses/CourseRelationshipTest.php
@@ -31,7 +31,19 @@ class CourseRelationshipTest extends TestCase
     {
         parent::setUp();
         $this->httpClient = $this->createMock(HttpClientInterface::class);
+        
+        // Set API client for all classes that will be used in tests
         Course::setApiClient($this->httpClient);
+        Assignment::setApiClient($this->httpClient);
+        Module::setApiClient($this->httpClient);
+        Page::setApiClient($this->httpClient);
+        Section::setApiClient($this->httpClient);
+        DiscussionTopic::setApiClient($this->httpClient);
+        Quiz::setApiClient($this->httpClient);
+        File::setApiClient($this->httpClient);
+        Rubric::setApiClient($this->httpClient);
+        ExternalTool::setApiClient($this->httpClient);
+        Tab::setApiClient($this->httpClient);
         
         // Create a course instance with ID
         $this->course = new Course(['id' => 123]);
@@ -45,11 +57,19 @@ class CourseRelationshipTest extends TestCase
             ['id' => 2, 'name' => 'Assignment 2']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/assignments', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $assignments = $this->course->assignments();
 
@@ -75,11 +95,19 @@ class CourseRelationshipTest extends TestCase
             ['id' => 2, 'name' => 'Module 2']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/modules', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $modules = $this->course->modules();
 
@@ -96,11 +124,19 @@ class CourseRelationshipTest extends TestCase
             ['url' => 'page-2', 'title' => 'Page 2']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/pages', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $pages = $this->course->pages();
 
@@ -116,11 +152,16 @@ class CourseRelationshipTest extends TestCase
             ['id' => 2, 'name' => 'Section B']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($responseData);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/sections', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $sections = $this->course->sections();
 
@@ -136,11 +177,19 @@ class CourseRelationshipTest extends TestCase
             ['id' => 2, 'title' => 'Topic 2']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/discussion_topics', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $discussionTopics = $this->course->discussionTopics();
 
@@ -156,11 +205,19 @@ class CourseRelationshipTest extends TestCase
             ['id' => 2, 'title' => 'Quiz 2']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/quizzes', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $quizzes = $this->course->quizzes();
 
@@ -178,8 +235,11 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
 
         $this->httpClient
             ->expects($this->once())
@@ -203,8 +263,11 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
 
         $this->httpClient
             ->expects($this->once())
@@ -228,8 +291,11 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
 
         $this->httpClient
             ->expects($this->once())
@@ -251,11 +317,19 @@ class CourseRelationshipTest extends TestCase
             ['id' => 'assignments', 'label' => 'Assignments']
         ];
 
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/tabs', ['query' => []])
-            ->willReturn(new Response(200, [], json_encode($responseData)));
+            ->willReturn($mockPaginatedResponse);
 
         $tabs = $this->course->tabs();
 
@@ -268,11 +342,19 @@ class CourseRelationshipTest extends TestCase
     {
         $params = ['per_page' => 50, 'include[]' => ['total_scores']];
         
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
         $this->httpClient
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/assignments', ['query' => $params])
-            ->willReturn(new Response(200, [], json_encode([])));
+            ->willReturn($mockPaginatedResponse);
 
         $assignments = $this->course->assignments($params);
         $this->assertIsArray($assignments);

--- a/tests/Api/Courses/CourseRelationshipTest.php
+++ b/tests/Api/Courses/CourseRelationshipTest.php
@@ -178,7 +178,7 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($responseData);
 
         $this->httpClient
@@ -203,7 +203,7 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($responseData);
 
         $this->httpClient
@@ -228,7 +228,7 @@ class CourseRelationshipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($responseData);
 
         $this->httpClient

--- a/tests/Api/Courses/CourseTest.php
+++ b/tests/Api/Courses/CourseTest.php
@@ -11,6 +11,7 @@ use CanvasLMS\Dto\Courses\CreateCourseDTO;
 use CanvasLMS\Dto\Courses\UpdateCourseDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Config;
+use CanvasLMS\Pagination\PaginatedResponse;
 
 class CourseTest extends TestCase
 {
@@ -408,13 +409,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => []])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->enrollments();
 
@@ -443,13 +450,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['state[]' => ['active']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getActiveEnrollments();
 
@@ -475,13 +488,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['StudentEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getStudentEnrollments();
 
@@ -507,13 +526,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['TeacherEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getTeacherEnrollments();
 
@@ -539,13 +564,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['TaEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getTaEnrollments();
 
@@ -571,13 +602,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['ObserverEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getObserverEnrollments();
 
@@ -603,13 +640,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['DesignerEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->getDesignerEnrollments();
 
@@ -635,13 +678,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['user_id' => 101]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $hasUser = $course->hasUserEnrolled(101);
 
@@ -666,13 +715,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['user_id' => 101, 'type[]' => ['StudentEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $hasStudent = $course->hasUserEnrolled(101, 'StudentEnrollment');
 
@@ -687,13 +742,19 @@ class CourseTest extends TestCase
         $courseData = ['id' => 123, 'name' => 'Test Course'];
         $course = new Course($courseData);
 
-        $response = new Response(200, [], json_encode([]));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([]); // Empty array means no enrollments
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['user_id' => 101]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $hasUser = $course->hasUserEnrolled(101);
 
@@ -718,13 +779,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['user_id' => 101, 'type[]' => ['StudentEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $hasStudent = $course->hasStudentEnrolled(101);
 
@@ -749,13 +816,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['user_id' => 101, 'type[]' => ['TeacherEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $hasTeacher = $course->hasTeacherEnrolled(101);
 
@@ -787,13 +860,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['StudentEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $count = $course->getStudentCount();
 
@@ -818,13 +897,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['TeacherEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $count = $course->getTeacherCount();
 
@@ -856,13 +941,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => []])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $count = $course->getTotalEnrollmentCount();
 
@@ -920,13 +1011,19 @@ class CourseTest extends TestCase
             ]
         ];
 
-        $response = new Response(200, [], json_encode($enrollmentData));
+        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($enrollmentData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/enrollments', ['query' => ['type[]' => ['StudentEnrollment']]])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $enrollments = $course->enrollments(['type[]' => ['StudentEnrollment']]); // Method access with params
 

--- a/tests/Api/DiscussionTopics/DiscussionTopicTest.php
+++ b/tests/Api/DiscussionTopics/DiscussionTopicTest.php
@@ -36,7 +36,7 @@ class DiscussionTopicTest extends TestCase
         $reflection = new \ReflectionClass(DiscussionTopic::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -55,7 +55,7 @@ class DiscussionTopicTest extends TestCase
         $reflection = new \ReflectionClass(DiscussionTopic::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         DiscussionTopic::checkCourse();
     }
@@ -228,7 +228,7 @@ class DiscussionTopicTest extends TestCase
         $this->assertTrue($discussionTopic->getPublished());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -263,7 +263,7 @@ class DiscussionTopicTest extends TestCase
             ->with('courses/123/discussion_topics', ['query' => []])
             ->willReturn($responseMock);
 
-        $discussionTopics = DiscussionTopic::fetchAll();
+        $discussionTopics = DiscussionTopic::get();
 
         $this->assertIsArray($discussionTopics);
         $this->assertCount(2, $discussionTopics);

--- a/tests/Api/Enrollments/EnrollmentTest.php
+++ b/tests/Api/Enrollments/EnrollmentTest.php
@@ -655,7 +655,7 @@ class EnrollmentTest extends TestCase
             'user' => $userData
         ]);
 
-        $user = $enrollment->getUser();
+        $user = $enrollment->user();
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertEquals(100, $user->getId());
@@ -683,7 +683,7 @@ class EnrollmentTest extends TestCase
             ->method('get')
             ->willReturn($response);
 
-        $user = $enrollment->getUser();
+        $user = $enrollment->user();
 
         $this->assertInstanceOf(User::class, $user);
         $this->assertEquals(100, $user->getId());
@@ -695,7 +695,7 @@ class EnrollmentTest extends TestCase
     {
         $enrollment = new Enrollment(['id' => 1, 'userId' => null]);
 
-        $user = $enrollment->getUser();
+        $user = $enrollment->user();
 
         $this->assertNull($user);
     }
@@ -717,7 +717,7 @@ class EnrollmentTest extends TestCase
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage('Could not load user with ID 999');
 
-        $enrollment->getUser();
+        $enrollment->user();
     }
 
     public function testGetCourseFromStaticContext(): void
@@ -730,7 +730,7 @@ class EnrollmentTest extends TestCase
             'courseId' => 123
         ]);
 
-        $retrievedCourse = $enrollment->getCourse();
+        $retrievedCourse = $enrollment->course();
 
         $this->assertInstanceOf(Course::class, $retrievedCourse);
         $this->assertEquals(123, $retrievedCourse->getId());
@@ -760,7 +760,7 @@ class EnrollmentTest extends TestCase
             ->with('/courses/789')
             ->willReturn($response);
 
-        $course = $enrollment->getCourse();
+        $course = $enrollment->course();
 
         $this->assertInstanceOf(Course::class, $course);
         $this->assertEquals(789, $course->getId());
@@ -771,7 +771,7 @@ class EnrollmentTest extends TestCase
     {
         $enrollment = new Enrollment(['id' => 1, 'courseId' => null]);
 
-        $course = $enrollment->getCourse();
+        $course = $enrollment->course();
 
         $this->assertNull($course);
     }
@@ -792,7 +792,7 @@ class EnrollmentTest extends TestCase
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage('Could not load course with ID 999');
 
-        $enrollment->getCourse();
+        $enrollment->course();
     }
 
     // Enrollment Type Check Tests

--- a/tests/Api/Enrollments/EnrollmentTest.php
+++ b/tests/Api/Enrollments/EnrollmentTest.php
@@ -149,7 +149,7 @@ class EnrollmentTest extends TestCase
         $this->assertEquals('StudentEnrollment', $enrollment->getType());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseBody = json_encode([
             [
@@ -175,7 +175,7 @@ class EnrollmentTest extends TestCase
             ->with('courses/123/enrollments', ['query' => []])
             ->willReturn($response);
 
-        $enrollments = Enrollment::fetchAll();
+        $enrollments = Enrollment::get();
 
         $this->assertIsArray($enrollments);
         $this->assertCount(2, $enrollments);
@@ -185,7 +185,7 @@ class EnrollmentTest extends TestCase
         $this->assertEquals('TeacherEnrollment', $enrollments[1]->getType());
     }
 
-    public function testFetchAllWithParameters(): void
+    public function testGetWithParameters(): void
     {
         $params = [
             'type[]' => ['StudentEnrollment'],
@@ -210,7 +210,7 @@ class EnrollmentTest extends TestCase
             ->with('courses/123/enrollments', ['query' => $params])
             ->willReturn($response);
 
-        $enrollments = Enrollment::fetchAll($params);
+        $enrollments = Enrollment::get($params);
 
         $this->assertIsArray($enrollments);
         $this->assertCount(1, $enrollments);
@@ -399,7 +399,7 @@ class EnrollmentTest extends TestCase
         $this->assertEquals('active', $enrollment->getEnrollmentState());
     }
 
-    public function testFetchAllBySection(): void
+    public function testGetBySection(): void
     {
         $responseBody = json_encode([
             [
@@ -426,7 +426,7 @@ class EnrollmentTest extends TestCase
         $this->assertEquals(456, $enrollments[0]->getSectionId());
     }
 
-    public function testFetchAllByUser(): void
+    public function testGetByUser(): void
     {
         $responseBody = json_encode([
             [

--- a/tests/Api/ExternalTools/ExternalToolAccountContextTest.php
+++ b/tests/Api/ExternalTools/ExternalToolAccountContextTest.php
@@ -56,10 +56,13 @@ class ExternalToolAccountContextTest extends TestCase
     {
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn([
                 ['id' => 3, 'name' => 'Course Tool', 'consumer_key' => 'key3']
             ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->mockClient->expects($this->once())
             ->method('getPaginated')

--- a/tests/Api/ExternalTools/ExternalToolAccountContextTest.php
+++ b/tests/Api/ExternalTools/ExternalToolAccountContextTest.php
@@ -25,7 +25,7 @@ class ExternalToolAccountContextTest extends TestCase
         Config::setAccountId(1);
     }
 
-    public function testFetchAllUsesAccountContext(): void
+    public function testGetUsesAccountContext(): void
     {
         $toolsData = [
             ['id' => 1, 'name' => 'Tool 1', 'consumer_key' => 'key1'],
@@ -43,7 +43,7 @@ class ExternalToolAccountContextTest extends TestCase
             ->with('accounts/1/external_tools', ['query' => []])
             ->willReturn($mockResponse);
 
-        $tools = ExternalTool::fetchAll();
+        $tools = ExternalTool::get();
 
         $this->assertCount(2, $tools);
         $this->assertInstanceOf(ExternalTool::class, $tools[0]);
@@ -56,7 +56,7 @@ class ExternalToolAccountContextTest extends TestCase
     {
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn([
                 ['id' => 3, 'name' => 'Course Tool', 'consumer_key' => 'key3']
             ]);

--- a/tests/Api/ExternalTools/ExternalToolTest.php
+++ b/tests/Api/ExternalTools/ExternalToolTest.php
@@ -131,7 +131,7 @@ class ExternalToolTest extends TestCase
         $this->assertEquals('Test Tool', $tool->getName());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $toolsData = [
             ['id' => 1, 'name' => 'Tool 1', 'privacy_level' => 'public'],
@@ -147,7 +147,7 @@ class ExternalToolTest extends TestCase
             ->with('accounts/1/external_tools', ['query' => []])
             ->willReturn($this->mockResponse);
         
-        $tools = ExternalTool::fetchAll();
+        $tools = ExternalTool::get();
         
         $this->assertIsArray($tools);
         $this->assertCount(2, $tools);
@@ -155,7 +155,7 @@ class ExternalToolTest extends TestCase
         $this->assertEquals('Tool 1', $tools[0]->getName());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['include_parents' => true, 'placement' => 'editor_button'];
         $toolsData = [['id' => 1, 'name' => 'Tool 1', 'privacy_level' => 'public']];
@@ -169,7 +169,7 @@ class ExternalToolTest extends TestCase
             ->with('accounts/1/external_tools', ['query' => $params])
             ->willReturn($this->mockResponse);
         
-        $tools = ExternalTool::fetchAll($params);
+        $tools = ExternalTool::get($params);
         
         $this->assertIsArray($tools);
         $this->assertCount(1, $tools);

--- a/tests/Api/FeatureFlags/FeatureFlagTest.php
+++ b/tests/Api/FeatureFlags/FeatureFlagTest.php
@@ -37,7 +37,7 @@ class FeatureFlagTest extends TestCase
         return $mockResponse;
     }
 
-    public function testFetchAllUsesAccountContext(): void
+    public function testGetUsesAccountContext(): void
     {
         $expectedData = [
             [
@@ -60,7 +60,7 @@ class FeatureFlagTest extends TestCase
             ->with('accounts/1/features', ['query' => []])
             ->willReturn($mockResponse);
 
-        $features = FeatureFlag::fetchAll();
+        $features = FeatureFlag::get();
 
         $this->assertCount(1, $features);
         $this->assertInstanceOf(FeatureFlag::class, $features[0]);

--- a/tests/Api/Files/FileContextTest.php
+++ b/tests/Api/Files/FileContextTest.php
@@ -54,10 +54,13 @@ class FileContextTest extends TestCase
     {
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn([
                 ['id' => 3, 'filename' => 'syllabus.pdf', 'display_name' => 'Course Syllabus']
             ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->mockClient->expects($this->once())
             ->method('getPaginated')
@@ -76,10 +79,13 @@ class FileContextTest extends TestCase
     {
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn([
                 ['id' => 4, 'filename' => 'group_project.zip', 'display_name' => 'Group Project']
             ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->mockClient->expects($this->once())
             ->method('getPaginated')
@@ -98,10 +104,13 @@ class FileContextTest extends TestCase
     {
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn([
                 ['id' => 5, 'filename' => 'lecture.pdf', 'display_name' => 'Lecture Notes']
             ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
 
         $this->mockClient->expects($this->once())
             ->method('getPaginated')

--- a/tests/Api/GroupCategories/GroupCategoryTest.php
+++ b/tests/Api/GroupCategories/GroupCategoryTest.php
@@ -95,7 +95,7 @@ class GroupCategoryTest extends TestCase
         $this->assertEquals('Test Category', $category->name);
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $categoriesData = [
             ['id' => 1, 'name' => 'Category 1'],
@@ -113,7 +113,7 @@ class GroupCategoryTest extends TestCase
             ->with('accounts/1/group_categories', ['query' => []])
             ->willReturn($this->mockResponse);
 
-        $categories = GroupCategory::fetchAll();
+        $categories = GroupCategory::get();
 
         $this->assertIsArray($categories);
         $this->assertCount(2, $categories);
@@ -121,7 +121,7 @@ class GroupCategoryTest extends TestCase
         $this->assertEquals('Category 1', $categories[0]->name);
     }
 
-    public function testFetchAllFromAccount(): void
+    public function testGetFromAccount(): void
     {
         $categoriesData = [
             ['id' => 1, 'name' => 'Account Category 1'],
@@ -136,7 +136,7 @@ class GroupCategoryTest extends TestCase
             ->with('accounts/1/group_categories', ['query' => []])
             ->willReturn($this->mockResponse);
 
-        $categories = GroupCategory::fetchAll();
+        $categories = GroupCategory::get();
 
         $this->assertIsArray($categories);
         $this->assertCount(2, $categories);
@@ -282,7 +282,7 @@ class GroupCategoryTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($groupsData);
         
         $this->mockHttpClient->expects($this->once())

--- a/tests/Api/Groups/GroupContentMigrationTest.php
+++ b/tests/Api/Groups/GroupContentMigrationTest.php
@@ -41,7 +41,7 @@ class GroupContentMigrationTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')->willReturn($migrationsData);
+        $mockPaginatedResponse->method('all')->willReturn($migrationsData);
         
         $this->mockClient->method('getPaginated')
             ->with('groups/123/content_migrations', ['query' => []])

--- a/tests/Api/Groups/GroupMembershipTest.php
+++ b/tests/Api/Groups/GroupMembershipTest.php
@@ -75,22 +75,22 @@ class GroupMembershipTest extends TestCase
             ->with('groups/456/memberships/123')
             ->willReturn($this->mockResponse);
 
-        $membership = GroupMembership::find(123, 456);
+        $membership = GroupMembership::find(123, ['group_id' => 456]);
 
         $this->assertInstanceOf(GroupMembership::class, $membership);
         $this->assertEquals(123, $membership->id);
         $this->assertEquals(456, $membership->groupId);
     }
 
-    public function testFetchAllThrowsException(): void
+    public function testGetThrowsException(): void
     {
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage('Group ID is required. Use fetchAllForGroup($groupId, $params) instead.');
         
-        GroupMembership::fetchAll();
+        GroupMembership::get();
     }
 
-    public function testFetchAllForGroup(): void
+    public function testGetForGroup(): void
     {
         $membershipsData = [
             ['id' => 1, 'user_id' => 100, 'workflow_state' => 'accepted'],
@@ -99,7 +99,7 @@ class GroupMembershipTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($membershipsData);
         
         $this->mockHttpClient->expects($this->once())

--- a/tests/Api/Groups/GroupTest.php
+++ b/tests/Api/Groups/GroupTest.php
@@ -99,7 +99,7 @@ class GroupTest extends TestCase
         $this->assertEquals('Test Group', $group->name);
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $groupsData = [
             ['id' => 1, 'name' => 'Group 1'],
@@ -114,7 +114,7 @@ class GroupTest extends TestCase
             ->with('accounts/1/groups', ['query' => []])
             ->willReturn($this->mockResponse);
 
-        $groups = Group::fetchAll();
+        $groups = Group::get();
 
         $this->assertIsArray($groups);
         $this->assertCount(2, $groups);
@@ -244,7 +244,7 @@ class GroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($membersData);
         
         $this->mockHttpClient->expects($this->once())
@@ -373,7 +373,7 @@ class GroupTest extends TestCase
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($membershipsData);
         
         $this->mockHttpClient->expects($this->once())
@@ -432,7 +432,7 @@ class GroupTest extends TestCase
         
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn([$membershipData]);
         
         // Mock fetching memberships
@@ -460,7 +460,7 @@ class GroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($groupsData);
         
         $this->mockHttpClient->expects($this->once())
@@ -483,7 +483,7 @@ class GroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($groupsData);
         
         $this->mockHttpClient->expects($this->once())

--- a/tests/Api/Groups/GroupTest.php
+++ b/tests/Api/Groups/GroupTest.php
@@ -424,16 +424,18 @@ class GroupTest extends TestCase
         
         // Mock finding the membership
         $membershipData = [
-            'id' => 456,
-            'user_id' => 789,
-            'group_id' => 123,
-            'workflow_state' => 'accepted'
+            [
+                'id' => 456,
+                'user_id' => 789,
+                'group_id' => 123,
+                'workflow_state' => 'accepted'
+            ]
         ];
         
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
             ->method('all')
-            ->willReturn([$membershipData]);
+            ->willReturn($membershipData);
         
         // Mock fetching memberships
         $this->mockHttpClient->expects($this->once())

--- a/tests/Api/MediaObjects/MediaObjectTest.php
+++ b/tests/Api/MediaObjects/MediaObjectTest.php
@@ -57,7 +57,7 @@ class MediaObjectTest extends TestCase
     /**
      * Test fetching all media objects (global context)
      */
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $mockData = [
             'media_objects' => [
@@ -81,7 +81,7 @@ class MediaObjectTest extends TestCase
 
         $this->setHttpClient($mockClient);
 
-        $mediaObjects = MediaObject::fetchAll();
+        $mediaObjects = MediaObject::get();
 
         $this->assertIsArray($mediaObjects);
         $this->assertCount(1, $mediaObjects);
@@ -93,7 +93,7 @@ class MediaObjectTest extends TestCase
     /**
      * Test fetching media objects with parameters
      */
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = [
             'sort' => 'title',
@@ -111,7 +111,7 @@ class MediaObjectTest extends TestCase
 
         $this->setHttpClient($mockClient);
 
-        $mediaObjects = MediaObject::fetchAll($params);
+        $mediaObjects = MediaObject::get($params);
 
         $this->assertIsArray($mediaObjects);
         $this->assertEmpty($mediaObjects);

--- a/tests/Api/Modules/ModuleItemTest.php
+++ b/tests/Api/Modules/ModuleItemTest.php
@@ -199,7 +199,7 @@ class ModuleItemTest extends TestCase
         $this->assertEquals($moduleItemData['type'], $moduleItem->getType());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $moduleItemsData = [
             [
@@ -231,7 +231,7 @@ class ModuleItemTest extends TestCase
             )
             ->willReturn($this->mockResponse);
 
-        $moduleItems = ModuleItem::fetchAll();
+        $moduleItems = ModuleItem::get();
         
         $this->assertCount(2, $moduleItems);
         $this->assertContainsOnlyInstancesOf(ModuleItem::class, $moduleItems);
@@ -392,18 +392,32 @@ class ModuleItemTest extends TestCase
         $this->assertInstanceOf(ModuleItem::class, $result);
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
         $paginatedResponse = $this->createMock(PaginatedResponse::class);
+        $paginatedResponse->method('getJsonData')->willReturn([
+            ['id' => 1, 'title' => 'Item 1'],
+            ['id' => 2, 'title' => 'Item 2']
+        ]);
+        $paginatedResponse->method('toPaginationResult')->willReturnCallback(function ($data) {
+            return new \CanvasLMS\Pagination\PaginationResult(
+                $data,
+                [],
+                1,
+                1,
+                count($data)
+            );
+        });
 
         $this->httpClientMock->expects($this->once())
             ->method('getPaginated')
             ->with('courses/1/modules/2/items', ['query' => []])
             ->willReturn($paginatedResponse);
 
-        $result = ModuleItem::fetchAllPaginated();
+        $result = ModuleItem::paginate();
         
-        $this->assertSame($paginatedResponse, $result);
+        $this->assertInstanceOf(\CanvasLMS\Pagination\PaginationResult::class, $result);
+        $this->assertCount(2, $result->getData());
     }
 
     public function testModuleItemConstants(): void

--- a/tests/Api/Modules/ModuleRelationshipTest.php
+++ b/tests/Api/Modules/ModuleRelationshipTest.php
@@ -80,17 +80,17 @@ class ModuleRelationshipTest extends TestCase
             ]
         ];
 
-        // Set up mock expectations
-        $this->mockStream->method('getContents')
-            ->willReturn(json_encode($itemsData));
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($itemsData);
 
-        $this->mockResponse->method('getBody')
-            ->willReturn($this->mockStream);
-
+        // Set up mock expectations for paginated request
         $this->mockHttpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/modules/456/items', ['query' => []])
-            ->willReturn($this->mockResponse);
+            ->willReturn($mockPaginatedResponse);
 
         // Test the method
         $items = $module->items();
@@ -113,19 +113,19 @@ class ModuleRelationshipTest extends TestCase
             ['id' => 1, 'module_id' => 456, 'title' => 'Item 1']
         ];
 
-        // Set up mock expectations
-        $this->mockStream->method('getContents')
-            ->willReturn(json_encode($itemsData));
-
-        $this->mockResponse->method('getBody')
-            ->willReturn($this->mockStream);
-
         $params = ['include' => ['content_details'], 'per_page' => 50];
 
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($itemsData);
+
+        // Set up mock expectations for paginated request
         $this->mockHttpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/123/modules/456/items', ['query' => $params])
-            ->willReturn($this->mockResponse);
+            ->willReturn($mockPaginatedResponse);
 
         // Test the method
         $items = $module->items($params);

--- a/tests/Api/Modules/ModuleTest.php
+++ b/tests/Api/Modules/ModuleTest.php
@@ -191,7 +191,7 @@ class ModuleTest extends TestCase
         $this->assertEquals([['id' => 1], ['id' => 2]], $module->getItems());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $modulesData = [
             ['id' => 1, 'name' => 'Module 1'],
@@ -209,7 +209,7 @@ class ModuleTest extends TestCase
             ->with('courses/1/modules', ['query' => []])
             ->willReturn($response);
 
-        $modules = Module::fetchAll();
+        $modules = Module::get();
 
         $this->assertCount(2, $modules);
         $this->assertInstanceOf(Module::class, $modules[0]);
@@ -217,7 +217,7 @@ class ModuleTest extends TestCase
         $this->assertEquals('Module 2', $modules[1]->getName());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $modulesData = [
             ['id' => 1, 'name' => 'Introduction Module']
@@ -240,13 +240,13 @@ class ModuleTest extends TestCase
             ->with('courses/1/modules', ['query' => $params])
             ->willReturn($response);
 
-        $modules = Module::fetchAll($params);
+        $modules = Module::get($params);
 
         $this->assertCount(1, $modules);
         $this->assertEquals('Introduction Module', $modules[0]->getName());
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
         $response = $this->createMock(ResponseInterface::class);
         $stream = $this->createMock(StreamInterface::class);
@@ -264,10 +264,10 @@ class ModuleTest extends TestCase
             ->with('courses/1/modules', ['query' => ['per_page' => 10]])
             ->willReturn($paginatedResponse);
 
-        $result = Module::fetchAllPaginated(['per_page' => 10]);
+        $result = Module::paginate(['per_page' => 10]);
 
-        $this->assertInstanceOf(PaginatedResponse::class, $result);
-        $data = $result->getJsonData();
+        $this->assertInstanceOf(\CanvasLMS\Pagination\PaginationResult::class, $result);
+        $data = $result->getData();
         $this->assertCount(1, $data);
     }
 

--- a/tests/Api/Modules/ModuleTest.php
+++ b/tests/Api/Modules/ModuleTest.php
@@ -564,16 +564,16 @@ class ModuleTest extends TestCase
             ['id' => 2, 'title' => 'Item 2']
         ];
 
-        $response = $this->createMock(ResponseInterface::class);
-        $stream = $this->createMock(StreamInterface::class);
-        
-        $stream->method('getContents')->willReturn(json_encode($itemsData));
-        $response->method('getBody')->willReturn($stream);
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($itemsData);
 
         $this->httpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/1/modules/123/items', ['query' => []])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $items = $module->items();
 
@@ -589,18 +589,18 @@ class ModuleTest extends TestCase
             ['id' => 1, 'title' => 'Item 1', 'content_details' => ['points_possible' => 10]]
         ];
 
-        $response = $this->createMock(ResponseInterface::class);
-        $stream = $this->createMock(StreamInterface::class);
-        
-        $stream->method('getContents')->willReturn(json_encode($itemsData));
-        $response->method('getBody')->willReturn($stream);
-
         $params = ['include' => ['content_details']];
 
+        // Mock paginated response
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($itemsData);
+
         $this->httpClient->expects($this->once())
-            ->method('get')
+            ->method('getPaginated')
             ->with('courses/1/modules/123/items', ['query' => $params])
-            ->willReturn($response);
+            ->willReturn($mockPaginatedResponse);
 
         $items = $module->items($params);
 

--- a/tests/Api/OutcomeGroups/OutcomeGroupTest.php
+++ b/tests/Api/OutcomeGroups/OutcomeGroupTest.php
@@ -34,23 +34,26 @@ class OutcomeGroupTest extends TestCase
         Config::setAccountId(1);
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             ['id' => 1, 'title' => 'Group 1'],
             ['id' => 2, 'title' => 'Group 2']
         ];
 
-        $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
-            ->willReturn($responseData);
+        $mockResponse = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
+        $mockStream = $this->createMock(\Psr\Http\Message\StreamInterface::class);
+        $mockStream->method('getContents')
+            ->willReturn(json_encode($responseData));
+        $mockResponse->method('getBody')
+            ->willReturn($mockStream);
 
         $this->mockClient->expects($this->once())
-            ->method('getPaginated')
+            ->method('get')
             ->with('accounts/1/outcome_groups', ['query' => []])
-            ->willReturn($mockPaginatedResponse);
+            ->willReturn($mockResponse);
 
-        $groups = OutcomeGroup::fetchAll();
+        $groups = OutcomeGroup::get();
 
         $this->assertCount(2, $groups);
         $this->assertInstanceOf(OutcomeGroup::class, $groups[0]);
@@ -66,7 +69,7 @@ class OutcomeGroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($responseData);
 
         $this->mockClient->expects($this->once())
@@ -185,7 +188,7 @@ class OutcomeGroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($responseData);
 
         $this->mockClient->expects($this->once())
@@ -289,7 +292,7 @@ class OutcomeGroupTest extends TestCase
         $this->assertEquals('/api/v1/accounts/1/outcome_groups/123/outcomes/789', $link->url);
     }
 
-    public function testFetchAllLinks(): void
+    public function testGetLinks(): void
     {
         $responseData = [
             [
@@ -300,7 +303,7 @@ class OutcomeGroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($responseData);
 
         $this->mockClient->expects($this->once())
@@ -315,7 +318,7 @@ class OutcomeGroupTest extends TestCase
         $this->assertEquals('/api/v1/accounts/1/outcome_group_links/1', $links[0]->url);
     }
 
-    public function testFetchAllLinksByContext(): void
+    public function testGetLinksByContext(): void
     {
         $responseData = [
             [
@@ -325,7 +328,7 @@ class OutcomeGroupTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($responseData);
 
         $this->mockClient->expects($this->once())

--- a/tests/Api/OutcomeResults/OutcomeResultTest.php
+++ b/tests/Api/OutcomeResults/OutcomeResultTest.php
@@ -30,7 +30,7 @@ class OutcomeResultTest extends TestCase
         Config::setAccountId(1);
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -76,7 +76,7 @@ class OutcomeResultTest extends TestCase
         $this->assertEquals(1001, $results[0]->links['user']);
     }
 
-    public function testFetchAllWithUserAndOutcomeIds(): void
+    public function testGetWithUserAndOutcomeIds(): void
     {
         $responseData = [
             [
@@ -115,7 +115,7 @@ class OutcomeResultTest extends TestCase
         $this->assertEquals(2002, $results[0]->links['learning_outcome']);
     }
 
-    public function testFetchAllWithIncludeParameter(): void
+    public function testGetWithIncludeParameter(): void
     {
         $responseData = [
             [
@@ -165,7 +165,7 @@ class OutcomeResultTest extends TestCase
         $this->assertEquals('Essay Assignment', $results[0]->alignment['name']);
     }
 
-    public function testFetchAllReturnsEmptyArrayOnNoResults(): void
+    public function testGetReturnsEmptyArrayOnNoResults(): void
     {
         $this->mockStream->method('getContents')
             ->willReturn(json_encode([]));
@@ -184,7 +184,7 @@ class OutcomeResultTest extends TestCase
         $this->assertEmpty($results);
     }
 
-    public function testFetchAllWithPagination(): void
+    public function testGetWithPagination(): void
     {
         $responseData = [
             ['id' => 1, 'score' => 3.5],

--- a/tests/Api/Outcomes/OutcomeTest.php
+++ b/tests/Api/Outcomes/OutcomeTest.php
@@ -32,7 +32,7 @@ class OutcomeTest extends TestCase
         Config::setAccountId(1);
     }
 
-    public function testFetchAllUsesAccountContext(): void
+    public function testGetUsesAccountContext(): void
     {
         $expectedData = [
             [
@@ -53,7 +53,7 @@ class OutcomeTest extends TestCase
             ->with('accounts/1/outcome_groups/global/outcomes', ['query' => []])
             ->willReturn($this->mockResponse);
         
-        $outcomes = Outcome::fetchAll();
+        $outcomes = Outcome::get();
         
         $this->assertCount(1, $outcomes);
         $this->assertInstanceOf(Outcome::class, $outcomes[0]);
@@ -72,7 +72,7 @@ class OutcomeTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')
+        $mockPaginatedResponse->method('all')
             ->willReturn($expectedData);
         
         $this->mockClient->expects($this->once())

--- a/tests/Api/Pages/PageTest.php
+++ b/tests/Api/Pages/PageTest.php
@@ -934,7 +934,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages/test-page/revisions')
             ->willReturn($responseMock);
 
-        $revisions = $page->getRevisions();
+        $revisions = $page->revisions();
 
         $this->assertCount(2, $revisions);
         $this->assertInstanceOf(PageRevision::class, $revisions[0]);
@@ -949,7 +949,7 @@ class PageTest extends TestCase
         $this->expectExceptionMessage('Page URL is required');
 
         $page = new Page();
-        $page->getRevisions();
+        $page->revisions();
     }
 
     public function testToArray(): void
@@ -1102,7 +1102,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages/test-page/revisions/3', ['query' => []])
             ->willReturn($responseMock);
 
-        $revision = $page->getRevision(3);
+        $revision = $page->revision(3);
 
         $this->assertInstanceOf(PageRevision::class, $revision);
         $this->assertEquals(3, $revision->getRevisionId());
@@ -1134,7 +1134,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages/test-page/revisions/latest', ['query' => []])
             ->willReturn($responseMock);
 
-        $revision = $page->getRevision('latest');
+        $revision = $page->revision('latest');
 
         $this->assertInstanceOf(PageRevision::class, $revision);
         $this->assertTrue($revision->getLatest());
@@ -1167,7 +1167,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages/test-page/revisions/3', ['query' => ['summary' => true]])
             ->willReturn($responseMock);
 
-        $revision = $page->getRevision(3, true);
+        $revision = $page->revision(3, true);
 
         $this->assertInstanceOf(PageRevision::class, $revision);
         $this->assertNull($revision->getBody());

--- a/tests/Api/Pages/PageTest.php
+++ b/tests/Api/Pages/PageTest.php
@@ -37,7 +37,7 @@ class PageTest extends TestCase
         $reflection = new \ReflectionClass(Page::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -56,7 +56,7 @@ class PageTest extends TestCase
         $reflection = new \ReflectionClass(Page::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         Page::checkCourse();
     }
@@ -331,7 +331,7 @@ class PageTest extends TestCase
         $this->assertEquals('Test Page With Spaces', $page->getTitle());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -364,7 +364,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages', ['query' => []])
             ->willReturn($responseMock);
 
-        $pages = Page::fetchAll();
+        $pages = Page::get();
 
         $this->assertCount(2, $pages);
         $this->assertInstanceOf(Page::class, $pages[0]);
@@ -375,7 +375,7 @@ class PageTest extends TestCase
         $this->assertEquals('Page 2', $pages[1]->getTitle());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['published' => true, 'sort' => 'title'];
         $responseData = [];
@@ -396,14 +396,14 @@ class PageTest extends TestCase
             ->with('courses/123/pages', ['query' => $params])
             ->willReturn($responseMock);
 
-        $pages = Page::fetchAll($params);
+        $pages = Page::get($params);
 
         $this->assertCount(0, $pages);
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
-        $this->assertTrue(method_exists(Page::class, 'fetchAllPaginated'));
+        $this->assertTrue(method_exists(Page::class, 'paginate'));
     }
 
     public function testCreate(): void
@@ -1245,7 +1245,7 @@ class PageTest extends TestCase
         $this->assertTrue($frontPage->getFrontPage());
     }
 
-    public function testFetchAllWithQueryParams(): void
+    public function testGetWithQueryParams(): void
     {
         $params = [
             'sort' => 'title',
@@ -1289,7 +1289,7 @@ class PageTest extends TestCase
             ->with('courses/123/pages', ['query' => $expectedParams])
             ->willReturn($responseMock);
 
-        $pages = Page::fetchAll($params);
+        $pages = Page::get($params);
 
         $this->assertCount(2, $pages);
         $this->assertEquals('Test Page 1', $pages[0]->getTitle());

--- a/tests/Api/Progress/ProgressTest.php
+++ b/tests/Api/Progress/ProgressTest.php
@@ -277,12 +277,12 @@ class ProgressTest extends TestCase
         $this->assertEquals(['success' => true], $progress->getResults());
     }
 
-    public function testFetchAllThrowsException(): void
+    public function testGetThrowsException(): void
     {
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage('Progress API does not support listing all progress objects. Use find() with specific ID.');
 
-        Progress::fetchAll();
+        Progress::get();
     }
 
     public function testAllGettersAndSetters(): void

--- a/tests/Api/QuizSubmissions/QuizSubmissionTest.php
+++ b/tests/Api/QuizSubmissions/QuizSubmissionTest.php
@@ -313,7 +313,7 @@ class QuizSubmissionTest extends TestCase
         QuizSubmission::getCurrentUserSubmission();
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $expectedData = [
             'quiz_submissions' => [
@@ -338,7 +338,7 @@ class QuizSubmissionTest extends TestCase
             ->with('courses/123/quizzes/456/submissions', ['query' => []])
             ->willReturn($response);
 
-        $submissions = QuizSubmission::fetchAll();
+        $submissions = QuizSubmission::get();
 
         $this->assertIsArray($submissions);
         $this->assertCount(2, $submissions);
@@ -348,7 +348,7 @@ class QuizSubmissionTest extends TestCase
         $this->assertEquals(790, $submissions[1]->getId());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['include' => ['user', 'quiz']];
         $responseData = ['quiz_submissions' => []];
@@ -359,21 +359,32 @@ class QuizSubmissionTest extends TestCase
             ->with('courses/123/quizzes/456/submissions', ['query' => $params])
             ->willReturn($response);
 
-        QuizSubmission::fetchAll($params);
+        QuizSubmission::get($params);
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
         $paginatedResponse = $this->createMock(PaginatedResponse::class);
+        $paginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([
+                ['id' => 1, 'quiz_id' => 456, 'user_id' => 789],
+                ['id' => 2, 'quiz_id' => 456, 'user_id' => 790]
+            ]);
+        
+        $paginatedResponse->expects($this->once())
+            ->method('toPaginationResult')
+            ->with($this->isType('array'))
+            ->willReturn($this->createMock(PaginationResult::class));
 
         $this->httpClient->expects($this->once())
             ->method('getPaginated')
             ->with('courses/123/quizzes/456/submissions', ['query' => []])
             ->willReturn($paginatedResponse);
 
-        $result = QuizSubmission::fetchAllPaginated();
+        $result = QuizSubmission::paginate();
 
-        $this->assertSame($paginatedResponse, $result);
+        $this->assertInstanceOf(PaginationResult::class, $result);
     }
 
     public function testCreate(): void

--- a/tests/Api/Quizzes/QuizTest.php
+++ b/tests/Api/Quizzes/QuizTest.php
@@ -36,7 +36,7 @@ class QuizTest extends TestCase
         $reflection = new \ReflectionClass(Quiz::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -55,7 +55,7 @@ class QuizTest extends TestCase
         $reflection = new \ReflectionClass(Quiz::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         Quiz::checkCourse();
     }
@@ -283,7 +283,7 @@ class QuizTest extends TestCase
         $this->assertEquals('assignment', $quiz->getQuizType());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $quizzesData = [
             ['id' => 1, 'title' => 'Quiz 1', 'quiz_type' => 'assignment'],
@@ -306,7 +306,7 @@ class QuizTest extends TestCase
             ->with('courses/123/quizzes', ['query' => []])
             ->willReturn($responseMock);
 
-        $quizzes = Quiz::fetchAll();
+        $quizzes = Quiz::get();
 
         $this->assertIsArray($quizzes);
         $this->assertCount(2, $quizzes);
@@ -316,7 +316,7 @@ class QuizTest extends TestCase
         $this->assertEquals('Quiz 2', $quizzes[1]->getTitle());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['published' => true];
         $quizzesData = [
@@ -339,7 +339,7 @@ class QuizTest extends TestCase
             ->with('courses/123/quizzes', ['query' => $params])
             ->willReturn($responseMock);
 
-        $quizzes = Quiz::fetchAll($params);
+        $quizzes = Quiz::get($params);
 
         $this->assertIsArray($quizzes);
         $this->assertCount(1, $quizzes);

--- a/tests/Api/Rubrics/RubricAccountContextTest.php
+++ b/tests/Api/Rubrics/RubricAccountContextTest.php
@@ -66,8 +66,11 @@ class RubricAccountContextTest extends TestCase
         $mockResponse = new Response(200, [], json_encode($rubricsData));
         $paginatedResponse = $this->createMock(PaginatedResponse::class);
         $paginatedResponse->expects($this->once())
-            ->method('all')
+            ->method('getJsonData')
             ->willReturn($rubricsData);
+        $paginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null); // No more pages
         
         $this->httpClientMock->expects($this->once())
             ->method('getPaginated')

--- a/tests/Api/Rubrics/RubricAccountContextTest.php
+++ b/tests/Api/Rubrics/RubricAccountContextTest.php
@@ -31,7 +31,7 @@ class RubricAccountContextTest extends TestCase
     /**
      * Test fetching rubrics from account context (default)
      */
-    public function testFetchAllFromAccountContext(): void
+    public function testGetFromAccountContext(): void
     {
         $rubricsData = [
             ['id' => 1, 'title' => 'Account Rubric 1', 'context_type' => 'Account', 'context_id' => 1],
@@ -45,7 +45,7 @@ class RubricAccountContextTest extends TestCase
             ->with('accounts/1/rubrics', ['query' => []])
             ->willReturn($mockResponse);
         
-        $rubrics = Rubric::fetchAll();
+        $rubrics = Rubric::get();
         
         $this->assertCount(2, $rubrics);
         $this->assertInstanceOf(Rubric::class, $rubrics[0]);
@@ -66,7 +66,7 @@ class RubricAccountContextTest extends TestCase
         $mockResponse = new Response(200, [], json_encode($rubricsData));
         $paginatedResponse = $this->createMock(PaginatedResponse::class);
         $paginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($rubricsData);
         
         $this->httpClientMock->expects($this->once())

--- a/tests/Api/Rubrics/RubricAssessmentTest.php
+++ b/tests/Api/Rubrics/RubricAssessmentTest.php
@@ -240,12 +240,12 @@ class RubricAssessmentTest extends TestCase
     /**
      * Test fetchAll method throws exception
      */
-    public function testFetchAllThrowsException(): void
+    public function testGetThrowsException(): void
     {
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage("Fetching all rubric assessments is not supported");
 
-        RubricAssessment::fetchAll();
+        RubricAssessment::get();
     }
 
     /**

--- a/tests/Api/Rubrics/RubricAssociationTest.php
+++ b/tests/Api/Rubrics/RubricAssociationTest.php
@@ -183,12 +183,12 @@ class RubricAssociationTest extends TestCase
     /**
      * Test fetchAll method throws exception
      */
-    public function testFetchAllThrowsException(): void
+    public function testGetThrowsException(): void
     {
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage("Fetching all rubric associations is not supported");
 
-        RubricAssociation::fetchAll();
+        RubricAssociation::get();
     }
 
     /**

--- a/tests/Api/Rubrics/RubricTest.php
+++ b/tests/Api/Rubrics/RubricTest.php
@@ -506,7 +506,7 @@ class RubricTest extends TestCase
     /**
      * Test fetchAll rubrics (test method existence and context handling)
      */
-    public function testFetchAllRubrics(): void
+    public function testGetRubrics(): void
     {
         // Testing that fetchAll method works with context parameters
         // Due to pagination complexity, we'll just test that the method exists and handles context
@@ -519,7 +519,7 @@ class RubricTest extends TestCase
         Rubric::setCourse(null);
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage("Course context is required for course-scoped rubric operations");
-        Rubric::fetchAll([]);
+        Rubric::get([]);
     }
 
     /**

--- a/tests/Api/SubmissionComments/SubmissionCommentTest.php
+++ b/tests/Api/SubmissionComments/SubmissionCommentTest.php
@@ -43,11 +43,11 @@ class SubmissionCommentTest extends TestCase
         
         $courseProperty = $reflection->getProperty('course');
         $courseProperty->setAccessible(true);
-        $courseProperty->setValue(null, new Course(['id' => 0]));
+        $courseProperty->setValue(null, null);
         
         $assignmentProperty = $reflection->getProperty('assignment');
         $assignmentProperty->setAccessible(true);
-        $assignmentProperty->setValue(null, new Assignment(['id' => 0]));
+        $assignmentProperty->setValue(null, null);
         
         $userIdProperty = $reflection->getProperty('userId');
         $userIdProperty->setAccessible(true);

--- a/tests/Api/Submissions/SubmissionTest.php
+++ b/tests/Api/Submissions/SubmissionTest.php
@@ -42,11 +42,11 @@ class SubmissionTest extends TestCase
         
         $courseProperty = $reflection->getProperty('course');
         $courseProperty->setAccessible(true);
-        $courseProperty->setValue(null, new Course(['id' => 0]));
+        $courseProperty->setValue(null, null);
         
         $assignmentProperty = $reflection->getProperty('assignment');
         $assignmentProperty->setAccessible(true);
-        $assignmentProperty->setValue(null, new Assignment(['id' => 0]));
+        $assignmentProperty->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -592,7 +592,7 @@ class SubmissionTest extends TestCase
         $submission->save();
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -627,7 +627,7 @@ class SubmissionTest extends TestCase
             ->with('courses/123/assignments/456/submissions')
             ->willReturn($responseMock);
 
-        $submissions = Submission::fetchAll();
+        $submissions = Submission::get();
 
         $this->assertCount(2, $submissions);
         $this->assertInstanceOf(Submission::class, $submissions[0]);
@@ -636,7 +636,7 @@ class SubmissionTest extends TestCase
         $this->assertEquals(222, $submissions[1]->getUserId());
     }
 
-    public function testFetchAllWithParameters(): void
+    public function testGetWithParameters(): void
     {
         $params = [
             'student_ids' => [111, 222],
@@ -660,7 +660,7 @@ class SubmissionTest extends TestCase
             ->with('courses/123/assignments/456/submissions', ['query' => $params])
             ->willReturn($response);
 
-        $submissions = Submission::fetchAll($params);
+        $submissions = Submission::get($params);
         
         $this->assertCount(2, $submissions);
         $this->assertEquals(111, $submissions[0]->getUserId());

--- a/tests/Api/Tabs/TabTest.php
+++ b/tests/Api/Tabs/TabTest.php
@@ -36,7 +36,7 @@ class TabTest extends TestCase
         $reflection = new \ReflectionClass(Tab::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course(['id' => 0]));
+        $property->setValue(null, null);
     }
 
     public function testSetCourse(): void
@@ -58,7 +58,7 @@ class TabTest extends TestCase
         $reflection = new \ReflectionClass(Tab::class);
         $property = $reflection->getProperty('course');
         $property->setAccessible(true);
-        $property->setValue(null, new Course([]));
+        $property->setValue(null, null);
 
         Tab::checkCourse();
     }
@@ -112,7 +112,7 @@ class TabTest extends TestCase
         $this->assertEquals(1, $tab->getPosition());
     }
 
-    public function testFetchAll(): void
+    public function testGet(): void
     {
         $responseData = [
             [
@@ -151,7 +151,7 @@ class TabTest extends TestCase
             ->with('courses/123/tabs', ['query' => []])
             ->willReturn($responseMock);
 
-        $tabs = Tab::fetchAll();
+        $tabs = Tab::get();
 
         $this->assertCount(2, $tabs);
         $this->assertInstanceOf(Tab::class, $tabs[0]);
@@ -159,7 +159,7 @@ class TabTest extends TestCase
         $this->assertEquals('assignments', $tabs[1]->getId());
     }
 
-    public function testFetchAllWithParams(): void
+    public function testGetWithParams(): void
     {
         $params = ['include' => ['course_subject_tabs']];
         $responseData = [];
@@ -180,12 +180,12 @@ class TabTest extends TestCase
             ->with('courses/123/tabs', ['query' => $params])
             ->willReturn($responseMock);
 
-        $tabs = Tab::fetchAll($params);
+        $tabs = Tab::get($params);
 
         $this->assertCount(0, $tabs);
     }
 
-    public function testFetchAllPaginated(): void
+    public function testGetPaginated(): void
     {
         $paginatedResponseMock = $this->createMock(PaginatedResponse::class);
 
@@ -199,7 +199,7 @@ class TabTest extends TestCase
 
         // Since we can't easily mock static methods, we'll test that the method exists
         // and returns the expected type from the parent class
-        $this->assertTrue(method_exists(Tab::class, 'fetchAllPaginated'));
+        $this->assertTrue(method_exists(Tab::class, 'paginate'));
     }
 
     public function testUpdate(): void
@@ -371,7 +371,7 @@ class TabTest extends TestCase
     {
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage(
-            'Canvas API does not support finding individual tabs by ID. Use fetchAll() to retrieve all tabs.'
+            'Canvas API does not support finding individual tabs by ID. Use get() to retrieve all tabs.'
         );
 
         Tab::find(123);

--- a/tests/Api/Users/UserContentMigrationTest.php
+++ b/tests/Api/Users/UserContentMigrationTest.php
@@ -41,7 +41,7 @@ class UserContentMigrationTest extends TestCase
         ];
 
         $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
-        $mockPaginatedResponse->method('fetchAllPages')->willReturn($migrationsData);
+        $mockPaginatedResponse->method('all')->willReturn($migrationsData);
         
         $this->mockClient->method('getPaginated')
             ->with('users/123/content_migrations', ['query' => []])

--- a/tests/Api/Users/UserRelationshipTest.php
+++ b/tests/Api/Users/UserRelationshipTest.php
@@ -144,7 +144,7 @@ class UserRelationshipTest extends TestCase
         // Mock paginated response
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
         $mockPaginatedResponse->expects($this->once())
-            ->method('fetchAllPages')
+            ->method('all')
             ->willReturn($groupsData);
 
         // Set up mock expectations for paginated request

--- a/tests/Api/Users/UserTest.php
+++ b/tests/Api/Users/UserTest.php
@@ -407,7 +407,7 @@ class UserTest extends TestCase
             ->willReturn($response);
         
         $currentUser = User::self();
-        $profile = $currentUser->getProfile();
+        $profile = $currentUser->profile();
         
         $this->assertEquals('Current User', $profile->name);
     }
@@ -527,7 +527,7 @@ class UserTest extends TestCase
         $currentUser = User::fetchSelf();
         
         // Now use a method that requires ID
-        $profile = $currentUser->getProfile();
+        $profile = $currentUser->profile();
         
         $this->assertEquals('Test bio', $profile->bio);
     }
@@ -579,7 +579,7 @@ class UserTest extends TestCase
         
         // First mock for User::find()
         $userResponse = new Response(200, [], json_encode($userData));
-        // Second mock for getProfile()
+        // Second mock for profile()
         $profileResponse = new Response(200, [], json_encode($profileData));
         
         $this->httpClientMock
@@ -596,7 +596,7 @@ class UserTest extends TestCase
         $user = User::find($userId);
         $this->assertEquals($userId, $user->getId());
         
-        $profile = $user->getProfile();
+        $profile = $user->profile();
         $this->assertEquals('Specific User', $profile->name);
     }
 
@@ -634,13 +634,16 @@ class UserTest extends TestCase
             ['id' => 2, 'name' => 'Group 2']
         ];
         
-        $response = new Response(200, [], json_encode($groupsData));
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($groupsData);
         
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
-            ->with('users/self/groups', $this->anything())
-            ->willReturn($response);
+            ->method('getPaginated')
+            ->with('users/self/groups', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
         
         $currentUser = User::self();
         $groups = $currentUser->groups();
@@ -736,13 +739,16 @@ class UserTest extends TestCase
             ]
         ];
         
-        $response = new Response(200, [], json_encode($loginData));
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('all')
+            ->willReturn($loginData);
         
         $this->httpClientMock
             ->expects($this->once())
-            ->method('get')
-            ->with('users/self/logins', $this->anything())
-            ->willReturn($response);
+            ->method('getPaginated')
+            ->with('users/self/logins', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
         
         $user = User::self();
         $logins = $user->logins();

--- a/tests/Pagination/EdgeCaseTest.php
+++ b/tests/Pagination/EdgeCaseTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace CanvasLMS\Tests\Pagination;
+
+use PHPUnit\Framework\TestCase;
+use CanvasLMS\Api\Courses\Course;
+use CanvasLMS\Api\Enrollments\Enrollment;
+use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use CanvasLMS\Config;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Edge Case Tests for Pagination
+ *
+ * Tests handling of large datasets, rate limiting, and timeout scenarios
+ */
+class EdgeCaseTest extends TestCase
+{
+    private $mockHttpClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
+        Course::setApiClient($this->mockHttpClient);
+        Enrollment::setApiClient($this->mockHttpClient);
+        Config::setBaseUrl('https://canvas.example.com/api/v1');
+        Config::setApiKey('test-api-key');
+        Config::setAccountId(1);
+    }
+
+    /**
+     * Test handling of large dataset with 100 pages
+     */
+    public function testLargeDatasetPagination(): void
+    {
+        // Create mock responses for 100 pages
+        $totalPages = 100;
+        $itemsPerPage = 100;
+        $responses = [];
+
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $items = [];
+            for ($i = 0; $i < $itemsPerPage; $i++) {
+                $items[] = [
+                    'id' => ($page - 1) * $itemsPerPage + $i + 1,
+                    'name' => "Course " . (($page - 1) * $itemsPerPage + $i + 1),
+                    'course_code' => "COURSE" . (($page - 1) * $itemsPerPage + $i + 1),
+                    'workflow_state' => 'available'
+                ];
+            }
+
+            $nextPage = $page < $totalPages ? $page + 1 : null;
+            $prevPage = $page > 1 ? $page - 1 : null;
+
+            $linkHeader = $this->buildLinkHeader($page, $totalPages, $nextPage, $prevPage);
+
+            $mockResponse = $this->createMock(ResponseInterface::class);
+            $mockStream = $this->createMock(StreamInterface::class);
+            $mockStream->method('getContents')->willReturn(json_encode($items));
+            $mockResponse->method('getBody')->willReturn($mockStream);
+            $mockResponse->method('getHeader')->with('Link')->willReturn([$linkHeader]);
+
+            $responses[] = $mockResponse;
+        }
+
+        // Set up expectations for getPaginated and subsequent get calls
+        $this->mockHttpClient->expects($this->exactly($totalPages - 1))
+            ->method('get')
+            ->willReturnCallback(function($path) use ($responses) {
+                static $callCount = 1; // Start from index 1 since first response is used in getPaginated
+                return $responses[$callCount++];
+            });
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->willReturn(new PaginatedResponse($responses[0], $this->mockHttpClient));
+
+        // Execute the test - use Course instead of Enrollment
+        $startTime = microtime(true);
+        $allCourses = Course::all();
+        $duration = microtime(true) - $startTime;
+
+        // Assertions
+        $this->assertCount($totalPages * $itemsPerPage, $allCourses);
+        $this->assertEquals(1, $allCourses[0]->id);
+        $this->assertEquals(10000, $allCourses[9999]->id);
+
+        // Verify all items are Course objects
+        foreach ($allCourses as $course) {
+            $this->assertInstanceOf(Course::class, $course);
+        }
+
+        // Performance check - should complete in reasonable time
+        $this->assertLessThan(60, $duration, 'Large dataset pagination took too long');
+    }
+
+    /**
+     * Test rate limit handling during pagination
+     */
+    public function testRateLimitHandlingDuringPagination(): void
+    {
+        // First response - successful
+        $firstPageData = [
+            ['id' => 1, 'name' => 'Course 1'],
+            ['id' => 2, 'name' => 'Course 2']
+        ];
+
+        $linkHeader = '<https://canvas.example.com/api/v1/courses?page=2>; rel="next", ' .
+                     '<https://canvas.example.com/api/v1/courses?page=1>; rel="current", ' .
+                     '<https://canvas.example.com/api/v1/courses?page=3>; rel="last"';
+
+        $mockFirstResponse = $this->createMock(ResponseInterface::class);
+        $mockFirstStream = $this->createMock(StreamInterface::class);
+        $mockFirstStream->method('getContents')->willReturn(json_encode($firstPageData));
+        $mockFirstResponse->method('getBody')->willReturn($mockFirstStream);
+        $mockFirstResponse->method('getHeader')->with('Link')->willReturn([$linkHeader]);
+
+        // Second call - rate limited (429)
+        $rateLimitException = new RequestException(
+            'Too Many Requests',
+            new Request('GET', '/courses?page=2'),
+            new Response(429, ['Retry-After' => '2'])
+        );
+
+        // Since rate limiting returns null on failure, we won't get additional pages
+        // The actual behavior is that pagination stops when an error occurs
+
+        // Set up mock expectations
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->willReturn(new PaginatedResponse($mockFirstResponse, $this->mockHttpClient));
+
+        // The first get() call will throw the rate limit exception
+        // PaginatedResponse::fetchUrl returns null on error, stopping pagination
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->willThrowException($rateLimitException);
+
+        // Execute - will get first page, then stop on rate limit
+        $allCourses = Course::all();
+
+        // Should get only the first page due to rate limiting
+        $this->assertCount(2, $allCourses);
+        $this->assertEquals('Course 1', $allCourses[0]->name);
+        $this->assertEquals('Course 2', $allCourses[1]->name);
+    }
+
+    /**
+     * Test timeout handling during pagination
+     */
+    public function testTimeoutHandlingDuringPagination(): void
+    {
+        // First page - successful
+        $firstPageData = [
+            ['id' => 1, 'name' => 'Module 1'],
+            ['id' => 2, 'name' => 'Module 2']
+        ];
+
+        $linkHeader = '<https://canvas.example.com/api/v1/courses/1/modules?page=2>; rel="next"';
+
+        $mockFirstResponse = $this->createMock(ResponseInterface::class);
+        $mockFirstStream = $this->createMock(StreamInterface::class);
+        $mockFirstStream->method('getContents')->willReturn(json_encode($firstPageData));
+        $mockFirstResponse->method('getBody')->willReturn($mockFirstStream);
+        $mockFirstResponse->method('getHeader')->with('Link')->willReturn([$linkHeader]);
+
+        // Second page - timeout
+        $timeoutException = new RequestException(
+            'Connection timeout',
+            new Request('GET', '/courses/1/modules?page=2'),
+            null,
+            null,
+            ['errno' => CURLE_OPERATION_TIMEDOUT]
+        );
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->willReturn(new PaginatedResponse($mockFirstResponse, $this->mockHttpClient));
+
+        // Simulate timeout on second page fetch
+        $this->mockHttpClient->expects($this->once())
+            ->method('get')
+            ->willThrowException($timeoutException);
+
+        // Execute - all() should handle timeout and return partial results
+        $modules = Course::all();
+
+        // With timeout, we should get at least the first page
+        // The actual behavior depends on error handling implementation
+        // For now, we expect it to fail gracefully and return what it has
+        $this->assertNotNull($modules);
+    }
+
+    /**
+     * Test memory-efficient pagination with paginate() method
+     */
+    public function testMemoryEfficientPaginationWithPaginateMethod(): void
+    {
+        $processedCount = 0;
+        $perPage = 100;
+        $totalPages = 10;
+
+        // Set up mock responses for all pages
+        $responses = [];
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $items = [];
+            for ($i = 0; $i < $perPage; $i++) {
+                $itemId = ($page - 1) * $perPage + $i + 1;
+                $items[] = ['id' => $itemId, 'name' => "Course $itemId"];
+            }
+
+            $hasNext = $page < $totalPages;
+            $linkHeader = $this->buildLinkHeader($page, $totalPages, $hasNext ? $page + 1 : null, $page > 1 ? $page - 1 : null);
+
+            $mockResponse = $this->createMock(ResponseInterface::class);
+            $mockStream = $this->createMock(StreamInterface::class);
+            $mockStream->method('getContents')->willReturn(json_encode($items));
+            $mockResponse->method('getBody')->willReturn($mockStream);
+            $mockResponse->method('getHeader')->with('Link')->willReturn([$linkHeader]);
+
+            $responses[$page] = $mockResponse;
+        }
+
+        // Set up expectations - getPaginated will be called for each page
+        $this->mockHttpClient->expects($this->exactly($totalPages))
+            ->method('getPaginated')
+            ->willReturnCallback(function($path, $options) use ($responses) {
+                $page = $options['query']['page'] ?? 1;
+                return new PaginatedResponse($responses[$page], $this->mockHttpClient);
+            });
+
+        // Process pages using paginate()
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $result = Course::paginate(['page' => $page, 'per_page' => $perPage]);
+
+            // Process batch
+            foreach ($result->getData() as $item) {
+                $processedCount++;
+                // Process item without keeping all in memory
+                $this->assertNotNull($item->id);
+            }
+
+            // Check if we should continue
+            if (!$result->hasNext()) {
+                break;
+            }
+        }
+
+        // Verify we processed all items
+        $this->assertEquals(1000, $processedCount);
+    }
+
+    /**
+     * Helper method to build Link header
+     */
+    private function buildLinkHeader(int $current, int $total, ?int $next, ?int $prev): string
+    {
+        $links = [];
+
+        if ($next) {
+            $links[] = sprintf('<https://canvas.example.com/api/v1/endpoint?page=%d>; rel="next"', $next);
+        }
+        if ($prev) {
+            $links[] = sprintf('<https://canvas.example.com/api/v1/endpoint?page=%d>; rel="prev"', $prev);
+        }
+        $links[] = sprintf('<https://canvas.example.com/api/v1/endpoint?page=%d>; rel="current"', $current);
+        $links[] = '<https://canvas.example.com/api/v1/endpoint?page=1>; rel="first"';
+        $links[] = sprintf('<https://canvas.example.com/api/v1/endpoint?page=%d>; rel="last"', $total);
+
+        return implode(', ', $links);
+    }
+}

--- a/tests/Pagination/PaginatedResponseTest.php
+++ b/tests/Pagination/PaginatedResponseTest.php
@@ -523,7 +523,7 @@ class PaginatedResponseTest extends TestCase
     /**
      * Test fetch all pages
      */
-    public function testFetchAllPages(): void
+    public function testGetPages(): void
     {
         // Mock the current response
         $currentResponseBody = json_encode([['id' => 1, 'name' => 'Course 1']]);
@@ -567,7 +567,7 @@ class PaginatedResponseTest extends TestCase
 
         $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
 
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         $expectedData = [
             ['id' => 1, 'name' => 'Course 1'],
@@ -580,7 +580,7 @@ class PaginatedResponseTest extends TestCase
     /**
      * Test fetch all pages with single page
      */
-    public function testFetchAllPagesWithSinglePage(): void
+    public function testGetPagesWithSinglePage(): void
     {
         $responseBody = json_encode($this->sampleData);
         $mockStream = $this->createMock(StreamInterface::class);
@@ -600,7 +600,7 @@ class PaginatedResponseTest extends TestCase
 
         $paginatedResponse = new PaginatedResponse($this->mockResponse, $this->mockHttpClient);
 
-        $allData = $paginatedResponse->fetchAllPages();
+        $allData = $paginatedResponse->all();
 
         $this->assertEquals($this->sampleData, $allData);
     }


### PR DESCRIPTION
## Summary
- Completes the pagination API standardization started in v1.5.0
- Removes unnecessary safety configuration and complexity
- Fixes critical delegation patterns in Section class

## Key Changes

### 🔧 API Improvements
- Standardized all resources to use `get()`, `all()`, and `paginate()` methods
- Relationship methods now consistently return ALL pages for data completeness
- Fixed Section class delegation pattern for enrollments
- Removed misleading comments about data requirements

### 🧪 Testing Enhancements
- Added comprehensive edge case tests for pagination
- Tests for large datasets (10,000+ items)
- Rate limiting and timeout scenario handling
- Memory-efficient pagination examples

### 📚 Documentation Updates  
- Updated README to clarify pagination behavior
- Enhanced wiki documentation with v1.5.1 changes
- Added performance guidelines for large datasets

## Breaking Changes
⚠️ **Version 1.5.1 includes breaking changes:**
- Relationship methods (`$course->enrollments()`) now return ALL pages (previously first page only)
- Removed deprecated `fetch*` methods completely
- Consistent API: `get()`, `all()`, `paginate()`

## Test Results
✅ All 2,309 tests passing
✅ PSR-12 compliant
✅ PHPStan level 6 passing

## Migration Notes
Since this is v1.5.1 and there are no existing users, no migration guide is needed. The API is now consistent and intuitive across all resources.