### PR TITLE
fix: handle deeply nested arrays in Canvas multipart builder (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fixed Canvas Facade Multipart Builder for Deeply Nested Structures** (#165)
+  - Fixed `Canvas::prepareMultipartData()` to properly handle deeply nested arrays
+  - Implemented recursive `flattenArray()` helper method with proper array type detection
+  - Sequential arrays of scalars now correctly use `[]` suffix (e.g., `colors[]=red, colors[]=blue`)
+  - Sequential arrays of arrays now correctly use numeric indices (e.g., `items[0][name]=A, items[1][name]=B`)
+  - Associative arrays correctly use `[key]` notation (e.g., `user[name]=John, user[age]=30`)
+  - Fixed issue where nested arrays were converted to "Array" string
+  - Added 6 comprehensive test cases covering:
+    - Deeply nested sequential arrays (appointment groups pattern)
+    - Deeply nested associative arrays (bulk grades pattern)
+    - Mixed sequential/associative nesting
+    - Backward compatibility with simple arrays
+    - Empty array handling
+    - String array conversion prevention
+  - **Impact**: Canvas API endpoints requiring deeply nested structures (appointment groups, bulk operations) now work correctly via Canvas facade
+  - **Note**: Standard SDK operations (Course, Assignment, User) were already working correctly via DTOs
+
 ## [1.6.0] - 2025-10-06
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes #165 - Canvas facade multipart builder now correctly handles deeply nested array structures required by certain Canvas API endpoints (appointment groups, bulk grade operations).

## Problem

The `Canvas::prepareMultipartData()` method only flattened arrays one level deep, causing nested arrays to be converted to the string "Array" via PHP's string casting. This broke Canvas API endpoints requiring deeply nested multipart structures.

## Solution

Implemented recursive array flattening with intelligent array type detection:

### Technical Changes
- **Added recursive `flattenArray()` helper method** in [src/Canvas.php](src/Canvas.php)
  - Uses PHP 8.1's `array_is_list()` to distinguish sequential vs associative arrays
  - Sequential arrays of scalars → `[]` suffix (e.g., `colors[]=red, colors[]=blue`)
  - Sequential arrays of arrays → numeric indices (e.g., `items[0][name]=A, items[1][name]=B`)
  - Associative arrays → `[key]` notation (e.g., `user[name]=John, user[age]=30`)
  - Handles arbitrary nesting depth via recursion
  - Preserves resource (file upload) handling

- **Simplified `prepareMultipartData()` method**
  - Delegates to recursive helper for cleaner separation of concerns
  - Added comprehensive PHPDoc with usage examples

### Test Coverage
Added 6 comprehensive test cases in [tests/CanvasTest.php](tests/CanvasTest.php):

1. **Deeply nested sequential arrays** - Validates appointment groups pattern
   ```php
   appointment_group[new_appointments][0][]=2024-01-01T10:00:00Z
   ```

2. **Deeply nested associative arrays** - Validates bulk grades pattern
   ```php
   grade_data[134][posted_grade]=A-
   ```

3. **Mixed sequential/associative nesting** - Validates quiz questions pattern
4. **Backward compatibility** - Ensures simple arrays still work
5. **Empty array handling** - Validates edge case behavior
6. **Prevention of "Array" string conversion** - Verifies core bug fix

## Impact

### What's Fixed ✅
- Canvas API endpoints requiring deeply nested structures now work correctly via Canvas facade
- Appointment groups creation with time slot arrays
- Bulk grade operations with nested submission data
- Any custom endpoint using deeply nested multipart data

### Backward Compatibility ✅
- All existing simple array usage continues to work unchanged
- Standard SDK operations (Course, Assignment, User) unaffected (use DTOs)
- No breaking changes introduced
- All 2396 existing tests pass

## Quality Assurance

- ✅ **Tests**: 2396 tests, 20962 assertions, 0 failures
- ✅ **PHPStan**: Level 6 analysis, 0 errors  
- ✅ **PSR-12**: 0 coding standard violations
- ✅ **Pre-commit hooks**: All checks passed
- ✅ **Code review**: Approved by canvas-php-code-reviewer agent

## Files Changed

- `src/Canvas.php` - Implemented recursive multipart flattening (~70 lines)
- `tests/CanvasTest.php` - Added 6 comprehensive test cases (+312 lines)
- `CHANGELOG.md` - Added entry under [Unreleased] > Fixed

## Testing Instructions

```bash
# Run specific tests for this fix
docker compose exec php ./vendor/bin/phpunit tests/CanvasTest.php --filter="PrepareMultipartData"

# Run full test suite
docker compose exec php composer test

# Run all quality checks
docker compose exec php composer check
```

## Additional Notes

- This fix only affects the Canvas facade's raw API calls (`Canvas::post()`, etc.)
- Standard SDK operations through DTOs were already working correctly
- The recursive implementation has no stack overflow risk (typical depth 2-4 levels)
- Empty arrays produce no multipart fields (expected Canvas API behavior)