### PR TITLE
feat: standardize date/time properties to DateTime across 21 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **⚠️ BREAKING CHANGE: Standardized Date/Time Property Types Across 21 Models** (#154)
+  - Changed all date/time properties from `?string` to `?DateTime` in the following classes:
+    - **Course**: `createdAt`, `startAt`, `endAt`
+    - **Assignment**: `dueAt`, `lockAt`, `unlockAt`, `createdAt`, `updatedAt`, `peerReviewsAssignAt`
+    - **Quiz**: `dueAt`, `lockAt`, `unlockAt`, `createdAt`, `updatedAt`
+    - **Enrollment**: `createdAt`, `updatedAt`, `lastActivityAt`, `startAt`, `endAt`
+    - **DiscussionTopic**: `postedAt`, `lastReplyAt`, `delayedPostAt`, `createdAt`, `updatedAt`
+    - **Submission**: `submittedAt`, `gradedAt`, `postedAt`
+    - **File**: `createdAt`, `updatedAt`, `unlockAt`, `lockAt`
+    - **Page**: `createdAt`, `updatedAt`
+    - **Section**: `startAt`, `endAt`
+    - **ExternalTool**: `createdAt`, `updatedAt`
+    - **OutcomeResult**: `submittedOrAssessedAt`, `attemptedAt`, `assessedAt`
+    - **RubricAssessment**: `createdAt`, `updatedAt`
+    - **RubricAssociation**: `createdAt`, `updatedAt`
+    - **Login**: `createdAt`
+    - **CourseReports**: `createdAt`, `startedAt`, `endedAt`
+    - **GroupMembership**: `createdAt`, `updatedAt`
+    - **DeveloperKey**: `createdAt`, `updatedAt`, `lastUsedAt`
+    - **QuizSubmission**: `startedAt`, `finishedAt`, `endAt`
+    - **OutcomeImport**: `createdAt`, `endedAt`, `updatedAt`
+    - **Conversation**: `lastMessageAt`, `startAt`
+    - **User**: `lastLogin`
+    - **SharedBrandConfig**: `createdAt`, `updatedAt` (custom constructor implementation)
+  - Updated corresponding getters/setters to use `?DateTime` type hints (where applicable)
+  - Enhanced `AbstractBaseApi::__construct()` to automatically convert date strings to DateTime objects via `castValue()`
+  - Expanded `castValue()` date field detection from 12 to 29 recognized date field names
+  - **Migration Guide for Consumers:**
+    ```php
+    // Before (returned string):
+    $dateString = $course->createdAt; // "2024-01-15T10:30:00Z"
+
+    // After (returns DateTime):
+    $dateObject = $course->getCreatedAt(); // DateTime object
+    $formatted = $course->getCreatedAt()?->format('Y-m-d'); // "2024-01-15"
+    $iso8601 = $course->getCreatedAt()?->format('c'); // ISO-8601 format
+    ```
+  - Benefits:
+    - Type-safe DateTime operations with IDE autocomplete across all models
+    - Automatic ISO-8601 parsing eliminates manual conversions
+    - Consistent date handling across the entire SDK
+    - Prevents TypeError when using save/update operations
+  - Added comprehensive test coverage for date hydration, null handling, and DTO serialization
+
 ## [1.5.4] - 2025-09-29
 
 ### Added

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -77,6 +77,9 @@ abstract class AbstractBaseApi implements ApiInterface
                                 $value = (bool) $value;
                                 break;
                         }
+                    } else {
+                        // For non-builtin types (like DateTime), use castValue()
+                        $value = $this->castValue($key, $value);
                     }
                 }
 
@@ -216,9 +219,15 @@ abstract class AbstractBaseApi implements ApiInterface
         $dateFields = [
             'startAt',
             'endAt',
+            'startedAt',
+            'endedAt',
+            'finishedAt',
             'createdAt',
             'updatedAt',
             'deletedAt',
+            'modifiedAt',
+            'editedAt',
+            'lastEditedAt',
             'publishedAt',
             'postedAt',
             'dueAt',
@@ -226,6 +235,17 @@ abstract class AbstractBaseApi implements ApiInterface
             'unlockAt',
             'submittedAt',
             'gradedAt',
+            'delayedPostAt',
+            'lastReplyAt',
+            'lastMessageAt',
+            'lastActivityAt',
+            'lastUsedAt',
+            'lastLogin',
+            'submittedOrAssessedAt',
+            'attemptedAt',
+            'assessedAt',
+            'peerReviewsAssignAt',
+            'cachedDueDate',
         ];
 
         if (in_array($key, $dateFields, true) && is_string($value) && !empty($value)) {

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -246,10 +246,18 @@ abstract class AbstractBaseApi implements ApiInterface
             'assessedAt',
             'peerReviewsAssignAt',
             'cachedDueDate',
+            'expiresAt',
+            'activatedAt',
+            'archivedAt',
         ];
 
         if (in_array($key, $dateFields, true) && is_string($value) && !empty($value)) {
-            return new DateTime($value);
+            try {
+                return new DateTime($value);
+            } catch (\Exception $e) {
+                // Return null for invalid date strings
+                return null;
+            }
         }
 
         return $value;

--- a/src/Api/Assignments/Assignment.php
+++ b/src/Api/Assignments/Assignment.php
@@ -137,17 +137,17 @@ class Assignment extends AbstractBaseApi
     /**
      * Assignment due date
      */
-    public ?string $dueAt = null;
+    public ?\DateTime $dueAt = null;
 
     /**
      * Date when assignment becomes locked
      */
-    public ?string $lockAt = null;
+    public ?\DateTime $lockAt = null;
 
     /**
      * Date when assignment becomes available
      */
-    public ?string $unlockAt = null;
+    public ?\DateTime $unlockAt = null;
 
     /**
      * All date variations for the assignment
@@ -209,12 +209,12 @@ class Assignment extends AbstractBaseApi
     /**
      * Assignment creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Assignment last update timestamp
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * URL to download all submissions as a zip
@@ -273,7 +273,7 @@ class Assignment extends AbstractBaseApi
     /**
      * Date peer reviews are assigned
      */
-    public ?string $peerReviewsAssignAt = null;
+    public ?\DateTime $peerReviewsAssignAt = null;
 
     /**
      * Whether intra-group peer reviews are allowed
@@ -860,9 +860,9 @@ class Assignment extends AbstractBaseApi
     /**
      * Get due date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getDueAt(): ?string
+    public function getDueAt(): ?\DateTime
     {
         return $this->dueAt;
     }
@@ -870,11 +870,11 @@ class Assignment extends AbstractBaseApi
     /**
      * Set due date
      *
-     * @param string|null $dueAt
+     * @param \DateTime|null $dueAt
      *
      * @return void
      */
-    public function setDueAt(?string $dueAt): void
+    public function setDueAt(?\DateTime $dueAt): void
     {
         $this->dueAt = $dueAt;
     }
@@ -882,9 +882,9 @@ class Assignment extends AbstractBaseApi
     /**
      * Get lock date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getLockAt(): ?string
+    public function getLockAt(): ?\DateTime
     {
         return $this->lockAt;
     }
@@ -892,11 +892,11 @@ class Assignment extends AbstractBaseApi
     /**
      * Set lock date
      *
-     * @param string|null $lockAt
+     * @param \DateTime|null $lockAt
      *
      * @return void
      */
-    public function setLockAt(?string $lockAt): void
+    public function setLockAt(?\DateTime $lockAt): void
     {
         $this->lockAt = $lockAt;
     }
@@ -904,9 +904,9 @@ class Assignment extends AbstractBaseApi
     /**
      * Get unlock date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUnlockAt(): ?string
+    public function getUnlockAt(): ?\DateTime
     {
         return $this->unlockAt;
     }
@@ -914,11 +914,11 @@ class Assignment extends AbstractBaseApi
     /**
      * Set unlock date
      *
-     * @param string|null $unlockAt
+     * @param \DateTime|null $unlockAt
      *
      * @return void
      */
-    public function setUnlockAt(?string $unlockAt): void
+    public function setUnlockAt(?\DateTime $unlockAt): void
     {
         $this->unlockAt = $unlockAt;
     }
@@ -1168,9 +1168,9 @@ class Assignment extends AbstractBaseApi
     /**
      * Get created at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -1178,11 +1178,11 @@ class Assignment extends AbstractBaseApi
     /**
      * Set created at timestamp
      *
-     * @param string|null $createdAt
+     * @param \DateTime|null $createdAt
      *
      * @return void
      */
-    public function setCreatedAt(?string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -1190,9 +1190,9 @@ class Assignment extends AbstractBaseApi
     /**
      * Get updated at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -1200,11 +1200,11 @@ class Assignment extends AbstractBaseApi
     /**
      * Set updated at timestamp
      *
-     * @param string|null $updatedAt
+     * @param \DateTime|null $updatedAt
      *
      * @return void
      */
-    public function setUpdatedAt(?string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -1228,9 +1228,9 @@ class Assignment extends AbstractBaseApi
             'submission_types' => $this->submissionTypes,
             'allowed_extensions' => $this->allowedExtensions,
             'allowed_attempts' => $this->allowedAttempts,
-            'due_at' => $this->dueAt,
-            'lock_at' => $this->lockAt,
-            'unlock_at' => $this->unlockAt,
+            'due_at' => $this->dueAt?->format('c'),
+            'lock_at' => $this->lockAt?->format('c'),
+            'unlock_at' => $this->unlockAt?->format('c'),
             'all_dates' => $this->allDates,
             'published' => $this->published,
             'workflow_state' => $this->workflowState,
@@ -1242,8 +1242,8 @@ class Assignment extends AbstractBaseApi
             'group_category_id' => $this->groupCategoryId,
             'html_url' => $this->htmlUrl,
             'has_overrides' => $this->hasOverrides,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'created_at' => $this->createdAt?->format('c'),
+            'updated_at' => $this->updatedAt?->format('c'),
             'submissions_download_url' => $this->submissionsDownloadUrl,
             'due_date_required' => $this->dueDateRequired,
             'max_name_length' => $this->maxNameLength,
@@ -1323,9 +1323,9 @@ class Assignment extends AbstractBaseApi
             'submission_types' => $this->submissionTypes,
             'allowed_extensions' => $this->allowedExtensions,
             'allowed_attempts' => $this->allowedAttempts,
-            'due_at' => $this->dueAt,
-            'lock_at' => $this->lockAt,
-            'unlock_at' => $this->unlockAt,
+            'due_at' => $this->dueAt?->format('c'),
+            'lock_at' => $this->lockAt?->format('c'),
+            'unlock_at' => $this->unlockAt?->format('c'),
             'published' => $this->published,
             'assignment_group_id' => $this->assignmentGroupId,
             'position' => $this->position,

--- a/src/Api/Conversations/Conversation.php
+++ b/src/Api/Conversations/Conversation.php
@@ -51,9 +51,9 @@ class Conversation extends AbstractBaseApi
 
     public ?string $lastMessage = null;
 
-    public ?string $lastMessageAt = null;
+    public ?\DateTime $lastMessageAt = null;
 
-    public ?string $startAt = null;
+    public ?\DateTime $startAt = null;
 
     public ?int $messageCount = null;
 

--- a/src/Api/CourseReports/CourseReports.php
+++ b/src/Api/CourseReports/CourseReports.php
@@ -47,17 +47,17 @@ class CourseReports extends AbstractBaseApi
     /**
      * Report creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Report start timestamp
      */
-    public ?string $startedAt = null;
+    public ?\DateTime $startedAt = null;
 
     /**
      * Report completion timestamp
      */
-    public ?string $endedAt = null;
+    public ?\DateTime $endedAt = null;
 
     /**
      * Parameters used to generate the report
@@ -294,9 +294,9 @@ class CourseReports extends AbstractBaseApi
             'status' => $this->status,
             'file_url' => $this->fileUrl,
             'attachment' => $this->attachment,
-            'created_at' => $this->createdAt,
-            'started_at' => $this->startedAt,
-            'ended_at' => $this->endedAt,
+            'created_at' => $this->createdAt?->format('c'),
+            'started_at' => $this->startedAt?->format('c'),
+            'ended_at' => $this->endedAt?->format('c'),
             'parameters' => $this->parameters,
             'progress' => $this->progress,
         ];

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -185,19 +185,19 @@ class Course extends AbstractBaseApi
     public ?string $gradePassbackSetting = null;
 
     /**
-     * @var string
+     * @var \DateTime|null
      */
-    public string $createdAt = '';
+    public ?\DateTime $createdAt = null;
 
     /**
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $startAt = null;
+    public ?\DateTime $startAt = null;
 
     /**
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $endAt = null;
+    public ?\DateTime $endAt = null;
 
     /**
      * @var string|null
@@ -2019,49 +2019,49 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
 
     /**
-     * @param string $createdAt
+     * @param \DateTime|null $createdAt
      */
-    public function setCreatedAt(string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
 
     /**
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getStartAt(): ?string
+    public function getStartAt(): ?\DateTime
     {
         return $this->startAt;
     }
 
     /**
-     * @param string|null $startAt
+     * @param \DateTime|null $startAt
      */
-    public function setStartAt(?string $startAt): void
+    public function setStartAt(?\DateTime $startAt): void
     {
         $this->startAt = $startAt;
     }
 
     /**
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getEndAt(): ?string
+    public function getEndAt(): ?\DateTime
     {
         return $this->endAt;
     }
 
     /**
-     * @param string|null $endAt
+     * @param \DateTime|null $endAt
      */
-    public function setEndAt(?string $endAt): void
+    public function setEndAt(?\DateTime $endAt): void
     {
         $this->endAt = $endAt;
     }

--- a/src/Api/DeveloperKeys/DeveloperKey.php
+++ b/src/Api/DeveloperKeys/DeveloperKey.php
@@ -39,9 +39,9 @@ class DeveloperKey extends AbstractBaseApi
 
     public ?string $name = null;
 
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     public ?string $workflowState = null;
 
@@ -73,7 +73,7 @@ class DeveloperKey extends AbstractBaseApi
 
     public ?int $accessTokenCount = null;
 
-    public ?string $lastUsedAt = null;
+    public ?\DateTime $lastUsedAt = null;
 
     public ?bool $testClusterOnly = null;
 

--- a/src/Api/DiscussionTopics/DiscussionTopic.php
+++ b/src/Api/DiscussionTopics/DiscussionTopic.php
@@ -99,7 +99,7 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * When the discussion topic was posted
      */
-    public ?string $postedAt = null;
+    public ?\DateTime $postedAt = null;
 
     /**
      * Discussion type (threaded, side_comment, etc.)
@@ -191,7 +191,7 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * When the last reply was posted
      */
-    public ?string $lastReplyAt = null;
+    public ?\DateTime $lastReplyAt = null;
 
     /**
      * Whether users can see posts (based on require_initial_post)
@@ -226,7 +226,7 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * When the topic will be automatically published
      */
-    public ?string $delayedPostAt = null;
+    public ?\DateTime $delayedPostAt = null;
 
     /**
      * Whether the topic is locked for the current user
@@ -321,12 +321,12 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Discussion topic creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Discussion topic last update timestamp
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Create a new DiscussionTopic instance
@@ -485,9 +485,9 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Get posted at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getPostedAt(): ?string
+    public function getPostedAt(): ?\DateTime
     {
         return $this->postedAt;
     }
@@ -495,11 +495,11 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Set posted at timestamp
      *
-     * @param string|null $postedAt
+     * @param \DateTime|null $postedAt
      *
      * @return void
      */
-    public function setPostedAt(?string $postedAt): void
+    public function setPostedAt(?\DateTime $postedAt): void
     {
         $this->postedAt = $postedAt;
     }
@@ -881,9 +881,9 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Get created at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -891,11 +891,11 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Set created at timestamp
      *
-     * @param string|null $createdAt
+     * @param \DateTime|null $createdAt
      *
      * @return void
      */
-    public function setCreatedAt(?string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -903,9 +903,9 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Get updated at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -913,11 +913,11 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Set updated at timestamp
      *
-     * @param string|null $updatedAt
+     * @param \DateTime|null $updatedAt
      *
      * @return void
      */
-    public function setUpdatedAt(?string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -925,9 +925,9 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Get last reply at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getLastReplyAt(): ?string
+    public function getLastReplyAt(): ?\DateTime
     {
         return $this->lastReplyAt;
     }
@@ -935,11 +935,11 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Set last reply at timestamp
      *
-     * @param string|null $lastReplyAt
+     * @param \DateTime|null $lastReplyAt
      *
      * @return void
      */
-    public function setLastReplyAt(?string $lastReplyAt): void
+    public function setLastReplyAt(?\DateTime $lastReplyAt): void
     {
         $this->lastReplyAt = $lastReplyAt;
     }
@@ -1079,9 +1079,9 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Get delayed post at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getDelayedPostAt(): ?string
+    public function getDelayedPostAt(): ?\DateTime
     {
         return $this->delayedPostAt;
     }
@@ -1089,11 +1089,11 @@ class DiscussionTopic extends AbstractBaseApi
     /**
      * Set delayed post at timestamp
      *
-     * @param string|null $delayedPostAt
+     * @param \DateTime|null $delayedPostAt
      *
      * @return void
      */
-    public function setDelayedPostAt(?string $delayedPostAt): void
+    public function setDelayedPostAt(?\DateTime $delayedPostAt): void
     {
         $this->delayedPostAt = $delayedPostAt;
     }
@@ -1462,8 +1462,8 @@ class DiscussionTopic extends AbstractBaseApi
             'title' => $this->title,
             'message' => $this->message,
             'html_url' => $this->htmlUrl,
-            'posted_at' => $this->postedAt,
-            'last_reply_at' => $this->lastReplyAt,
+            'posted_at' => $this->postedAt?->format('c'),
+            'last_reply_at' => $this->lastReplyAt?->format('c'),
             'discussion_type' => $this->discussionType,
             'require_initial_post' => $this->requireInitialPost,
             'user_can_see_posts' => $this->userCanSeePosts,
@@ -1474,7 +1474,7 @@ class DiscussionTopic extends AbstractBaseApi
             'subscription_hold' => $this->subscriptionHold,
             'locked' => $this->locked,
             'pinned' => $this->pinned,
-            'delayed_post_at' => $this->delayedPostAt,
+            'delayed_post_at' => $this->delayedPostAt?->format('c'),
             'locked_for_user' => $this->lockedForUser,
             'lock_info' => $this->lockInfo,
             'lock_explanation' => $this->lockExplanation,
@@ -1504,8 +1504,8 @@ class DiscussionTopic extends AbstractBaseApi
             'attachments' => $this->attachments,
             'permissions' => $this->permissions,
             'is_announcement' => $this->isAnnouncement,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'created_at' => $this->createdAt?->format('c'),
+            'updated_at' => $this->updatedAt?->format('c'),
         ];
     }
 

--- a/src/Api/Enrollments/Enrollment.php
+++ b/src/Api/Enrollments/Enrollment.php
@@ -97,9 +97,9 @@ class Enrollment extends AbstractBaseApi
 
     public ?bool $limitPrivilegesToCourseSection = null;
 
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     // Canvas-specific properties
     public ?string $role = null;
@@ -137,11 +137,11 @@ class Enrollment extends AbstractBaseApi
 
     public ?int $totalActivityTime = null;
 
-    public ?string $lastActivityAt = null;
+    public ?\DateTime $lastActivityAt = null;
 
-    public ?string $startAt = null;
+    public ?\DateTime $startAt = null;
 
-    public ?string $endAt = null;
+    public ?\DateTime $endAt = null;
 
     /** @var mixed[]|null */
     public ?array $observedUsers = null;
@@ -665,12 +665,12 @@ class Enrollment extends AbstractBaseApi
         return $this->limitPrivilegesToCourseSection;
     }
 
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
 
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -763,17 +763,17 @@ class Enrollment extends AbstractBaseApi
         return $this->totalActivityTime;
     }
 
-    public function getLastActivityAt(): ?string
+    public function getLastActivityAt(): ?\DateTime
     {
         return $this->lastActivityAt;
     }
 
-    public function getStartAt(): ?string
+    public function getStartAt(): ?\DateTime
     {
         return $this->startAt;
     }
 
-    public function getEndAt(): ?string
+    public function getEndAt(): ?\DateTime
     {
         return $this->endAt;
     }
@@ -865,12 +865,12 @@ class Enrollment extends AbstractBaseApi
         $this->limitPrivilegesToCourseSection = $limitPrivilegesToCourseSection;
     }
 
-    public function setStartAt(?string $startAt): void
+    public function setStartAt(?\DateTime $startAt): void
     {
         $this->startAt = $startAt;
     }
 
-    public function setEndAt(?string $endAt): void
+    public function setEndAt(?\DateTime $endAt): void
     {
         $this->endAt = $endAt;
     }

--- a/src/Api/ExternalTools/ExternalTool.php
+++ b/src/Api/ExternalTools/ExternalTool.php
@@ -242,12 +242,12 @@ class ExternalTool extends AbstractBaseApi
     /**
      * External tool creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * External tool last update timestamp
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * The unique identifier for the deployment of the tool
@@ -920,9 +920,9 @@ class ExternalTool extends AbstractBaseApi
     /**
      * Get created at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -930,11 +930,11 @@ class ExternalTool extends AbstractBaseApi
     /**
      * Set created at timestamp
      *
-     * @param string|null $createdAt
+     * @param \DateTime|null $createdAt
      *
      * @return void
      */
-    public function setCreatedAt(?string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -942,9 +942,9 @@ class ExternalTool extends AbstractBaseApi
     /**
      * Get updated at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -952,11 +952,11 @@ class ExternalTool extends AbstractBaseApi
     /**
      * Set updated at timestamp
      *
-     * @param string|null $updatedAt
+     * @param \DateTime|null $updatedAt
      *
      * @return void
      */
-    public function setUpdatedAt(?string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }
@@ -1040,8 +1040,8 @@ class ExternalTool extends AbstractBaseApi
             'icon_url' => $this->iconUrl,
             'not_selectable' => $this->notSelectable,
             'workflow_state' => $this->workflowState,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'created_at' => $this->createdAt?->format('c'),
+            'updated_at' => $this->updatedAt?->format('c'),
             'deployment_id' => $this->deploymentId,
             'unified_tool_id' => $this->unifiedToolId,
         ];

--- a/src/Api/Files/File.php
+++ b/src/Api/Files/File.php
@@ -119,23 +119,23 @@ class File extends AbstractBaseApi
     /**
      * The datetime the file was created
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * The datetime the file was last updated
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * The datetime the file will be deleted (not present for file upload requests)
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $unlockAt = null;
+    public ?\DateTime $unlockAt = null;
 
     /**
      * Whether the file is locked
@@ -154,9 +154,9 @@ class File extends AbstractBaseApi
     /**
      * The datetime the file was locked at
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $lockAt = null;
+    public ?\DateTime $lockAt = null;
 
     /**
      * Whether the file is locked for the user
@@ -842,19 +842,19 @@ class File extends AbstractBaseApi
     /**
      * Get the created at timestamp
      *
-     * @return string
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): string
+    public function getCreatedAt(): ?\DateTime
     {
-        return $this->createdAt ?? '';
+        return $this->createdAt;
     }
 
     /**
      * Set the created at timestamp
      *
-     * @param string $createdAt
+     * @param \DateTime|null $createdAt
      */
-    public function setCreatedAt(string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -862,19 +862,19 @@ class File extends AbstractBaseApi
     /**
      * Get the updated at timestamp
      *
-     * @return string
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): string
+    public function getUpdatedAt(): ?\DateTime
     {
-        return $this->updatedAt ?? '';
+        return $this->updatedAt;
     }
 
     /**
      * Set the updated at timestamp
      *
-     * @param string $updatedAt
+     * @param \DateTime|null $updatedAt
      */
-    public function setUpdatedAt(string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Api/Groups/GroupMembership.php
+++ b/src/Api/Groups/GroupMembership.php
@@ -65,12 +65,12 @@ class GroupMembership extends AbstractBaseApi
     /**
      * When the membership was created
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * When the membership was last updated
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Just created membership flag

--- a/src/Api/Logins/Login.php
+++ b/src/Api/Logins/Login.php
@@ -53,7 +53,7 @@ class Login extends AbstractBaseApi
 
     public ?string $declaredUserType = null;
 
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Get endpoint for the API calls (required by AbstractBaseApi)

--- a/src/Api/OutcomeImports/OutcomeImport.php
+++ b/src/Api/OutcomeImports/OutcomeImport.php
@@ -24,11 +24,11 @@ class OutcomeImport extends AbstractBaseApi
 
     public ?int $learningOutcomeGroupId = null;
 
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
-    public ?string $endedAt = null;
+    public ?\DateTime $endedAt = null;
 
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     public ?string $workflowState = null;
 

--- a/src/Api/OutcomeResults/OutcomeResult.php
+++ b/src/Api/OutcomeResults/OutcomeResult.php
@@ -27,7 +27,7 @@ class OutcomeResult extends AbstractBaseApi
 
     public ?float $score = null;
 
-    public ?string $submittedOrAssessedAt = null;
+    public ?\DateTime $submittedOrAssessedAt = null;
 
     /** @var array<string, mixed>|null */
     public ?array $links = null;
@@ -40,9 +40,9 @@ class OutcomeResult extends AbstractBaseApi
 
     public ?bool $hidden = null;
 
-    public ?string $attemptedAt = null;
+    public ?\DateTime $attemptedAt = null;
 
-    public ?string $assessedAt = null;
+    public ?\DateTime $assessedAt = null;
 
     public ?int $assignmentId = null;
 

--- a/src/Api/Pages/Page.php
+++ b/src/Api/Pages/Page.php
@@ -153,12 +153,12 @@ class Page extends AbstractBaseApi
     /**
      * Page creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Page last update timestamp
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * User who last edited the page
@@ -602,9 +602,9 @@ class Page extends AbstractBaseApi
     /**
      * Get created at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -612,11 +612,11 @@ class Page extends AbstractBaseApi
     /**
      * Set created at timestamp
      *
-     * @param string|null $createdAt
+     * @param \DateTime|null $createdAt
      *
      * @return void
      */
-    public function setCreatedAt(?string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -624,9 +624,9 @@ class Page extends AbstractBaseApi
     /**
      * Get updated at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -634,11 +634,11 @@ class Page extends AbstractBaseApi
     /**
      * Set updated at timestamp
      *
-     * @param string|null $updatedAt
+     * @param \DateTime|null $updatedAt
      *
      * @return void
      */
-    public function setUpdatedAt(?string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Api/QuizSubmissions/QuizSubmission.php
+++ b/src/Api/QuizSubmissions/QuizSubmission.php
@@ -91,17 +91,17 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * When the submission was started
      */
-    public ?string $startedAt = null;
+    public ?\DateTime $startedAt = null;
 
     /**
      * When the submission was finished
      */
-    public ?string $finishedAt = null;
+    public ?\DateTime $finishedAt = null;
 
     /**
      * When the submission will end (time limit)
      */
-    public ?string $endAt = null;
+    public ?\DateTime $endAt = null;
 
     /**
      * Attempt number (1-based)
@@ -360,7 +360,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Get started at timestamp
      */
-    public function getStartedAt(): ?string
+    public function getStartedAt(): ?\DateTime
     {
         return $this->startedAt;
     }
@@ -368,7 +368,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Set started at timestamp
      */
-    public function setStartedAt(?string $startedAt): void
+    public function setStartedAt(?\DateTime $startedAt): void
     {
         $this->startedAt = $startedAt;
     }
@@ -376,7 +376,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Get finished at timestamp
      */
-    public function getFinishedAt(): ?string
+    public function getFinishedAt(): ?\DateTime
     {
         return $this->finishedAt;
     }
@@ -384,7 +384,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Set finished at timestamp
      */
-    public function setFinishedAt(?string $finishedAt): void
+    public function setFinishedAt(?\DateTime $finishedAt): void
     {
         $this->finishedAt = $finishedAt;
     }
@@ -392,7 +392,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Get end at timestamp
      */
-    public function getEndAt(): ?string
+    public function getEndAt(): ?\DateTime
     {
         return $this->endAt;
     }
@@ -400,7 +400,7 @@ class QuizSubmission extends AbstractBaseApi
     /**
      * Set end at timestamp
      */
-    public function setEndAt(?string $endAt): void
+    public function setEndAt(?\DateTime $endAt): void
     {
         $this->endAt = $endAt;
     }
@@ -976,7 +976,9 @@ class QuizSubmission extends AbstractBaseApi
 
         // Update current instance with response data
         $this->workflowState = $submissionData['workflow_state'] ?? $this->workflowState;
-        $this->finishedAt = $submissionData['finished_at'] ?? $this->finishedAt;
+        $this->finishedAt = isset($submissionData['finished_at']) && $submissionData['finished_at']
+            ? new \DateTime($submissionData['finished_at'])
+            : $this->finishedAt;
         $this->score = $submissionData['score'] ?? $this->score;
 
         return $this;
@@ -1060,7 +1062,7 @@ class QuizSubmission extends AbstractBaseApi
             return null;
         }
 
-        $endTime = strtotime($this->endAt);
+        $endTime = $this->endAt->getTimestamp();
         $currentTime = time();
 
         return max(0, $endTime - $currentTime);
@@ -1094,9 +1096,9 @@ class QuizSubmission extends AbstractBaseApi
             'quizId' => $this->quizId,
             'userId' => $this->userId,
             'submissionId' => $this->submissionId,
-            'startedAt' => $this->startedAt,
-            'finishedAt' => $this->finishedAt,
-            'endAt' => $this->endAt,
+            'startedAt' => $this->startedAt?->format('c'),
+            'finishedAt' => $this->finishedAt?->format('c'),
+            'endAt' => $this->endAt?->format('c'),
             'attempt' => $this->attempt,
             'extraAttempts' => $this->extraAttempts,
             'extraTime' => $this->extraTime,
@@ -1127,9 +1129,9 @@ class QuizSubmission extends AbstractBaseApi
             'quiz_id' => $this->quizId,
             'user_id' => $this->userId,
             'submission_id' => $this->submissionId,
-            'started_at' => $this->startedAt,
-            'finished_at' => $this->finishedAt,
-            'end_at' => $this->endAt,
+            'started_at' => $this->startedAt?->format('c'),
+            'finished_at' => $this->finishedAt?->format('c'),
+            'end_at' => $this->endAt?->format('c'),
             'attempt' => $this->attempt,
             'extra_attempts' => $this->extraAttempts,
             'extra_time' => $this->extraTime,

--- a/src/Api/Quizzes/Quiz.php
+++ b/src/Api/Quizzes/Quiz.php
@@ -136,17 +136,17 @@ class Quiz extends AbstractBaseApi
     /**
      * Quiz due date
      */
-    public ?string $dueAt = null;
+    public ?\DateTime $dueAt = null;
 
     /**
      * Date when quiz becomes locked
      */
-    public ?string $lockAt = null;
+    public ?\DateTime $lockAt = null;
 
     /**
      * Date when quiz becomes available
      */
-    public ?string $unlockAt = null;
+    public ?\DateTime $unlockAt = null;
 
     /**
      * Whether the quiz is published
@@ -238,12 +238,12 @@ class Quiz extends AbstractBaseApi
     /**
      * Quiz creation timestamp
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Quiz last update timestamp
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Create a new Quiz instance
@@ -561,9 +561,9 @@ class Quiz extends AbstractBaseApi
     /**
      * Get due date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getDueAt(): ?string
+    public function getDueAt(): ?\DateTime
     {
         return $this->dueAt;
     }
@@ -571,11 +571,11 @@ class Quiz extends AbstractBaseApi
     /**
      * Set due date
      *
-     * @param string|null $dueAt
+     * @param \DateTime|null $dueAt
      *
      * @return void
      */
-    public function setDueAt(?string $dueAt): void
+    public function setDueAt(?\DateTime $dueAt): void
     {
         $this->dueAt = $dueAt;
     }
@@ -583,9 +583,9 @@ class Quiz extends AbstractBaseApi
     /**
      * Get lock date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getLockAt(): ?string
+    public function getLockAt(): ?\DateTime
     {
         return $this->lockAt;
     }
@@ -593,11 +593,11 @@ class Quiz extends AbstractBaseApi
     /**
      * Set lock date
      *
-     * @param string|null $lockAt
+     * @param \DateTime|null $lockAt
      *
      * @return void
      */
-    public function setLockAt(?string $lockAt): void
+    public function setLockAt(?\DateTime $lockAt): void
     {
         $this->lockAt = $lockAt;
     }
@@ -605,9 +605,9 @@ class Quiz extends AbstractBaseApi
     /**
      * Get unlock date
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUnlockAt(): ?string
+    public function getUnlockAt(): ?\DateTime
     {
         return $this->unlockAt;
     }
@@ -615,11 +615,11 @@ class Quiz extends AbstractBaseApi
     /**
      * Set unlock date
      *
-     * @param string|null $unlockAt
+     * @param \DateTime|null $unlockAt
      *
      * @return void
      */
-    public function setUnlockAt(?string $unlockAt): void
+    public function setUnlockAt(?\DateTime $unlockAt): void
     {
         $this->unlockAt = $unlockAt;
     }
@@ -1001,9 +1001,9 @@ class Quiz extends AbstractBaseApi
     /**
      * Get created at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getCreatedAt(): ?string
+    public function getCreatedAt(): ?\DateTime
     {
         return $this->createdAt;
     }
@@ -1011,11 +1011,11 @@ class Quiz extends AbstractBaseApi
     /**
      * Set created at timestamp
      *
-     * @param string|null $createdAt
+     * @param \DateTime|null $createdAt
      *
      * @return void
      */
-    public function setCreatedAt(?string $createdAt): void
+    public function setCreatedAt(?\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
     }
@@ -1023,9 +1023,9 @@ class Quiz extends AbstractBaseApi
     /**
      * Get updated at timestamp
      *
-     * @return string|null
+     * @return \DateTime|null
      */
-    public function getUpdatedAt(): ?string
+    public function getUpdatedAt(): ?\DateTime
     {
         return $this->updatedAt;
     }
@@ -1033,11 +1033,11 @@ class Quiz extends AbstractBaseApi
     /**
      * Set updated at timestamp
      *
-     * @param string|null $updatedAt
+     * @param \DateTime|null $updatedAt
      *
      * @return void
      */
-    public function setUpdatedAt(?string $updatedAt): void
+    public function setUpdatedAt(?\DateTime $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Api/Rubrics/RubricAssessment.php
+++ b/src/Api/Rubrics/RubricAssessment.php
@@ -183,16 +183,16 @@ class RubricAssessment extends AbstractBaseApi
     /**
      * Created timestamp
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Updated timestamp
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Course context for operations

--- a/src/Api/Rubrics/RubricAssociation.php
+++ b/src/Api/Rubrics/RubricAssociation.php
@@ -156,16 +156,16 @@ class RubricAssociation extends AbstractBaseApi
     /**
      * Created timestamp
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * Updated timestamp
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Course context for operations

--- a/src/Api/Sections/Section.php
+++ b/src/Api/Sections/Section.php
@@ -93,12 +93,12 @@ class Section extends AbstractBaseApi
     /**
      * Section start date
      */
-    public ?string $startAt = null;
+    public ?\DateTime $startAt = null;
 
     /**
      * Section end date
      */
-    public ?string $endAt = null;
+    public ?\DateTime $endAt = null;
 
     /**
      * Whether this section restricts enrollments to students
@@ -461,8 +461,8 @@ class Section extends AbstractBaseApi
             'name' => $this->name,
             'sis_section_id' => $this->sisSectionId,
             'integration_id' => $this->integrationId,
-            'start_at' => $this->startAt,
-            'end_at' => $this->endAt,
+            'start_at' => $this->startAt?->format('c'),
+            'end_at' => $this->endAt?->format('c'),
             'restrict_enrollments_to_section_dates' => $this->restrictEnrollmentsToSectionDates,
         ], fn ($value) => $value !== null);
     }
@@ -493,12 +493,12 @@ class Section extends AbstractBaseApi
         return $this->integrationId;
     }
 
-    public function getStartAt(): ?string
+    public function getStartAt(): ?\DateTime
     {
         return $this->startAt;
     }
 
-    public function getEndAt(): ?string
+    public function getEndAt(): ?\DateTime
     {
         return $this->endAt;
     }
@@ -539,12 +539,12 @@ class Section extends AbstractBaseApi
         $this->integrationId = $integrationId;
     }
 
-    public function setStartAt(?string $startAt): void
+    public function setStartAt(?\DateTime $startAt): void
     {
         $this->startAt = $startAt;
     }
 
-    public function setEndAt(?string $endAt): void
+    public function setEndAt(?\DateTime $endAt): void
     {
         $this->endAt = $endAt;
     }

--- a/src/Api/SharedBrandConfigs/SharedBrandConfig.php
+++ b/src/Api/SharedBrandConfigs/SharedBrandConfig.php
@@ -52,12 +52,12 @@ class SharedBrandConfig
     /**
      * When this was created
      */
-    public ?string $createdAt = null;
+    public ?\DateTime $createdAt = null;
 
     /**
      * When this was last updated
      */
-    public ?string $updatedAt = null;
+    public ?\DateTime $updatedAt = null;
 
     /**
      * Constructor
@@ -66,12 +66,25 @@ class SharedBrandConfig
      */
     public function __construct(array $data = [])
     {
+        // Define date fields that need DateTime conversion
+        $dateFields = ['createdAt', 'updatedAt'];
+
         // Convert snake_case keys from Canvas API to camelCase properties
         foreach ($data as $key => $value) {
             $camelKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
 
             if (property_exists($this, $camelKey) && !is_null($value)) {
-                $this->{$camelKey} = $value;
+                // Cast date fields to DateTime
+                if (in_array($camelKey, $dateFields, true) && is_string($value)) {
+                    try {
+                        $this->{$camelKey} = new \DateTime($value);
+                    } catch (\Exception $e) {
+                        // If parsing fails, leave as null
+                        $this->{$camelKey} = null;
+                    }
+                } else {
+                    $this->{$camelKey} = $value;
+                }
             }
         }
     }
@@ -287,8 +300,8 @@ class SharedBrandConfig
             'account_id' => $this->accountId,
             'brand_config_md5' => $this->brandConfigMd5,
             'name' => $this->name,
-            'created_at' => $this->createdAt,
-            'updated_at' => $this->updatedAt,
+            'created_at' => $this->createdAt?->format('c'),
+            'updated_at' => $this->updatedAt?->format('c'),
         ];
     }
 }

--- a/src/Api/Submissions/Submission.php
+++ b/src/Api/Submissions/Submission.php
@@ -138,7 +138,7 @@ class Submission extends AbstractBaseApi
     /**
      * Date and time when submission was submitted
      */
-    public ?string $submittedAt = null;
+    public ?\DateTime $submittedAt = null;
 
     /**
      * Canvas URL for viewing this submission
@@ -173,7 +173,7 @@ class Submission extends AbstractBaseApi
     /**
      * Date and time when submission was graded
      */
-    public ?string $gradedAt = null;
+    public ?\DateTime $gradedAt = null;
 
     /**
      * Workflow state of the submission
@@ -229,7 +229,7 @@ class Submission extends AbstractBaseApi
     /**
      * Date and time when grades were posted
      */
-    public ?string $postedAt = null;
+    public ?\DateTime $postedAt = null;
 
     /**
      * Array of submission comments
@@ -753,12 +753,12 @@ class Submission extends AbstractBaseApi
         $this->attempt = $attempt;
     }
 
-    public function getSubmittedAt(): ?string
+    public function getSubmittedAt(): ?\DateTime
     {
         return $this->submittedAt;
     }
 
-    public function setSubmittedAt(?string $submittedAt): void
+    public function setSubmittedAt(?\DateTime $submittedAt): void
     {
         $this->submittedAt = $submittedAt;
     }
@@ -823,12 +823,12 @@ class Submission extends AbstractBaseApi
         $this->graderId = $graderId;
     }
 
-    public function getGradedAt(): ?string
+    public function getGradedAt(): ?\DateTime
     {
         return $this->gradedAt;
     }
 
-    public function setGradedAt(?string $gradedAt): void
+    public function setGradedAt(?\DateTime $gradedAt): void
     {
         $this->gradedAt = $gradedAt;
     }
@@ -933,12 +933,12 @@ class Submission extends AbstractBaseApi
         $this->anonymousId = $anonymousId;
     }
 
-    public function getPostedAt(): ?string
+    public function getPostedAt(): ?\DateTime
     {
         return $this->postedAt;
     }
 
-    public function setPostedAt(?string $postedAt): void
+    public function setPostedAt(?\DateTime $postedAt): void
     {
         $this->postedAt = $postedAt;
     }

--- a/src/Api/Users/User.php
+++ b/src/Api/Users/User.php
@@ -214,9 +214,9 @@ class User extends AbstractBaseApi
      * Optional: This field is only returned in certain API calls, and will return a
      * timestamp representing the last time the user logged in to canvas.
      *
-     * @var string|null
+     * @var \DateTime|null
      */
-    public ?string $lastLogin;
+    public ?\DateTime $lastLogin;
 
     /**
      * Optional: This field is only returned in certain API calls, and will return
@@ -925,17 +925,21 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string|null
+     * Get last login timestamp
+     *
+     * @return \DateTime|null
      */
-    public function getLastLogin(): ?string
+    public function getLastLogin(): ?\DateTime
     {
         return $this->lastLogin;
     }
 
     /**
-     * @param string|null $lastLogin
+     * Set last login timestamp
+     *
+     * @param \DateTime|null $lastLogin
      */
-    public function setLastLogin(?string $lastLogin): void
+    public function setLastLogin(?\DateTime $lastLogin): void
     {
         $this->lastLogin = $lastLogin;
     }

--- a/src/Dto/Courses/CreateCourseDTO.php
+++ b/src/Dto/Courses/CreateCourseDTO.php
@@ -221,7 +221,8 @@ class CreateCourseDTO extends AbstractBaseDto implements DTOInterface
     public ?int $gradingStandardId = null;
 
     /**
-     * Optional. The grade_passback_setting for the course. Only ‘nightly_sync’, ‘disabled’, and ” are allowed.
+     * Optional. The grade_passback_setting for the course.
+     * Only 'nightly_sync', 'disabled', and " are allowed.
      *
      * @var string|null $gradePassbackSetting
      */

--- a/src/Dto/Courses/UpdateCourseDTO.php
+++ b/src/Dto/Courses/UpdateCourseDTO.php
@@ -170,8 +170,8 @@ class UpdateCourseDTO extends AbstractBaseDto implements DTOInterface
     public ?string $syllabusBody = null;
 
     /**
-     * @var bool|null Indicates whether the Course Summary (consisting of the course’s assignments and calendar events)
-     * is displayed on the syllabus page. Defaults to true.
+     * @var bool|null Indicates whether the Course Summary (consisting of the course's assignments
+     * and calendar events) is displayed on the syllabus page. Defaults to true.
      */
     public ?bool $syllabusCourseSummary = null;
 
@@ -228,9 +228,9 @@ class UpdateCourseDTO extends AbstractBaseDto implements DTOInterface
     public ?bool $useBlueprintRestrictionsByObjectType = null;
 
     /**
-     * @var mixed[]|null Allows setting multiple Blueprint Restriction to
-     * apply to blueprint course objects of the matching type when restricted.
-     * The possible object types are “assignment”, “attachment”, “discussion_topic”, “quiz” and “wiki_page”.
+     * @var mixed[]|null Allows setting multiple Blueprint Restriction to apply to blueprint course
+     * objects of the matching type when restricted. The possible object types are "assignment",
+     * "attachment", "discussion_topic", "quiz" and "wiki_page".
      */
     public ?array $blueprintRestrictionsByObjectType = null;
 

--- a/src/Dto/Users/CreateUserDTO.php
+++ b/src/Dto/Users/CreateUserDTO.php
@@ -177,10 +177,10 @@ class CreateUserDTO extends AbstractBaseDto implements DTOInterface
     /**
      * If true, validations are performed on the newly created user (and their associated pseudonym)
      * even if the request is made by a privileged user like an admin. When set to false,
-     * or not included in the request parameters,any newly created users are subject to validations unless the request
-     * is made by a user with a ‘manage_user_logins’ right. In which case, certain validations such as
-     * ‘require_acceptance_of_terms’ and ‘require_presence_of_name’ are not enforced. Use this parameter to return
-     * helpful json errors while building users with an admin request.
+     * or not included in the request parameters,any newly created users are subject to validations
+     * unless the request is made by a user with a 'manage_user_logins' right. In which case, certain
+     * validations such as 'require_acceptance_of_terms' and 'require_presence_of_name' are not enforced.
+     * Use this parameter to return helpful json errors while building users with an admin request.
      *
      * @var bool|null
      */

--- a/tests/Api/Announcements/AnnouncementTest.php
+++ b/tests/Api/Announcements/AnnouncementTest.php
@@ -84,8 +84,10 @@ class AnnouncementTest extends TestCase
         $this->assertEquals('Important Announcement', $announcement->getTitle());
         $this->assertEquals('This is an important announcement', $announcement->getMessage());
         $this->assertEquals('https://canvas.example.com/announcements/1', $announcement->getHtmlUrl());
-        $this->assertEquals('2024-01-01T10:00:00Z', $announcement->getPostedAt());
-        $this->assertEquals('2024-01-02T10:00:00Z', $announcement->getDelayedPostAt());
+        $this->assertInstanceOf(\DateTime::class, $announcement->getPostedAt());
+        $this->assertEquals('2024-01-01T10:00:00+00:00', $announcement->getPostedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $announcement->getDelayedPostAt());
+        $this->assertEquals('2024-01-02T10:00:00+00:00', $announcement->getDelayedPostAt()->format('c'));
         $this->assertEquals('side_comment', $announcement->getDiscussionType());
         $this->assertFalse($announcement->getRequireInitialPost());
         $this->assertFalse($announcement->getLocked());
@@ -305,7 +307,8 @@ class AnnouncementTest extends TestCase
         $announcement = Announcement::create($createDTO);
 
         $this->assertEquals('DTO Announcement', $announcement->getTitle());
-        $this->assertEquals('2024-03-01T10:00:00Z', $announcement->getDelayedPostAt());
+        $this->assertInstanceOf(\DateTime::class, $announcement->getDelayedPostAt());
+        $this->assertEquals('2024-03-01T10:00:00+00:00', $announcement->getDelayedPostAt()->format('c'));
     }
 
     public function testUpdate(): void
@@ -379,7 +382,8 @@ class AnnouncementTest extends TestCase
         $result = $announcement->scheduleFor('2024-06-01T10:00:00Z');
 
         $this->assertSame($announcement, $result);
-        $this->assertEquals('2024-06-01T10:00:00Z', $announcement->getDelayedPostAt());
+        $this->assertInstanceOf(\DateTime::class, $announcement->getDelayedPostAt());
+        $this->assertEquals('2024-06-01T10:00:00+00:00', $announcement->getDelayedPostAt()->format('c'));
     }
 
     public function testScheduleForThrowsExceptionWhenIdNotSet(): void

--- a/tests/Api/Assignments/AssignmentTest.php
+++ b/tests/Api/Assignments/AssignmentTest.php
@@ -90,10 +90,13 @@ class AssignmentTest extends TestCase
         $this->assertEquals(100.0, $assignment->getPointsPossible());
         $this->assertEquals('points', $assignment->getGradingType());
         $this->assertEquals(['online_text_entry'], $assignment->getSubmissionTypes());
-        $this->assertEquals('2024-12-31T23:59:59Z', $assignment->getDueAt());
+        $this->assertInstanceOf(\DateTime::class, $assignment->getDueAt());
+        $this->assertEquals('2024-12-31T23:59:59+00:00', $assignment->getDueAt()->format('c'));
         $this->assertTrue($assignment->getPublished());
-        $this->assertEquals('2024-01-01T00:00:00Z', $assignment->getCreatedAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $assignment->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $assignment->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assignment->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assignment->getUpdatedAt()->format('c'));
     }
 
     public function testGettersAndSetters(): void
@@ -133,14 +136,17 @@ class AssignmentTest extends TestCase
         $assignment->setAllowedAttempts(3);
         $this->assertEquals(3, $assignment->getAllowedAttempts());
 
-        $assignment->setDueAt('2024-12-31T23:59:59Z');
-        $this->assertEquals('2024-12-31T23:59:59Z', $assignment->getDueAt());
+        $assignment->setDueAt(new \DateTime('2024-12-31T23:59:59Z'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getDueAt());
+        $this->assertEquals('2024-12-31T23:59:59+00:00', $assignment->getDueAt()->format('c'));
 
-        $assignment->setLockAt('2025-01-01T00:00:00Z');
-        $this->assertEquals('2025-01-01T00:00:00Z', $assignment->getLockAt());
+        $assignment->setLockAt(new \DateTime('2025-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getLockAt());
+        $this->assertEquals('2025-01-01T00:00:00+00:00', $assignment->getLockAt()->format('c'));
 
-        $assignment->setUnlockAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $assignment->getUnlockAt());
+        $assignment->setUnlockAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getUnlockAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assignment->getUnlockAt()->format('c'));
 
         $assignment->setPublished(true);
         $this->assertTrue($assignment->getPublished());
@@ -172,11 +178,13 @@ class AssignmentTest extends TestCase
         $assignment->setHasOverrides(true);
         $this->assertTrue($assignment->getHasOverrides());
 
-        $assignment->setCreatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $assignment->getCreatedAt());
+        $assignment->setCreatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assignment->getCreatedAt()->format('c'));
 
-        $assignment->setUpdatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $assignment->getUpdatedAt());
+        $assignment->setUpdatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $assignment->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assignment->getUpdatedAt()->format('c'));
     }
 
     public function testFind(): void
@@ -656,9 +664,9 @@ class AssignmentTest extends TestCase
             'submission_types' => ['online_text_entry'],
             'allowed_extensions' => ['pdf', 'doc'],
             'allowed_attempts' => 3,
-            'due_at' => '2024-12-31T23:59:59Z',
-            'lock_at' => '2025-01-01T00:00:00Z',
-            'unlock_at' => '2024-01-01T00:00:00Z',
+            'due_at' => '2024-12-31T23:59:59+00:00',
+            'lock_at' => '2025-01-01T00:00:00+00:00',
+            'unlock_at' => '2024-01-01T00:00:00+00:00',
             'all_dates' => [],
             'published' => true,
             'workflow_state' => 'published',
@@ -670,8 +678,8 @@ class AssignmentTest extends TestCase
             'group_category_id' => null,
             'html_url' => '/courses/123/assignments/1',
             'has_overrides' => false,
-            'created_at' => '2024-01-01T00:00:00Z',
-            'updated_at' => '2024-01-01T00:00:00Z',
+            'created_at' => '2024-01-01T00:00:00+00:00',
+            'updated_at' => '2024-01-01T00:00:00+00:00',
             'submissions_download_url' => null,
             'due_date_required' => null,
             'max_name_length' => null,
@@ -765,9 +773,9 @@ class AssignmentTest extends TestCase
             'points_possible' => 100.0,
             'grading_type' => 'points',
             'submission_types' => ['online_text_entry'],
-            'due_at' => '2024-12-31T23:59:59Z',
-            'lock_at' => '2025-01-01T00:00:00Z',
-            'unlock_at' => '2024-01-01T00:00:00Z',
+            'due_at' => '2024-12-31T23:59:59+00:00',
+            'lock_at' => '2025-01-01T00:00:00+00:00',
+            'unlock_at' => '2024-01-01T00:00:00+00:00',
             'published' => true,
             'assignment_group_id' => 456,
         ];

--- a/tests/Api/CourseReports/CourseReportsTest.php
+++ b/tests/Api/CourseReports/CourseReportsTest.php
@@ -100,8 +100,10 @@ class CourseReportsTest extends TestCase
         $this->assertEquals(456, $report->id);
         $this->assertEquals('running', $report->status);
         $this->assertEquals(25, $report->progress);
-        $this->assertEquals('2024-01-15T10:00:00Z', $report->createdAt);
-        $this->assertEquals('2024-01-15T10:01:00Z', $report->startedAt);
+        $this->assertInstanceOf(\DateTime::class, $report->createdAt);
+        $this->assertEquals('2024-01-15T10:00:00+00:00', $report->createdAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $report->startedAt);
+        $this->assertEquals('2024-01-15T10:01:00+00:00', $report->startedAt->format('c'));
         $this->assertEquals(['enrollment_term_id' => 789], $report->parameters);
     }
 
@@ -152,7 +154,8 @@ class CourseReportsTest extends TestCase
         $this->assertEquals('complete', $report->status);
         $this->assertEquals('https://canvas.example.com/files/report.csv', $report->fileUrl);
         $this->assertEquals(100, $report->progress);
-        $this->assertEquals('2024-01-15T10:05:00Z', $report->endedAt);
+        $this->assertInstanceOf(\DateTime::class, $report->endedAt);
+        $this->assertEquals('2024-01-15T10:05:00+00:00', $report->endedAt->format('c'));
         $this->assertIsArray($report->attachment);
         $this->assertEquals(789, $report->attachment['id']);
     }
@@ -209,7 +212,8 @@ class CourseReportsTest extends TestCase
         $this->assertEquals(789, $report->id);
         $this->assertEquals('failed', $report->status);
         $this->assertEquals(50, $report->progress);
-        $this->assertEquals('2024-01-15T09:03:00Z', $report->endedAt);
+        $this->assertInstanceOf(\DateTime::class, $report->endedAt);
+        $this->assertEquals('2024-01-15T09:03:00+00:00', $report->endedAt->format('c'));
     }
 
     public function testLastReportThrowsExceptionWithoutCourse(): void
@@ -350,9 +354,9 @@ class CourseReportsTest extends TestCase
             'status' => 'complete',
             'file_url' => 'https://canvas.example.com/files/report.csv',
             'attachment' => ['id' => 456],
-            'created_at' => '2024-01-15T10:00:00Z',
-            'started_at' => '2024-01-15T10:01:00Z',
-            'ended_at' => '2024-01-15T10:05:00Z',
+            'created_at' => '2024-01-15T10:00:00+00:00',
+            'started_at' => '2024-01-15T10:01:00+00:00',
+            'ended_at' => '2024-01-15T10:05:00+00:00',
             'parameters' => ['term_id' => 789],
             'progress' => 100,
         ];
@@ -419,8 +423,11 @@ class CourseReportsTest extends TestCase
 
         // Verify snake_case properties are converted to camelCase
         $this->assertEquals('https://canvas.example.com/files/report.csv', $report->fileUrl);
-        $this->assertEquals('2024-01-15T10:00:00Z', $report->createdAt);
-        $this->assertEquals('2024-01-15T10:01:00Z', $report->startedAt);
-        $this->assertEquals('2024-01-15T10:05:00Z', $report->endedAt);
+        $this->assertInstanceOf(\DateTime::class, $report->createdAt);
+        $this->assertEquals('2024-01-15T10:00:00+00:00', $report->createdAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $report->startedAt);
+        $this->assertEquals('2024-01-15T10:01:00+00:00', $report->startedAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $report->endedAt);
+        $this->assertEquals('2024-01-15T10:05:00+00:00', $report->endedAt->format('c'));
     }
 }

--- a/tests/Api/DiscussionTopics/DiscussionTopicTest.php
+++ b/tests/Api/DiscussionTopics/DiscussionTopicTest.php
@@ -95,7 +95,8 @@ class DiscussionTopicTest extends TestCase
         $this->assertEquals('Test Discussion Topic', $discussionTopic->getTitle());
         $this->assertEquals('Test discussion message', $discussionTopic->getMessage());
         $this->assertEquals('/courses/123/discussion_topics/1', $discussionTopic->getHtmlUrl());
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getPostedAt());
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getPostedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getPostedAt()->format('c'));
         $this->assertEquals('threaded', $discussionTopic->getDiscussionType());
         $this->assertTrue($discussionTopic->getRequireInitialPost());
         $this->assertFalse($discussionTopic->getLocked());
@@ -112,8 +113,10 @@ class DiscussionTopicTest extends TestCase
         $this->assertFalse($discussionTopic->getOnlyGradersCanRate());
         $this->assertFalse($discussionTopic->getGroupTopic());
         $this->assertNull($discussionTopic->getGroupCategoryId());
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getCreatedAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getUpdatedAt()->format('c'));
     }
 
     public function testGettersAndSetters(): void
@@ -132,8 +135,9 @@ class DiscussionTopicTest extends TestCase
         $discussionTopic->setHtmlUrl('/courses/123/discussion_topics/1');
         $this->assertEquals('/courses/123/discussion_topics/1', $discussionTopic->getHtmlUrl());
 
-        $discussionTopic->setPostedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getPostedAt());
+        $discussionTopic->setPostedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getPostedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getPostedAt()->format('c'));
 
         $discussionTopic->setDiscussionType('threaded');
         $this->assertEquals('threaded', $discussionTopic->getDiscussionType());
@@ -186,11 +190,13 @@ class DiscussionTopicTest extends TestCase
         $discussionTopic->setGroupCategoryId(null);
         $this->assertNull($discussionTopic->getGroupCategoryId());
 
-        $discussionTopic->setCreatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getCreatedAt());
+        $discussionTopic->setCreatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getCreatedAt()->format('c'));
 
-        $discussionTopic->setUpdatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $discussionTopic->getUpdatedAt());
+        $discussionTopic->setUpdatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $discussionTopic->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $discussionTopic->getUpdatedAt()->format('c'));
     }
 
     public function testFind(): void
@@ -710,7 +716,7 @@ class DiscussionTopicTest extends TestCase
         $this->assertEquals($data['title'], $array['title']);
         $this->assertEquals($data['message'], $array['message']);
         $this->assertEquals($data['html_url'], $array['html_url']);
-        $this->assertEquals($data['posted_at'], $array['posted_at']);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $array['posted_at']);
         $this->assertEquals($data['discussion_type'], $array['discussion_type']);
         $this->assertEquals($data['require_initial_post'], $array['require_initial_post']);
         $this->assertEquals($data['locked'], $array['locked']);
@@ -727,8 +733,8 @@ class DiscussionTopicTest extends TestCase
         $this->assertEquals($data['only_graders_can_rate'], $array['only_graders_can_rate']);
         $this->assertEquals($data['group_topic'], $array['group_topic']);
         $this->assertEquals($data['group_category_id'], $array['group_category_id']);
-        $this->assertEquals($data['created_at'], $array['created_at']);
-        $this->assertEquals($data['updated_at'], $array['updated_at']);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $array['created_at']);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $array['updated_at']);
     }
 
     public function testToDtoArray(): void
@@ -764,9 +770,10 @@ class DiscussionTopicTest extends TestCase
         $topic = new DiscussionTopic([]);
 
         // Test lastReplyAt
-        $lastReplyAt = '2023-12-25T10:00:00Z';
+        $lastReplyAt = new \DateTime('2023-12-25T10:00:00Z');
         $topic->setLastReplyAt($lastReplyAt);
-        $this->assertEquals($lastReplyAt, $topic->getLastReplyAt());
+        $this->assertInstanceOf(\DateTime::class, $topic->getLastReplyAt());
+        $this->assertEquals('2023-12-25T10:00:00+00:00', $topic->getLastReplyAt()->format('c'));
 
         // Test userCanSeePosts
         $topic->setUserCanSeePosts(true);
@@ -1011,7 +1018,7 @@ class DiscussionTopicTest extends TestCase
 
         $this->assertEquals(123, $array['id']);
         $this->assertEquals('Test Discussion', $array['title']);
-        $this->assertEquals('2023-12-25T10:00:00Z', $array['last_reply_at']);
+        $this->assertEquals('2023-12-25T10:00:00+00:00', $array['last_reply_at']);
         $this->assertTrue($array['user_can_see_posts']);
         $this->assertEquals(15, $array['discussion_subentry_count']);
         $this->assertEquals('read', $array['read_state']);

--- a/tests/Api/Enrollments/EnrollmentTest.php
+++ b/tests/Api/Enrollments/EnrollmentTest.php
@@ -75,8 +75,10 @@ class EnrollmentTest extends TestCase
         $this->assertEquals(456, $enrollment->getSectionId());
         $this->assertEquals(789, $enrollment->getRoleId());
         $this->assertFalse($enrollment->isLimitPrivilegesToCourseSection());
-        $this->assertEquals('2023-01-01T00:00:00Z', $enrollment->getCreatedAt());
-        $this->assertEquals('2023-01-02T00:00:00Z', $enrollment->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getCreatedAt());
+        $this->assertEquals('2023-01-01T00:00:00+00:00', $enrollment->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getUpdatedAt());
+        $this->assertEquals('2023-01-02T00:00:00+00:00', $enrollment->getUpdatedAt()->format('c'));
         $this->assertEquals('StudentEnrollment', $enrollment->getRole());
         $this->assertEquals(85.5, $enrollment->getCurrentScore());
         $this->assertEquals('B', $enrollment->getCurrentGrade());
@@ -86,9 +88,12 @@ class EnrollmentTest extends TestCase
         $this->assertEquals(855.0, $enrollment->getCurrentPoints());
         $this->assertEquals(850.0, $enrollment->getUnpostedCurrentPoints());
         $this->assertEquals(3600, $enrollment->getTotalActivityTime());
-        $this->assertEquals('2023-01-03T00:00:00Z', $enrollment->getLastActivityAt());
-        $this->assertEquals('2023-01-01T00:00:00Z', $enrollment->getStartAt());
-        $this->assertEquals('2023-06-01T00:00:00Z', $enrollment->getEndAt());
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getLastActivityAt());
+        $this->assertEquals('2023-01-03T00:00:00+00:00', $enrollment->getLastActivityAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getStartAt());
+        $this->assertEquals('2023-01-01T00:00:00+00:00', $enrollment->getStartAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getEndAt());
+        $this->assertEquals('2023-06-01T00:00:00+00:00', $enrollment->getEndAt()->format('c'));
         $this->assertTrue($enrollment->canBeRemoved());
         $this->assertFalse($enrollment->isLocked());
         $this->assertEquals('account123', $enrollment->getSisAccountId());
@@ -623,8 +628,8 @@ class EnrollmentTest extends TestCase
         $enrollment->setSectionId(456);
         $enrollment->setRoleId(789);
         $enrollment->setLimitPrivilegesToCourseSection(true);
-        $enrollment->setStartAt('2023-01-01T00:00:00Z');
-        $enrollment->setEndAt('2023-06-01T00:00:00Z');
+        $enrollment->setStartAt(new \DateTime('2023-01-01T00:00:00Z'));
+        $enrollment->setEndAt(new \DateTime('2023-06-01T00:00:00Z'));
         $enrollment->setSisUserId('user123');
 
         $this->assertEquals(100, $enrollment->getUserId());
@@ -633,8 +638,10 @@ class EnrollmentTest extends TestCase
         $this->assertEquals(456, $enrollment->getSectionId());
         $this->assertEquals(789, $enrollment->getRoleId());
         $this->assertTrue($enrollment->isLimitPrivilegesToCourseSection());
-        $this->assertEquals('2023-01-01T00:00:00Z', $enrollment->getStartAt());
-        $this->assertEquals('2023-06-01T00:00:00Z', $enrollment->getEndAt());
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getStartAt());
+        $this->assertEquals('2023-01-01T00:00:00+00:00', $enrollment->getStartAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $enrollment->getEndAt());
+        $this->assertEquals('2023-06-01T00:00:00+00:00', $enrollment->getEndAt()->format('c'));
         $this->assertEquals('user123', $enrollment->getSisUserId());
     }
 

--- a/tests/Api/Files/FileTest.php
+++ b/tests/Api/Files/FileTest.php
@@ -581,8 +581,10 @@ class FileTest extends TestCase
         $this->assertEquals('text/plain', $file->getContentType());
         $this->assertEquals('https://example.com/file.txt', $file->getUrl());
         $this->assertEquals(1024, $file->getSize());
-        $this->assertEquals('2023-01-01T00:00:00Z', $file->getCreatedAt());
-        $this->assertEquals('2023-01-01T00:00:00Z', $file->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $file->getCreatedAt());
+        $this->assertEquals('2023-01-01T00:00:00+00:00', $file->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $file->getUpdatedAt());
+        $this->assertEquals('2023-01-01T00:00:00+00:00', $file->getUpdatedAt()->format('c'));
         $this->assertTrue($file->isLocked());
         $this->assertTrue($file->isHidden());
 
@@ -595,8 +597,8 @@ class FileTest extends TestCase
         $file->setContentType('application/octet-stream');
         $file->setUrl('https://example.com/new-file.txt');
         $file->setSize(2048);
-        $file->setCreatedAt('2024-01-01T00:00:00Z');
-        $file->setUpdatedAt('2024-01-01T00:00:00Z');
+        $file->setCreatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $file->setUpdatedAt(new \DateTime('2024-01-01T00:00:00Z'));
         $file->setLocked(false);
         $file->setHidden(false);
 
@@ -608,8 +610,10 @@ class FileTest extends TestCase
         $this->assertEquals('application/octet-stream', $file->getContentType());
         $this->assertEquals('https://example.com/new-file.txt', $file->getUrl());
         $this->assertEquals(2048, $file->getSize());
-        $this->assertEquals('2024-01-01T00:00:00Z', $file->getCreatedAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $file->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $file->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $file->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $file->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $file->getUpdatedAt()->format('c'));
         $this->assertFalse($file->isLocked());
         $this->assertFalse($file->isHidden());
     }

--- a/tests/Api/OutcomeResults/OutcomeResultTest.php
+++ b/tests/Api/OutcomeResults/OutcomeResultTest.php
@@ -74,7 +74,8 @@ class OutcomeResultTest extends TestCase
         $this->assertInstanceOf(OutcomeResult::class, $results[0]);
         $this->assertEquals(1, $results[0]->id);
         $this->assertEquals(3.5, $results[0]->score);
-        $this->assertEquals('2024-01-15T10:00:00Z', $results[0]->submittedOrAssessedAt);
+        $this->assertInstanceOf(\DateTime::class, $results[0]->submittedOrAssessedAt);
+        $this->assertEquals('2024-01-15T10:00:00+00:00', $results[0]->submittedOrAssessedAt->format('c'));
         $this->assertEquals(1001, $results[0]->links['user']);
     }
 

--- a/tests/Api/Pages/PageTest.php
+++ b/tests/Api/Pages/PageTest.php
@@ -97,8 +97,10 @@ class PageTest extends TestCase
         $this->assertEquals('rce', $page->getEditor());
         $this->assertEquals(['id' => 123, 'version' => '0.2'], $page->getBlockEditorAttributes());
         $this->assertEquals('https://canvas.example.com/courses/123/pages/course-syllabus', $page->getHtmlUrl());
-        $this->assertEquals('2024-01-01T00:00:00Z', $page->getCreatedAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $page->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $page->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $page->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $page->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $page->getUpdatedAt()->format('c'));
         $this->assertEquals(1, $page->getRevisionId());
         $this->assertEquals(42, $page->getPageViewsCount());
     }
@@ -147,11 +149,13 @@ class PageTest extends TestCase
         $page->setHtmlUrl('https://example.com/page');
         $this->assertEquals('https://example.com/page', $page->getHtmlUrl());
 
-        $page->setCreatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $page->getCreatedAt());
+        $page->setCreatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $page->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $page->getCreatedAt()->format('c'));
 
-        $page->setUpdatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $page->getUpdatedAt());
+        $page->setUpdatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $page->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $page->getUpdatedAt()->format('c'));
 
         $lastEditedBy = ['id' => 1, 'name' => 'John Doe'];
         $page->setLastEditedBy($lastEditedBy);

--- a/tests/Api/QuizSubmissions/QuizSubmissionTest.php
+++ b/tests/Api/QuizSubmissions/QuizSubmissionTest.php
@@ -119,9 +119,12 @@ class QuizSubmissionTest extends TestCase
         $this->assertEquals(456, $submission->getQuizId());
         $this->assertEquals(123, $submission->getUserId());
         $this->assertEquals(101112, $submission->getSubmissionId());
-        $this->assertEquals('2024-01-01T12:00:00Z', $submission->getStartedAt());
-        $this->assertEquals('2024-01-01T13:00:00Z', $submission->getFinishedAt());
-        $this->assertEquals('2024-01-01T13:30:00Z', $submission->getEndAt());
+        $this->assertInstanceOf(\DateTime::class, $submission->getStartedAt());
+        $this->assertEquals('2024-01-01T12:00:00+00:00', $submission->getStartedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getFinishedAt());
+        $this->assertEquals('2024-01-01T13:00:00+00:00', $submission->getFinishedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getEndAt());
+        $this->assertEquals('2024-01-01T13:30:00+00:00', $submission->getEndAt()->format('c'));
         $this->assertEquals(1, $submission->getAttempt());
         $this->assertEquals(0, $submission->getExtraAttempts());
         $this->assertEquals(10, $submission->getExtraTime());
@@ -153,14 +156,17 @@ class QuizSubmissionTest extends TestCase
         $submission->setSubmissionId(666);
         $this->assertEquals(666, $submission->getSubmissionId());
 
-        $submission->setStartedAt('2024-02-01T10:00:00Z');
-        $this->assertEquals('2024-02-01T10:00:00Z', $submission->getStartedAt());
+        $submission->setStartedAt(new \DateTime('2024-02-01T10:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getStartedAt());
+        $this->assertEquals('2024-02-01T10:00:00+00:00', $submission->getStartedAt()->format('c'));
 
-        $submission->setFinishedAt('2024-02-01T11:00:00Z');
-        $this->assertEquals('2024-02-01T11:00:00Z', $submission->getFinishedAt());
+        $submission->setFinishedAt(new \DateTime('2024-02-01T11:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getFinishedAt());
+        $this->assertEquals('2024-02-01T11:00:00+00:00', $submission->getFinishedAt()->format('c'));
 
-        $submission->setEndAt('2024-02-01T11:30:00Z');
-        $this->assertEquals('2024-02-01T11:30:00Z', $submission->getEndAt());
+        $submission->setEndAt(new \DateTime('2024-02-01T11:30:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getEndAt());
+        $this->assertEquals('2024-02-01T11:30:00+00:00', $submission->getEndAt()->format('c'));
 
         $submission->setAttempt(2);
         $this->assertEquals(2, $submission->getAttempt());
@@ -564,7 +570,8 @@ class QuizSubmissionTest extends TestCase
 
         $this->assertInstanceOf(QuizSubmission::class, $result);
         $this->assertEquals('complete', $submission->getWorkflowState());
-        $this->assertEquals('2024-01-01T13:00:00Z', $submission->getFinishedAt());
+        $this->assertInstanceOf(\DateTime::class, $submission->getFinishedAt());
+        $this->assertEquals('2024-01-01T13:00:00+00:00', $submission->getFinishedAt()->format('c'));
         $this->assertEquals(85.0, $submission->getScore());
     }
 

--- a/tests/Api/Quizzes/QuizTest.php
+++ b/tests/Api/Quizzes/QuizTest.php
@@ -98,9 +98,12 @@ class QuizTest extends TestCase
         $this->assertEquals(456, $quiz->getAssignmentGroupId());
         $this->assertEquals(60, $quiz->getTimeLimit());
         $this->assertEquals(100.0, $quiz->getPointsPossible());
-        $this->assertEquals('2024-12-31T23:59:59Z', $quiz->getDueAt());
-        $this->assertEquals('2025-01-01T00:00:00Z', $quiz->getLockAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getUnlockAt());
+        $this->assertInstanceOf(\DateTime::class, $quiz->getDueAt());
+        $this->assertEquals('2024-12-31T23:59:59+00:00', $quiz->getDueAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getLockAt());
+        $this->assertEquals('2025-01-01T00:00:00+00:00', $quiz->getLockAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getUnlockAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getUnlockAt()->format('c'));
         $this->assertTrue($quiz->getPublished());
         $this->assertEquals('published', $quiz->getWorkflowState());
         $this->assertTrue($quiz->getShuffleAnswers());
@@ -110,8 +113,10 @@ class QuizTest extends TestCase
         $this->assertEquals('always', $quiz->getHideResults());
         $this->assertEquals('192.168.1.0/24', $quiz->getIpFilter());
         $this->assertEquals('secret123', $quiz->getAccessCode());
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getCreatedAt());
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getUpdatedAt());
+        $this->assertInstanceOf(\DateTime::class, $quiz->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getCreatedAt()->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getUpdatedAt()->format('c'));
     }
 
     public function testGettersAndSetters(): void
@@ -142,14 +147,17 @@ class QuizTest extends TestCase
         $quiz->setPointsPossible(150.0);
         $this->assertEquals(150.0, $quiz->getPointsPossible());
 
-        $quiz->setDueAt('2024-12-31T23:59:59Z');
-        $this->assertEquals('2024-12-31T23:59:59Z', $quiz->getDueAt());
+        $quiz->setDueAt(new \DateTime('2024-12-31T23:59:59Z'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getDueAt());
+        $this->assertEquals('2024-12-31T23:59:59+00:00', $quiz->getDueAt()->format('c'));
 
-        $quiz->setLockAt('2025-01-01T00:00:00Z');
-        $this->assertEquals('2025-01-01T00:00:00Z', $quiz->getLockAt());
+        $quiz->setLockAt(new \DateTime('2025-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getLockAt());
+        $this->assertEquals('2025-01-01T00:00:00+00:00', $quiz->getLockAt()->format('c'));
 
-        $quiz->setUnlockAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getUnlockAt());
+        $quiz->setUnlockAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getUnlockAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getUnlockAt()->format('c'));
 
         $quiz->setPublished(true);
         $this->assertTrue($quiz->getPublished());
@@ -203,11 +211,13 @@ class QuizTest extends TestCase
         $quiz->setAllDates($allDates);
         $this->assertEquals($allDates, $quiz->getAllDates());
 
-        $quiz->setCreatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getCreatedAt());
+        $quiz->setCreatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getCreatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getCreatedAt()->format('c'));
 
-        $quiz->setUpdatedAt('2024-01-01T00:00:00Z');
-        $this->assertEquals('2024-01-01T00:00:00Z', $quiz->getUpdatedAt());
+        $quiz->setUpdatedAt(new \DateTime('2024-01-01T00:00:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $quiz->getUpdatedAt());
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $quiz->getUpdatedAt()->format('c'));
     }
 
     public function testToArray(): void

--- a/tests/Api/Rubrics/RubricAssessmentTest.php
+++ b/tests/Api/Rubrics/RubricAssessmentTest.php
@@ -570,8 +570,10 @@ class RubricAssessmentTest extends TestCase
         $this->assertEquals(222, $assessment->artifactId);
         $this->assertEquals('peer_review', $assessment->assessmentType);
         $this->assertEquals(333, $assessment->provisionalGradeId);
-        $this->assertEquals('2024-01-01T00:00:00Z', $assessment->createdAt);
-        $this->assertEquals('2024-01-02T00:00:00Z', $assessment->updatedAt);
+        $this->assertInstanceOf(\DateTime::class, $assessment->createdAt);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $assessment->createdAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $assessment->updatedAt);
+        $this->assertEquals('2024-01-02T00:00:00+00:00', $assessment->updatedAt->format('c'));
     }
 
     /**

--- a/tests/Api/Rubrics/RubricAssociationTest.php
+++ b/tests/Api/Rubrics/RubricAssociationTest.php
@@ -462,7 +462,9 @@ class RubricAssociationTest extends TestCase
         $this->assertTrue($association->bookmarked);
         $this->assertEquals(600, $association->contextId);
         $this->assertEquals('Course', $association->contextType);
-        $this->assertEquals('2024-01-01T00:00:00Z', $association->createdAt);
-        $this->assertEquals('2024-01-02T00:00:00Z', $association->updatedAt);
+        $this->assertInstanceOf(\DateTime::class, $association->createdAt);
+        $this->assertEquals('2024-01-01T00:00:00+00:00', $association->createdAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $association->updatedAt);
+        $this->assertEquals('2024-01-02T00:00:00+00:00', $association->updatedAt->format('c'));
     }
 }

--- a/tests/Api/Sections/SectionTest.php
+++ b/tests/Api/Sections/SectionTest.php
@@ -319,7 +319,8 @@ class SectionTest extends TestCase
         $section = Section::update(456, $updateData);
 
         $this->assertEquals('Updated Section', $section->name);
-        $this->assertEquals('2024-06-30T17:00:00Z', $section->endAt);
+        $this->assertInstanceOf(\DateTime::class, $section->endAt);
+        $this->assertEquals('2024-06-30T17:00:00+00:00', $section->endAt->format('c'));
     }
 
     public function testCrossList(): void
@@ -457,8 +458,8 @@ class SectionTest extends TestCase
             'name' => 'Section A',
             'sis_section_id' => 's34643',
             'integration_id' => '3452342345',
-            'start_at' => '2024-01-15T08:00:00Z',
-            'end_at' => '2024-05-15T17:00:00Z',
+            'start_at' => '2024-01-15T08:00:00+00:00',
+            'end_at' => '2024-05-15T17:00:00+00:00',
             'restrict_enrollments_to_section_dates' => true,
         ];
 

--- a/tests/Api/SharedBrandConfigs/SharedBrandConfigTest.php
+++ b/tests/Api/SharedBrandConfigs/SharedBrandConfigTest.php
@@ -55,8 +55,10 @@ class SharedBrandConfigTest extends TestCase
         $this->assertEquals('123', $config->accountId);
         $this->assertEquals('a1f113321fa024e7a14cb0948597a2a4', $config->brandConfigMd5);
         $this->assertEquals('Spring Theme', $config->name);
-        $this->assertEquals('2024-01-15T10:00:00Z', $config->createdAt);
-        $this->assertEquals('2024-01-15T11:00:00Z', $config->updatedAt);
+        $this->assertInstanceOf(\DateTime::class, $config->createdAt);
+        $this->assertEquals('2024-01-15T10:00:00+00:00', $config->createdAt->format('c'));
+        $this->assertInstanceOf(\DateTime::class, $config->updatedAt);
+        $this->assertEquals('2024-01-15T11:00:00+00:00', $config->updatedAt->format('c'));
     }
 
     public function testCreateWithArrayData(): void

--- a/tests/Api/Submissions/SubmissionTest.php
+++ b/tests/Api/Submissions/SubmissionTest.php
@@ -106,7 +106,8 @@ class SubmissionTest extends TestCase
         $this->assertEquals('online_text_entry', $submission->getSubmissionType());
         $this->assertEquals('My essay content', $submission->getBody());
         $this->assertEquals('submitted', $submission->getWorkflowState());
-        $this->assertEquals('2024-01-15T10:30:00Z', $submission->getSubmittedAt());
+        $this->assertInstanceOf(\DateTime::class, $submission->getSubmittedAt());
+        $this->assertEquals('2024-01-15T10:30:00+00:00', $submission->getSubmittedAt()->format('c'));
         $this->assertFalse($submission->getLate());
         $this->assertFalse($submission->getExcused());
         $this->assertEquals(85.5, $submission->getScore());
@@ -138,8 +139,9 @@ class SubmissionTest extends TestCase
         $submission->setAttempt(2);
         $this->assertEquals(2, $submission->getAttempt());
 
-        $submission->setSubmittedAt('2024-01-15T10:30:00Z');
-        $this->assertEquals('2024-01-15T10:30:00Z', $submission->getSubmittedAt());
+        $submission->setSubmittedAt(new \DateTime('2024-01-15T10:30:00Z'));
+        $this->assertInstanceOf(\DateTime::class, $submission->getSubmittedAt());
+        $this->assertEquals('2024-01-15T10:30:00+00:00', $submission->getSubmittedAt()->format('c'));
 
         $submission->setScore(95.0);
         $this->assertEquals(95.0, $submission->getScore());
@@ -400,7 +402,8 @@ class SubmissionTest extends TestCase
         $this->assertEquals('graded', $submission->getWorkflowState());
         $this->assertEquals(88.0, $submission->getScore());
         $this->assertEquals('88', $submission->getGrade());
-        $this->assertEquals('2024-01-16T09:15:00Z', $submission->getGradedAt());
+        $this->assertInstanceOf(\DateTime::class, $submission->getGradedAt());
+        $this->assertEquals('2024-01-16T09:15:00+00:00', $submission->getGradedAt()->format('c'));
     }
 
     public function testUpdateWithDTO(): void


### PR DESCRIPTION
## Summary

Standardizes all date/time properties from `?string` to `?DateTime` across 21 model classes (62 date fields total), providing type-safe date handling throughout the SDK.

## Changes

### Core Implementation
- ✅ Updated 21 model classes to use `?\DateTime` instead of `?string` for date properties
- ✅ Enhanced `AbstractBaseApi::castValue()` to recognize 29 date field patterns
- ✅ Updated all `toArray()` methods to serialize DateTime back to ISO-8601 format  
- ✅ Fixed `SharedBrandConfig` to handle DateTime conversion in custom constructor
- ✅ Fixed PSR-12 line length warnings in DTO PHPDoc comments

### Models Updated
Course, Assignment, Quiz, Enrollment, DiscussionTopic, Submission, File, Page, Section, ExternalTool, OutcomeResult, RubricAssessment, RubricAssociation, Login, CourseReports, GroupMembership, DeveloperKey, QuizSubmission, OutcomeImport, Conversation, User, SharedBrandConfig

### Test Coverage
- ✅ Updated 15 test files with 80+ test method assertions
- ✅ All 2376 tests passing
- ✅ 20,884 assertions verified
- ✅ PHPStan Level 8: 0 errors
- ✅ PSR-12 compliant

## Breaking Changes

⚠️ **This is a breaking change for consumers of the SDK**

### Before
```php
$dateString = $course->getCreatedAt(); // "2024-01-15T10:00:00Z"
$course->setStartAt('2024-09-01T08:00:00Z');
```

### After
```php
$date = $course->getCreatedAt(); // DateTime object
$formatted = $course->getCreatedAt()?->format('Y-m-d'); // "2024-01-15"
$iso8601 = $course->getCreatedAt()?->format('c'); // ISO-8601 format

$course->setStartAt(new \DateTime('2024-09-01T08:00:00Z'));
```

## Benefits

- ✅ Type-safe DateTime operations with IDE autocomplete
- ✅ Automatic ISO-8601 parsing eliminates manual conversions
- ✅ Consistent date handling across the entire SDK
- ✅ Prevents TypeError when using save/update operations
- ✅ Better integration with modern PHP date/time features

## Migration Guide

See [CHANGELOG.md](CHANGELOG.md) for complete migration documentation.

## Checklist

- [x] Code follows PSR-12 coding standards
- [x] PHPStan Level 8 passes with 0 errors
- [x] All tests pass (2376/2376)
- [x] Breaking changes documented in CHANGELOG
- [x] Migration guide provided

Resolves #154