### PR TITLE
fix: prevent silent middleware failure with external client (#167)

### DIFF
--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -60,6 +60,15 @@ class HttpClient implements HttpClientInterface
         array $middleware = []
     ) {
         $this->logger = $logger ?? new \Psr\Log\NullLogger();
+
+        // Validate configuration: cannot provide both custom client and middleware
+        if ($client !== null && !empty($middleware)) {
+            throw new \InvalidArgumentException(
+                'Cannot provide both a custom client and middleware. ' .
+                'Either configure middleware on your client or let HttpClient create one.'
+            );
+        }
+
         $this->handlerStack = HandlerStack::create();
 
         // If no middleware provided and no client provided, add sensible defaults


### PR DESCRIPTION
## Summary

Fixes critical bug where middleware passed to HttpClient constructor was silently ignored when using an external Guzzle client. This caused retry, rate limiting, and logging features to be bypassed without warning.

## Changes

### Core Fix
- Added fail-fast validation in `HttpClient` constructor
- Throws `InvalidArgumentException` when both `$client` and non-empty `$middleware` are provided
- Error message provides clear guidance for correct usage

### Test Coverage
- Added `testThrowsExceptionWhenProvidingClientAndMiddleware()` - validates exception for invalid config
- Added `testAllowsClientWithEmptyMiddlewareArray()` - validates edge case works correctly

### Documentation
- Updated CHANGELOG.md with comprehensive entry
- Documented impact, usage patterns, and backward compatibility

## Files Modified

- `src/Http/HttpClient.php` - Added validation logic (7 lines)
- `tests/Http/Middleware/HttpClientMiddlewareTest.php` - Added 2 test methods (38 lines)
- `CHANGELOG.md` - Added comprehensive documentation (17 lines)

## Testing

All quality checks passed:

```bash
# PSR-12 Coding Standards
✅ 0 files needed fixing (all compliant)

# PHPStan Static Analysis (Level 6)
✅ No errors

# Full Test Suite
✅ 2402/2402 tests passed
✅ New tests included:
   - testThrowsExceptionWhenProvidingClientAndMiddleware
   - testAllowsClientWithEmptyMiddlewareArray
```

## Backward Compatibility

✅ **No breaking changes** for valid usage patterns:

### Valid Patterns (Continue to Work)
```php
// Custom client only
new HttpClient($client)                           // ✅

// Middleware only
new HttpClient(null, null, [$middleware])         // ✅

// Neither (gets defaults)
new HttpClient()                                  // ✅

// Client with empty array
new HttpClient($client, null, [])                 // ✅
```

### Invalid Pattern (Now Fails Fast)
```php
// Previously: Silent failure (middleware ignored)
// Now: Clear exception with guidance
new HttpClient($client, null, [$middleware])      // ❌ InvalidArgumentException
```

## Impact

**Before:** Middleware silently ignored → production issues with no retries, rate limiting, or logging
**After:** Immediate exception with clear message → developers fix configuration during development

## Integration Notes

- No changes required to existing code using valid patterns
- No breaking changes to HttpClientInterface
- No Canvas API endpoint changes
- No DTO modifications needed

## Checklist

- [x] Code follows PSR-12 coding standards
- [x] Code passes PHPStan level 6 static analysis
- [x] All tests pass (2402/2402)
- [x] New tests added for both scenarios
- [x] CHANGELOG.md updated
- [x] No breaking changes for valid usage
- [x] Documentation includes usage examples
- [x] Commit message follows conventional format

Closes #167