### PR TITLE
Release v1.7.0: deep code review remediation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
 
@@ -12,42 +12,48 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         dependency-version: ['lowest', 'highest']
-        
+
     name: PHP ${{ matrix.php-version }} - ${{ matrix.dependency-version }} deps
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, curl, json
           coverage: xdebug
           tools: composer:v2
-          
+
       - name: Validate composer.json
         run: composer validate --strict
-        
+
+      - name: Remove platform pin for dependency resolution
+        # composer.json pins platform.php to the floor version for local
+        # reproducibility; in CI each matrix job must resolve dependencies
+        # for its actual PHP version or every job tests the same dep set
+        run: composer config platform.php --unset
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-        
+
       - name: Cache Composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.dependency-version }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.dependency-version }}-${{ hashFiles('composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-composer-${{ matrix.dependency-version }}-
+            ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.dependency-version }}-
             ${{ runner.os }}-composer-
-            
+
       - name: Install dependencies
         run: |
           if [ "${{ matrix.dependency-version }}" = "lowest" ]; then
@@ -55,29 +61,33 @@ jobs:
           else
             composer update --no-interaction --no-progress
           fi
-          
+
+      - name: Audit dependencies for known vulnerabilities
+        run: composer audit
+        if: matrix.dependency-version == 'highest'
+
       - name: Run PHPStan
         run: composer phpstan
-        
+
       - name: Check coding standards
         run: composer cs
-        
-      - name: PHP syntax check
-        run: find src/ -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-        
+
+      - name: Check code style (php-cs-fixer)
+        run: composer cs-strict
+
       - name: Run tests
         run: composer test
         if: matrix.php-version != '8.1' || matrix.dependency-version != 'highest'
-        
+
       - name: Run tests with coverage
         run: vendor/bin/phpunit tests --coverage-clover=coverage/clover.xml
         if: matrix.php-version == '8.1' && matrix.dependency-version == 'highest'
-        
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         if: matrix.php-version == '8.1' && matrix.dependency-version == 'highest'
         with:
-          file: ./coverage/clover.xml
+          files: ./coverage/clover.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,28 +3,23 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Run automated reviews only for PRs from maintainers; fork PRs cannot
+    # access the OAuth secret and unrestricted triggers burn quota
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,15 +28,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -49,31 +40,5 @@ jobs:
             - Canvas LMS API implementation
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
-
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,18 @@ on:
 
 jobs:
   claude:
+    # Author-association gate: anyone can comment @claude on a public repo,
+    # so restrict triggering to maintainers to avoid quota abuse and
+    # prompt injection from arbitrary users
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))) &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event_name == 'issues' && github.event.issue.author_association ||
+        github.event_name == 'pull_request_review' && github.event.review.author_association ||
+        github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,7 +39,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@ebcdfe6dc6bb7511eb63e59e07df256dbcf59a2e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -37,11 +37,13 @@ jobs:
               restore-keys: |
                 ${{ runner.os }}-phpdocumentor-
           - name: Build with phpDocumentor
-            run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -vv --target docs --cache-folder .phpdoc/cache --template default
+            # Render to a clean build dir: publishing docs/ directly would
+            # expose internal planning and strategy documents on Pages
+            run: docker run --rm --volume "$(pwd):/data" phpdoc/phpdoc:3 -vv --target build/apidocs --cache-folder .phpdoc/cache --template default
           - name: Upload artifact to GitHub Pages
             uses: actions/upload-pages-artifact@v3
             with:
-              path: docs
+              path: build/apidocs
 
     deploy:
         needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,34 +9,56 @@ permissions:
   contents: write
 
 jobs:
-  quality:
-    name: Quality Checks
+  verify-version:
+    name: Verify Release Consistency
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
+      - name: Check Version.php and CHANGELOG match the tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          CODE_VERSION=$(php -r "require 'src/Version.php'; echo \CanvasLMS\Version::VERSION;")
+          if [ "$TAG" != "$CODE_VERSION" ]; then
+            echo "::error::Tag v$TAG does not match Version::VERSION ($CODE_VERSION). Update src/Version.php before tagging."
+            exit 1
+          fi
+          if ! grep -q "## \[$TAG\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no entry for version $TAG."
+            exit 1
+          fi
+          echo "Release consistency verified for v$TAG"
+
+  quality:
+    name: Quality Checks
+    needs: verify-version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           extensions: mbstring, curl, json
           coverage: xdebug
           tools: composer:v2
-          
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
-        
+
       - name: Run all quality checks
         run: composer check
-        
+
       - name: Generate coverage report
         run: vendor/bin/phpunit tests --coverage-clover=coverage/clover.xml
-        
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
-          file: ./coverage/clover.xml
+          files: ./coverage/clover.xml
 
   notify-packagist:
     name: Update Packagist

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,13 @@ wiki/
 canvas-lms-*
 
 IMPLEMENTATION_STRUCTURE_RULES.md
+# Local AI assistant and planning artifacts (never commit)
+CLAUDE.md
+AGENTS.md
+GEMINI.md
+.claude/
+[0-9]*_*.md
+PROJECT_REVIEW.md
+
+# OS files
+.DS_Store

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,14 @@ $finder = PhpCsFixer\Finder::create()
     ->ignoreVCS(true);
 
 $config = new PhpCsFixer\Config();
+
+// The codebase targets PHP 8.1 syntax, so style checks are safe to run on
+// PHP versions newer than the fixer officially supports (e.g. the 8.4 CI
+// lane with the lowest-resolved fixer release)
+if (method_exists($config, 'setUnsupportedPhpVersionAllowed')) {
+    $config->setUnsupportedPhpVersionAllowed(true);
+}
+
 return $config
     ->setRiskyAllowed(true)
     ->setRules([

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-11
+
 ### Added
 - `AbstractBaseApi::stream()`: Generator-based pagination that yields hydrated objects page by page, a memory-safe alternative to `all()` for large datasets
 - Cache middleware is now reachable through configuration: `Config::setMiddleware(['cache' => ['adapter' => 'memory'|'file'|'apcu', ...]])` wires `CacheMiddleware` into the HTTP client (the cache subsystem previously had no public activation path)
@@ -711,7 +713,8 @@ Canvas LMS Kit is now production-ready with 90% Canvas API coverage, rate limiti
 - Contributing guidelines
 - Wiki with implementation guides
 
-[Unreleased]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.6.1...HEAD
+[Unreleased]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.6.1...v1.7.0
 [1.6.1]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.5.4...v1.6.0
 [1.5.4]: https://github.com/jjuanrivvera/canvas-lms-kit/compare/v1.5.3...v1.5.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `AbstractBaseApi::stream()`: Generator-based pagination that yields hydrated objects page by page, a memory-safe alternative to `all()` for large datasets
+- Cache middleware is now reachable through configuration: `Config::setMiddleware(['cache' => ['adapter' => 'memory'|'file'|'apcu', ...]])` wires `CacheMiddleware` into the HTTP client (the cache subsystem previously had no public activation path)
+- `AbstractBaseApi::overrideApiClient()` scopes an HTTP client to a single resource class, and `resetApiClients()` clears all client state (intended for test teardown)
+- `BrandConfig::setApiClient()` and `SharedBrandConfig::setApiClient()` for test isolation
+- `composer audit`, PHP 8.4, and php-cs-fixer added to CI; release workflow now verifies the tag matches `Version::VERSION` and the CHANGELOG before publishing
+- Dependabot configuration for Composer and GitHub Actions ecosystems
+
+### Changed
+- `find()` returns `static` (late static binding) across all resources so subclasses receive instances of their own type; previously a mix of `self` and concrete class names
+- 27 model properties on `Course`, `User`, `Module`, `ModuleItem`, and `ModuleAssignmentOverride` are now nullable with `null` defaults; Canvas omits optional fields and accessing an unset typed property previously threw "must not be accessed before initialization". Corresponding getters return nullable types
+- `Course::getStudentCount()`, `getTeacherCount()`, and `getTotalEnrollmentCount()` read totals from pagination metadata (one request with `per_page=1`) instead of fetching every enrollment page
+- `DeveloperKey::save()` data parameter is now optional, defaulting to object state like other resources
+- Property hydration computes reflection type maps once per class instead of per property per object, and `populate()` now applies the same scalar coercion as the constructor
+- `FeatureFlag`, `Analytics`, `BrandConfig`, and `SharedBrandConfig` resolve their HTTP clients through the shared registry, so configured middleware (retry, rate limiting, logging) now applies to them
+- `guzzlehttp/guzzle` minimum raised to `^7.4.5` (security advisories in 7.3.x); `psr/http-message` added as an explicit dependency
+- `FileSystemAdapter` defaults to owner-only permissions (0700 directories, 0600 files) since cached Canvas responses can contain PII
+
+### Fixed
+- `FileSystemAdapter::deleteByPattern()` matched wildcard patterns against md5-hashed filenames and never deleted anything, leaving cache invalidation on mutations silently broken; the original key is now stored in the cache envelope and matched directly
+- DTO `toApiArray()` serializes booleans as `'true'`/`'false'` strings; Guzzle's multipart encoder turned `false` into an empty string, which could fail to clear flags on Canvas
+- OAuth `revokeToken()`/`getSessionToken()` no longer have their manually-set Authorization header overwritten by the configured credential, and OAuth endpoint errors (e.g. `invalid_grant`) now surface in exception messages instead of a generic "Invalid response"
+- `LinkHeaderParser` splits entries only on commas outside angle brackets; pagination URLs containing commas (e.g. `context_codes`) previously broke mid-URL and silently truncated multi-page fetches
+- `Page::find()`, `Login::find()`/`findByAccountAndId()`, and `DeveloperKey::find()` follow pagination instead of scanning only the first page of results
+- `InMemoryAdapter` memory accounting no longer drifts when entries expire or are deleted by pattern
+- `Account::find()` encodes string IDs, and context type parameters are validated against the contexts Canvas supports before URL interpolation
+- `Submission::find()` constructs via `new static`, honoring its declared return type for subclasses
+- `Version::VERSION` corrected to match the released tag (was stale at 1.5.3 since v1.6.0)
+
 ## [1.6.1] - 2025-10-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development Commands
+**All PHP/Composer commands must be run through Docker:**
+- `docker compose exec php composer install` - Install dependencies
+- `docker compose exec php composer check` - Run all checks (coding standards, static analysis, tests)
+- `docker compose exec php composer test` - Run PHPUnit tests with testdox output
+- `docker compose exec php composer cs` - Check PSR-12 coding standards
+- `docker compose exec php composer cs-fix` - Fix PSR-12 coding standard violations automatically
+- `docker compose exec php composer phpstan` - Run PHPStan static analysis (level 8)
+
+### Running Single Tests
+```bash
+docker compose exec php ./vendor/bin/phpunit tests/Api/Courses/CourseTest.php
+docker compose exec php ./vendor/bin/phpunit --filter testMethodName
+```
+
+## Architecture Overview
+
+This is a PHP SDK for Canvas LMS API following these patterns:
+
+### Directory Structure Rules
+**IMPORTANT**: Follow the implementation structure rules defined in `IMPLEMENTATION_STRUCTURE_RULES.md`:
+- Resources with their own Canvas API documentation page get their own namespace
+- Read-only objects without endpoints go in `src/Objects/` folder
+- Always check `canvas-lms-docs/` to determine proper placement
+
+### Active Record Pattern
+API classes (Course, Module, User) act as Active Records:
+- Static methods: `create()`, `find()`, `get()`, `update()`
+- Instance methods: `save()`, `delete()`
+- Example: `$course = Course::find(123)` or `$course->save()`
+
+### Context Management Convention (IMPORTANT)
+**Account-as-Default**: Resources that exist in multiple contexts (Account/Course/User) ALWAYS default to Account context when called directly:
+
+```php
+// ✅ CORRECT - Direct API calls use Account context
+$groups = Group::get();              // Uses Config::getAccountId()
+$rubrics = Rubric::get();            // Uses Config::getAccountId()
+$migrations = ContentMigration::get(); // Uses Config::getAccountId()
+$events = CalendarEvent::get();      // Uses Config::getAccountId()
+$tools = ExternalTool::get();        // Uses Config::getAccountId()
+$files = File::get();                // Uses current user context (exception)
+
+// ✅ CORRECT - Context-specific access via instance methods
+$course = Course::find(123);
+$courseGroups = $course->groups();              // Course context
+$courseMigrations = $course->contentMigrations(); // Course context
+$courseRubrics = $course->rubrics();            // Course context
+$courseTools = $course->externalTools();        // Course context
+$courseEvents = $course->calendarEvents();      // Course context
+$courseFiles = $course->files();                // Course context
+
+$user = User::find(456);
+$userGroups = $user->groups();                    // User context
+
+// ✅ CORRECT - Direct context-specific access when needed
+$courseEvents = CalendarEvent::fetchByContext('course', 123);
+$userFiles = File::fetchByContext('users', 456);
+
+// ❌ NEVER DO THIS - No context parameters in direct calls
+$groups = Group::get($courseId);  // WRONG - not supported
+$rubrics = Rubric::get($courseId); // WRONG - not supported
+```
+
+**Multi-Context Resources**:
+- Groups (Account/Course/User)
+- Content Migrations (Account/Course/Group/User)
+- Rubrics (Account/Course)
+- External Tools (Account/Course)
+- Calendar Events (Account/Course/User/Group)
+- Files (User/Course/Group/Folder) - Note: No Account context support
+
+**Special Cases**:
+- **Files API**: Defaults to current user context (`/users/self/files`) as Canvas doesn't support Account-level files
+- **Calendar Events**: Uses `context_codes` parameter format (e.g., `account_1`, `course_123`)
+
+**Benefits**: Consistency, respects Canvas hierarchy, clean separation of concerns, no ambiguity
+
+### DTO Pattern
+Separate DTOs handle API request formatting:
+- `CreateCourseDTO`, `UpdateCourseDTO` for each entity
+- Transform data to Canvas API multipart format
+- Base class `AbstractBaseDto` handles common transformations
+
+### Configuration
+Global configuration via static `Config` class:
+```php
+Config::setApiKey('your-api-key');
+Config::setBaseUrl('https://canvas.example.com/api/v1');
+Config::setAccountId(1);
+```
+
+### HTTP Client
+- Uses Guzzle HTTP client with interface abstraction
+- Bearer token authentication
+- Custom exceptions for API errors
+- PSR-3 logger support
+
+### Key Classes Structure
+```
+src/
+├── Api/
+│   ├── AbstractBaseApi.php    # Base class with common CRUD operations
+│   ├── Courses/Course.php      # Canvas course operations
+│   ├── Modules/Module.php      # Canvas module operations
+│   └── Users/User.php          # Canvas user operations
+├── Dto/                        # Data Transfer Objects for API requests
+├── Http/HttpClient.php         # HTTP client implementation
+└── Config.php                  # Global configuration management
+```
+
+## Testing Guidelines
+
+- Unit tests use PHPUnit 10.5+
+- Mock HTTP client for API tests using `$this->createMock(HttpClientInterface::class)`
+- Test files mirror source structure in `tests/` directory
+- Run PHPStan at level 8 before committing
+
+## Code Standards
+
+- PSR-12 coding standard enforced
+- PHP 8.1+ features used (typed properties, union types)
+- All public methods have PHPDoc comments
+- Properties use getter/setter pattern with type declarations
+
+## Documentation Structure
+
+### Archived Implementation Plans
+Implementation plans and progress files for completed issues are archived in `docs/archive/implementation-plans/`:
+
+**Completed Issues:**
+- **Issue #8**: Assignments API - Full CRUD operations with DTO support
+- **Issue #10**: ModuleItem API - Dual dependency pattern (Course + Module)
+- **Issue #11**: Tabs API - Course navigation management
+- **Issue #13**: Pagination Support - RFC 5988 compliant Link header parsing
+- **Issue #14**: File Uploads - Canvas 3-step upload process
+- **Issue #18**: GitHub Actions Update - CI/CD pipeline maintenance
+- **Issue #22**: Configuration Management - Multi-tenant context support
+- **Issue #35**: Quizzes API - Complete quiz management with publishing workflow
+
+These archived files demonstrate the documentation-driven development approach and comprehensive planning methodology used throughout the project.
+
+### Strategic Planning
+- Active development tracked via [GitHub Issues](https://github.com/jjuanrivvera/canvas-lms-kit/issues)
+
+## Git Rules and Commit Guidelines
+
+### Critical Git Safety Rules
+**NEVER run `git stash --include-untracked`** - This command will permanently remove untracked files including CLAUDE.md and other documentation files that are essential for project operation. Use `git stash` (without --include-untracked) or `git stash push <specific-files>` instead.
+
+**Safe stash alternatives:**
+- `git stash` - Stash only tracked files
+- `git stash push <file1> <file2>` - Stash specific files
+- `git add <files> && git stash` - Stage files first, then stash
+
+### Staging Files Selectively
+- **Only stage files related to the current feature/fix** - use `git add <specific-files>` instead of `git add .`
+- **Review changes before staging** - use `git status` and `git diff` to verify only relevant changes are included
+- **Exclude unrelated modifications** - development artifacts, temporary files, or changes from other features
+- **Keep commits focused** - each commit should represent a single logical change
+
+### Commit Message Requirements
+- **NEVER mention collaboration with Claude** in commit messages, PR descriptions, or code comments
+- **NEVER include AI-generated signatures** like "Generated with Claude Code" or "Co-Authored-By: Claude"
+- Use conventional commit format: `feat:`, `fix:`, `refactor:`, etc.
+- Write clear, descriptive commit messages that explain the changes
+- Focus on what the code does, not how it was created
+
+### File Management Rules
+**The following files must NEVER be committed:**
+- Any temporary documentation files created during development
+- Any files containing AI collaboration references
+
+### Commit Content Guidelines
+- Commit only production-ready code and documentation
+- Exclude development artifacts, temporary files, and AI-related documentation
+- Include proper documentation for new features in appropriate locations
+- Ensure commit messages are professional and focus on business value
+
+### Example Commit Messages
+✅ **Good:**
+```
+feat: Add user registration form with password validation
+fix: Resolve authentication timeout in SSOController
+refactor: Improve database connection handling
+```
+
+❌ **Bad:**
+```
+feat: Add registration form (generated with Claude)
+fix: Authentication issue - Claude helped debug this
+refactor: DB connection (Co-Authored-By: Claude)
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 - 🚀 **Production Ready**: Rate limiting, middleware support, battle-tested
 - 📚 **Comprehensive**: 45 Canvas APIs fully implemented
-- 🛡️ **Type Safe**: Full PHP 8.1+ type declarations, strict_types, and PHPStan level 6
+- 🛡️ **Type Safe**: Full PHP 8.1+ type declarations, strict_types, and PHPStan level 8
 - 🔧 **Developer Friendly**: Intuitive Active Record pattern - just pass arrays!
 - 📖 **Well Documented**: Extensive examples, guides, and API reference
 - ⚡ **Performance**: Built-in pagination, caching support, and optimized queries
@@ -254,7 +254,8 @@ if (Config::isMasquerading()) {
 ```php
 // Support agent helping a student
 Config::asUser($studentId);
-$submissions = Assignment::find($assignmentId)->getSubmission($studentId);
+Assignment::setCourse(Course::find($courseId));
+$submission = Assignment::find($assignmentId)->submissionForUser($studentId);
 Config::stopMasquerading();
 ```
 
@@ -263,8 +264,8 @@ Config::stopMasquerading();
 // Test different user roles
 foreach ($testUsers as $userId => $role) {
     Config::asUser($userId);
-    $canEdit = Course::find($courseId)->canEdit(); // Check permissions as this user
-    echo "User {$userId} ({$role}): " . ($canEdit ? 'Can edit' : 'Cannot edit') . "\n";
+    $visibleCourses = Course::get(); // Courses visible to this user
+    echo "User {$userId} ({$role}): sees " . count($visibleCourses) . " courses\n";
 }
 Config::stopMasquerading();
 ```
@@ -299,7 +300,7 @@ $courses = Course::get(['per_page' => 50]); // First 50 courses
 // 2. paginate() - Get results with pagination metadata
 $result = Course::paginate(['per_page' => 25]);
 echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
-echo "Total courses: {$result->getTotalCount()}";
+echo "Courses on this page: {$result->getCount()}";
 
 // 3. all() - Fetch ALL items from all pages automatically
 $allCourses = Course::all();  // ⚠️ Use with caution on large datasets!
@@ -332,11 +333,11 @@ do {
     }
     
     // Optional: Add delay to respect rate limits
-    if ($batch->hasNextPage()) {
+    if ($batch->hasNext()) {
         sleep(1);
     }
     
-} while ($batch->hasNextPage());
+} while ($batch->hasNext());
 ```
 
 ### Common Pagination Patterns
@@ -353,10 +354,10 @@ foreach ($result->getData() as $course) {
 }
 
 // Pagination controls
-if ($result->hasPreviousPage()) {
+if ($result->hasPrev()) {
     echo "<a href='?page=" . ($page - 1) . "'>Previous</a>";
 }
-if ($result->hasNextPage()) {
+if ($result->hasNext()) {
     echo "<a href='?page=" . ($page + 1) . "'>Next</a>";
 }
 echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
@@ -365,7 +366,8 @@ echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
 #### Pattern 2: Exporting All Data
 ```php
 // For small datasets (< 1000 items)
-$assignments = Assignment::all(['course_id' => 123]);
+Assignment::setCourse(Course::find(123));
+$assignments = Assignment::all();
 exportToCSV($assignments);
 
 // For large datasets - stream to file
@@ -383,7 +385,7 @@ do {
         ]);
     }
     
-} while ($batch->hasNextPage());
+} while ($batch->hasNext());
 
 fclose($csvFile);
 ```
@@ -391,6 +393,7 @@ fclose($csvFile);
 #### Pattern 3: Finding Specific Items
 ```php
 // When you need just a subset
+Assignment::setCourse(Course::find(123));
 $recentAssignments = Assignment::get([
     'per_page' => 10,
     'order_by' => 'due_at'
@@ -413,7 +416,7 @@ do {
         }
     }
     
-} while ($batch->hasNextPage() && !$found);
+} while ($batch->hasNext() && !$found);
 ```
 
 ### PaginationResult Methods
@@ -425,13 +428,14 @@ $result = Course::paginate(['per_page' => 20]);
 
 // Data access
 $courses = $result->getData();           // Array of Course objects
-$total = $result->getTotalCount();       // Total number of courses
+$count = $result->getCount();            // Number of items on this page
+$result->isEmpty();                      // true if the page has no items
 
 // Navigation
-$result->hasNextPage();                  // true/false
-$result->hasPreviousPage();              // true/false
-$result->getNextPage();                  // Fetches next page (returns new PaginationResult)
-$result->getPreviousPage();              // Fetches previous page
+$result->hasNext();                      // true/false
+$result->hasPrev();                      // true/false
+$result->isFirstPage();                  // true/false
+$result->isLastPage();                   // true/false
 
 // Page information
 $result->getCurrentPage();               // Current page number
@@ -440,17 +444,22 @@ $result->getPerPage();                   // Items per page
 
 // URL access (for custom implementations)
 $result->getNextUrl();                   // Next page URL
-$result->getPreviousUrl();               // Previous page URL
+$result->getPrevUrl();               // Previous page URL
 ```
 
 ### Performance Guidelines
 
 ```php
 // 📗 Small datasets (< 100 items): Safe to use all()
+// Course-scoped resources require course context first
+$course = Course::find(123);
+Module::setCourse($course);
+Section::setCourse($course);
 $modules = Module::all();
 $sections = Section::all();
 
 // 📙 Medium datasets (100-1000 items): Consider your use case
+Assignment::setCourse($course);
 $assignments = Assignment::get(['per_page' => 100]);     // If you need subset
 $assignments = Assignment::paginate(['per_page' => 100]); // If processing batches
 $assignments = Assignment::all();                         // If you need everything
@@ -499,7 +508,7 @@ $allCourses = Course::all();
 
 // Get paginated results with metadata (recommended for large datasets)
 $paginated = Course::paginate(['per_page' => 50]);
-echo "Total courses: " . $paginated->getTotalCount();
+echo "Page {$paginated->getCurrentPage()} of {$paginated->getTotalPages()}";
 
 // Find a specific course
 $course = Course::find(123);
@@ -757,13 +766,13 @@ When working with large Canvas instances (universities, enterprise organizations
 
 ```php
 // ✅ GOOD: Memory-efficient for large datasets
-$result = User::paginate(['per_page' => 100]);
-while ($result) {
+$page = 1;
+do {
+    $result = User::paginate(['page' => $page++, 'per_page' => 100]);
     foreach ($result->getData() as $user) {
         // Process batch of 100 users
     }
-    $result = $result->hasNextPage() ? $result->getNextPage() : null;
-}
+} while ($result->hasNext());
 
 // ✅ GOOD: Get only what you need
 $recentCourses = Course::get(['per_page' => 20]); // Just first 20
@@ -777,7 +786,7 @@ $page = 1;
 do {
     $batch = Enrollment::paginate(['page' => $page++, 'per_page' => 500]);
     // Process batch
-} while ($batch->hasNextPage());
+} while ($batch->hasNext());
 ```
 
 **Memory Guidelines:**
@@ -1027,7 +1036,7 @@ $allCourses = Course::all();
 // 3. paginate() - Get results with pagination metadata
 $result = Course::paginate(['per_page' => 50]);
 echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";
-echo "Total courses: {$result->getTotalCount()}";
+echo "Courses on this page: {$result->getCount()}";
 
 // Access the data
 foreach ($result->getData() as $course) {
@@ -1035,8 +1044,11 @@ foreach ($result->getData() as $course) {
 }
 
 // Navigate pages
-if ($result->hasNextPage()) {
-    $nextPage = $result->getNextPage();
+if ($result->hasNext()) {
+    $nextPage = Course::paginate([
+        'page' => $result->getCurrentPage() + 1,
+        'per_page' => 50,
+    ]);
 }
 ```
 
@@ -1050,10 +1062,11 @@ $course->name = 'New Name';
 $enrollments = $course->save()->enrollments();
 
 // Chain multiple operations
+Assignment::setCourse($course);
 $assignment = new Assignment();
 $assignment->name = 'Final Project';
-$assignment->points_possible = 100;
-$submissions = $assignment->save()->getSubmissions();
+$assignment->pointsPossible = 100;
+$submissions = $assignment->save()->submissions();
 
 // Error handling with fluent interface
 try {
@@ -1162,7 +1175,7 @@ docker compose exec php composer test     # Run PHPUnit tests
 docker compose exec php composer check    # Run all checks (CS, PHPStan, tests)
 docker compose exec php composer cs       # Check PSR-12 coding standards
 docker compose exec php composer cs-fix   # Fix coding standards automatically
-docker compose exec php composer phpstan  # Run static analysis (level 6)
+docker compose exec php composer phpstan  # Run static analysis (level 8)
 
 # Local development (requires PHP 8.1+)
 composer test      # Run PHPUnit tests
@@ -1175,7 +1188,7 @@ composer phpstan   # Static analysis
 ### Code Quality Tools
 
 - **PHP-CS-Fixer**: Automatically fixes code to comply with PSR-12 standards
-- **PHPStan**: Static analysis at level 6 for maximum type safety
+- **PHPStan**: Static analysis at level 8 for maximum type safety
 - **PHPUnit**: Comprehensive test suite with 2,300+ tests
 - **Strict Types**: All files use `declare(strict_types=1)` for type safety
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,12 @@ foreach ($allUsers as $user) {
     processUser($user);
 }
 
-// ✅ CORRECT - Process in batches using paginate()
+// ✅ BEST - stream() lazily yields one object at a time across all pages
+foreach (User::stream(['per_page' => 100]) as $user) {
+    processUser($user);
+}
+
+// ✅ ALSO CORRECT - Process in batches using paginate()
 $page = 1;
 do {
     $batch = User::paginate(['page' => $page++, 'per_page' => 100]);

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ We release patches for security vulnerabilities. Which versions are eligible for
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 1.6.x   | :white_check_mark: |
+| < 1.6   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "ext-json": "*",
         "ext-curl": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.3",
+        "guzzlehttp/guzzle": "^7.4.5",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jjuanrivvera/canvas-lms-kit",
-    "description": "The most comprehensive PHP SDK for Canvas LMS API. Production-ready with +35 APIs implemented, rate limiting, and full test coverage.",
+    "description": "The most comprehensive PHP SDK for Canvas LMS API. Production-ready with 45 APIs implemented, rate limiting, and full test coverage.",
     "keywords": [
         "canvas",
         "canvas-lms",

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.65",
+        "friendsofphp/php-cs-fixer": "^3.76",
         "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6"

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.64",
+        "friendsofphp/php-cs-fixer": "^3.65",
         "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6"

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,7 @@
         "cs": "phpcs --standard=PSR12 src",
         "cs-strict": "php-cs-fixer fix --dry-run --diff",
         "cs-fix": "php-cs-fixer fix",
-        "phpstan": "phpstan analyse --memory-limit=256M",
+        "phpstan": "phpstan analyse --memory-limit=512M",
         "check": [
             "@cs",
             "@cs-strict",

--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-main": "1.0-dev"
+            "dev-main": "1.7-dev"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <extensions>
+    <bootstrap class="Tests\Support\ResetStaticStateExtension"/>
+  </extensions>
   <testsuites>
     <testsuite name="Test Suite">
       <directory>tests</directory>

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -38,45 +38,90 @@ abstract class AbstractBaseApi implements ApiInterface
     ];
 
     /**
+     * Cached property-to-builtin-type maps, keyed by class name.
+     *
+     * Hydrating large result sets previously created a ReflectionClass per
+     * property per object; the map is now computed once per class.
+     *
+     * @var array<class-string, array<string, string|null>>
+     */
+    private static array $propertyTypeCache = [];
+
+    /**
      * BaseApi constructor.
      *
      * @param mixed[] $data
      */
     public function __construct(array $data)
     {
+        $this->hydrate($data);
+    }
+
+    /**
+     * Get the builtin type name for each property of this class.
+     *
+     * @return array<string, string|null> Property name => builtin type name,
+     *                                    or null for non-builtin/untyped properties
+     */
+    private static function getPropertyTypeMap(): array
+    {
+        $class = static::class;
+
+        if (!isset(self::$propertyTypeCache[$class])) {
+            $map = [];
+            $reflection = new \ReflectionClass($class);
+
+            foreach ($reflection->getProperties() as $property) {
+                $type = $property->getType();
+                $map[$property->getName()] = $type instanceof \ReflectionNamedType && $type->isBuiltin()
+                    ? $type->getName()
+                    : null;
+            }
+
+            self::$propertyTypeCache[$class] = $map;
+        }
+
+        return self::$propertyTypeCache[$class];
+    }
+
+    /**
+     * Assign API response data to properties with type coercion.
+     *
+     * Shared by the constructor and populate() so objects keep the same
+     * type guarantees after save()/update() round-trips as on creation.
+     *
+     * @param mixed[] $data
+     *
+     * @return void
+     */
+    protected function hydrate(array $data): void
+    {
+        $typeMap = self::getPropertyTypeMap();
+
         foreach ($data as $key => $value) {
             $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
 
-            if (property_exists($this, $key) && !is_null($value)) {
-                // Handle type conversion for strict_types compatibility
-                $reflection = new \ReflectionClass($this);
-                if ($reflection->hasProperty($key)) {
-                    $property = $reflection->getProperty($key);
-                    $type = $property->getType();
-
-                    if ($type instanceof \ReflectionNamedType && $type->isBuiltin()) {
-                        switch ($type->getName()) {
-                            case 'int':
-                                $value = is_numeric($value) ? (int) $value : null;
-                                break;
-                            case 'float':
-                                $value = is_numeric($value) ? (float) $value : null;
-                                break;
-                            case 'string':
-                                $value = is_scalar($value) ? (string) $value : null;
-                                break;
-                            case 'bool':
-                                $value = (bool) $value;
-                                break;
-                        }
-                    } else {
-                        // For non-builtin types (like DateTime), use castValue()
-                        $value = $this->castValue($key, $value);
-                    }
-                }
-
-                $this->{$key} = $value;
+            if (!array_key_exists($key, $typeMap) || is_null($value)) {
+                continue;
             }
+
+            $builtinType = $typeMap[$key];
+
+            if ($builtinType !== null) {
+                // Coerce scalars for strict_types compatibility
+                $value = match ($builtinType) {
+                    'int' => is_numeric($value) ? (int) $value : null,
+                    'float' => is_numeric($value) ? (float) $value : null,
+                    'string' => is_scalar($value) ? (string) $value : null,
+                    'bool' => (bool) $value,
+                    default => $value,
+                };
+            } else {
+                // For non-builtin types (like DateTime), use castValue()
+                $value = $this->castValue($key, $value);
+            }
+
+            $this->{$key} = $value;
         }
     }
 
@@ -181,13 +226,7 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     protected function populate(array $data): void
     {
-        foreach ($data as $key => $value) {
-            // Convert snake_case keys to camelCase to match property names
-            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
-            if (property_exists($this, $key) && !is_null($value)) {
-                $this->{$key} = $this->castValue($key, $value);
-            }
-        }
+        $this->hydrate($data);
     }
 
     /**

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace CanvasLMS\Api;
 
-use CanvasLMS\Config;
+use CanvasLMS\Http\ApiClientRegistry;
 use CanvasLMS\Http\HttpClient;
-use CanvasLMS\Http\Middleware\LoggingMiddleware;
-use CanvasLMS\Http\Middleware\RateLimitMiddleware;
-use CanvasLMS\Http\Middleware\RetryMiddleware;
 use CanvasLMS\Interfaces\ApiInterface;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Pagination\PaginatedResponse;
@@ -28,11 +25,6 @@ use InvalidArgumentException;
  */
 abstract class AbstractBaseApi implements ApiInterface
 {
-    /**
-     * @var HttpClientInterface
-     */
-    protected static ?HttpClientInterface $apiClient = null;
-
     /**
      * Define method aliases
      *
@@ -89,7 +81,13 @@ abstract class AbstractBaseApi implements ApiInterface
     }
 
     /**
-     * Set the API client
+     * Set the shared default API client used by ALL resource classes.
+     *
+     * Calling this on any resource (e.g. Course::setApiClient()) replaces
+     * the client for every resource, because relationship methods cross
+     * class boundaries ($course->enrollments() calls Enrollment internally).
+     * Use overrideApiClient() to scope a client to a single class, and
+     * resetApiClients() in test teardown to avoid state leaking.
      *
      * @param HttpClientInterface $apiClient
      *
@@ -97,7 +95,30 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     public static function setApiClient(HttpClientInterface $apiClient): void
     {
-        self::$apiClient = $apiClient;
+        ApiClientRegistry::setDefault($apiClient);
+    }
+
+    /**
+     * Set an API client for this class only, leaving other resources on
+     * the shared default.
+     *
+     * @param HttpClientInterface $apiClient
+     *
+     * @return void
+     */
+    public static function overrideApiClient(HttpClientInterface $apiClient): void
+    {
+        ApiClientRegistry::setFor(static::class, $apiClient);
+    }
+
+    /**
+     * Clear the shared default client and all per-class overrides.
+     *
+     * @return void
+     */
+    public static function resetApiClients(): void
+    {
+        ApiClientRegistry::reset();
     }
 
     /**
@@ -107,9 +128,7 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     protected static function checkApiClient(): void
     {
-        if (!isset(self::$apiClient)) {
-            self::$apiClient = self::createConfiguredHttpClient();
-        }
+        static::getApiClient();
     }
 
     /**
@@ -119,11 +138,7 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     protected static function getApiClient(): HttpClientInterface
     {
-        if (self::$apiClient === null) {
-            self::$apiClient = self::createConfiguredHttpClient();
-        }
-
-        return self::$apiClient;
+        return ApiClientRegistry::resolve(static::class);
     }
 
     /**
@@ -133,35 +148,7 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     protected static function createConfiguredHttpClient(): HttpClient
     {
-        $middlewareConfig = Config::getMiddleware();
-        $middleware = [];
-        $logger = null;
-
-        // Check if logging is configured
-        if (isset($middlewareConfig['logging']) && $middlewareConfig['logging']['enabled'] !== false) {
-            // Use the configured logger from Config, defaults to NullLogger if not configured
-            $logger = Config::getLogger();
-        }
-
-        // If middleware config is empty, HttpClient will use defaults
-        if (!empty($middlewareConfig)) {
-            // Build middleware instances from configuration
-            if (isset($middlewareConfig['retry'])) {
-                $middleware[] = new RetryMiddleware($middlewareConfig['retry']);
-            }
-
-            if (isset($middlewareConfig['rate_limit'])) {
-                $middleware[] = new RateLimitMiddleware($middlewareConfig['rate_limit']);
-            }
-
-            if (isset($middlewareConfig['logging']) && $logger !== null) {
-                $loggingConfig = $middlewareConfig['logging'];
-                unset($loggingConfig['enabled']); // Remove the enabled flag
-                $middleware[] = new LoggingMiddleware($logger, $loggingConfig);
-            }
-        }
-
-        return new HttpClient(null, $logger, $middleware);
+        return ApiClientRegistry::createConfiguredHttpClient();
     }
 
     /**

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CanvasLMS\Api;
 
+use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Http\ApiClientRegistry;
 use CanvasLMS\Http\HttpClient;
 use CanvasLMS\Interfaces\ApiInterface;
@@ -395,6 +396,38 @@ abstract class AbstractBaseApi implements ApiInterface
     }
 
     /**
+     * Stream all items across all pages one at a time.
+     *
+     * Unlike all(), only one page of raw data is held in memory at a time,
+     * making this safe for very large datasets (e.g. tens of thousands of
+     * enrollments):
+     *
+     * ```php
+     * foreach (User::stream(['per_page' => 100]) as $user) {
+     *     processUser($user);
+     * }
+     * ```
+     *
+     * @param mixed[] $params Query parameters for the request
+     *
+     * @throws CanvasApiException
+     *
+     * @return \Generator<int, static>
+     */
+    public static function stream(array $params = []): \Generator
+    {
+        static::checkApiClient();
+        $paginatedResponse = self::getPaginatedResponse(static::getEndpoint(), $params);
+
+        do {
+            foreach ($paginatedResponse->getJsonData() as $item) {
+                yield new static($item);
+            }
+            $paginatedResponse = $paginatedResponse->getNext();
+        } while ($paginatedResponse !== null);
+    }
+
+    /**
      * Get paginated results with metadata
      *
      * @param array<string, mixed> $params Query parameters
@@ -432,12 +465,35 @@ abstract class AbstractBaseApi implements ApiInterface
      */
     public static function __callStatic($name, $arguments)
     {
-        foreach (static::$methodAliases as $method => $aliases) {
-            if (is_array($aliases) && in_array($name, $aliases, true)) {
-                return static::{$method}(...$arguments);
-            }
+        $method = static::getAliasMap()[$name] ?? null;
+
+        if ($method !== null) {
+            return static::{$method}(...$arguments);
         }
 
         throw new InvalidArgumentException("Method $name does not exist");
+    }
+
+    /**
+     * Build a flat alias-to-method lookup from $methodAliases.
+     *
+     * @return array<string, string>
+     */
+    protected static function getAliasMap(): array
+    {
+        static $maps = [];
+        $class = static::class;
+
+        if (!isset($maps[$class])) {
+            $map = [];
+            foreach (static::$methodAliases as $method => $aliases) {
+                foreach ($aliases as $alias) {
+                    $map[$alias] = $method;
+                }
+            }
+            $maps[$class] = $map;
+        }
+
+        return $maps[$class];
     }
 }

--- a/src/Api/AbstractBaseApi.php
+++ b/src/Api/AbstractBaseApi.php
@@ -168,6 +168,31 @@ abstract class AbstractBaseApi implements ApiInterface
     }
 
     /**
+     * Validate a context type path segment against an allowlist.
+     *
+     * Context types are interpolated into URL paths; validating against the
+     * contexts Canvas actually supports prevents crafted values from
+     * injecting extra path segments or query parameters.
+     *
+     * @param string|null $contextType The context type (plural, e.g. 'courses'); null is ignored
+     * @param array<int, string> $allowed Allowed context types
+     *
+     * @throws CanvasApiException If the context type is not allowed
+     *
+     * @return void
+     */
+    protected static function validateContext(?string $contextType, array $allowed): void
+    {
+        if ($contextType !== null && !in_array($contextType, $allowed, true)) {
+            throw new CanvasApiException(sprintf(
+                "Invalid context type '%s'. Allowed context types: %s",
+                $contextType,
+                implode(', ', $allowed)
+            ));
+        }
+    }
+
+    /**
      * Check if the API client is set, if not, instantiate a new one
      *
      * @return void

--- a/src/Api/Accounts/Account.php
+++ b/src/Api/Accounts/Account.php
@@ -221,9 +221,9 @@ class Account extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int|string $id, array $params = []): self
+    public static function find(int|string $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -231,7 +231,7 @@ class Account extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $responseData = self::parseJsonResponse($response);
 
-        return new self($responseData);
+        return new static($responseData);
     }
 
     /**

--- a/src/Api/Accounts/Account.php
+++ b/src/Api/Accounts/Account.php
@@ -227,7 +227,9 @@ class Account extends AbstractBaseApi
     {
         self::checkApiClient();
 
-        $endpoint = sprintf('accounts/%s', $id);
+        // Encode string IDs (e.g. sis_account_id:ABC-123): raw values could
+        // inject extra path segments or query parameters
+        $endpoint = sprintf('accounts/%s', rawurlencode((string) $id));
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $responseData = self::parseJsonResponse($response);
 

--- a/src/Api/Admins/Admin.php
+++ b/src/Api/Admins/Admin.php
@@ -158,9 +158,9 @@ class Admin extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $userId, array $params = []): self
+    public static function find(int $userId, array $params = []): static
     {
         self::checkApiClient();
 
@@ -187,7 +187,7 @@ class Admin extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return array<int, self>
+     * @return array<int, static>
      */
     public static function get(array $params = []): array
     {
@@ -205,7 +205,7 @@ class Admin extends AbstractBaseApi
         $responseData = self::parseJsonResponse($response);
 
         return array_map(function ($item) use ($accountId) {
-            $admin = new self($item);
+            $admin = new static($item);
             $admin->accountId = $accountId;
 
             return $admin;
@@ -219,7 +219,7 @@ class Admin extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return array<int, self>
+     * @return array<int, static>
      */
     public static function all(array $params = []): array
     {
@@ -238,7 +238,7 @@ class Admin extends AbstractBaseApi
 
         $admins = [];
         foreach ($allData as $item) {
-            $admin = new self($item);
+            $admin = new static($item);
             $admin->accountId = $accountId;
             $admins[] = $admin;
         }
@@ -272,7 +272,7 @@ class Admin extends AbstractBaseApi
         // Convert data to models with account ID
         $data = [];
         foreach ($paginatedResponse->getJsonData() as $item) {
-            $admin = new self($item);
+            $admin = new static($item);
             $admin->accountId = $accountId;
             $data[] = $admin;
         }

--- a/src/Api/Analytics/Analytics.php
+++ b/src/Api/Analytics/Analytics.php
@@ -6,7 +6,7 @@ namespace CanvasLMS\Api\Analytics;
 
 use CanvasLMS\Config;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Http\HttpClient;
+use CanvasLMS\Http\ApiClientRegistry;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -21,8 +21,6 @@ use Psr\Log\NullLogger;
  */
 class Analytics
 {
-    private static ?HttpClientInterface $httpClient = null;
-
     private static LoggerInterface $logger;
 
     /**
@@ -42,7 +40,7 @@ class Analytics
      */
     public static function setHttpClient(HttpClientInterface $client): void
     {
-        self::$httpClient = $client;
+        ApiClientRegistry::setFor(self::class, $client);
     }
 
     /**
@@ -62,11 +60,7 @@ class Analytics
      */
     private static function getHttpClient(): HttpClientInterface
     {
-        if (self::$httpClient === null) {
-            self::$httpClient = new HttpClient();
-        }
-
-        return self::$httpClient;
+        return ApiClientRegistry::resolve(self::class);
     }
 
     /**

--- a/src/Api/AppointmentGroups/AppointmentGroup.php
+++ b/src/Api/AppointmentGroups/AppointmentGroup.php
@@ -59,6 +59,8 @@ use DateTime;
  * @see https://canvas.instructure.com/doc/api/appointment_groups.html
  *
  * @package CanvasLMS\Api\AppointmentGroups
+ *
+ * @phpstan-consistent-constructor
  */
 class AppointmentGroup extends AbstractBaseApi
 {
@@ -292,16 +294,16 @@ class AppointmentGroup extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
         $endpoint = sprintf('appointment_groups/%d', $id);
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Assignments/Assignment.php
+++ b/src/Api/Assignments/Assignment.php
@@ -70,6 +70,8 @@ use CanvasLMS\Exceptions\CanvasApiException;
  * ```
  *
  * @package CanvasLMS\Api\Assignments
+ *
+ * @phpstan-consistent-constructor
  */
 class Assignment extends AbstractBaseApi
 {
@@ -1344,9 +1346,9 @@ class Assignment extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1355,7 +1357,7 @@ class Assignment extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $assignmentData = self::parseJsonResponse($response);
 
-        return new self($assignmentData);
+        return new static($assignmentData);
     }
 
     /**

--- a/src/Api/Bookmarks/Bookmark.php
+++ b/src/Api/Bookmarks/Bookmark.php
@@ -114,9 +114,9 @@ class Bookmark extends AbstractBaseApi
      *
      * @param int $id Bookmark ID
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $response = self::getApiClient()->get(
             self::getEndpoint() . '/' . $id
@@ -124,7 +124,7 @@ class Bookmark extends AbstractBaseApi
 
         $bookmarkData = self::parseJsonResponse($response);
 
-        return new self($bookmarkData);
+        return new static($bookmarkData);
     }
 
     /**

--- a/src/Api/BrandConfigs/BrandConfig.php
+++ b/src/Api/BrandConfigs/BrandConfig.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace CanvasLMS\Api\BrandConfigs;
 
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Http\HttpClient;
+use CanvasLMS\Http\ApiClientRegistry;
+use CanvasLMS\Interfaces\HttpClientInterface;
 
 /**
  * BrandConfig API
@@ -20,6 +21,18 @@ use CanvasLMS\Http\HttpClient;
  */
 class BrandConfig
 {
+    /**
+     * Set the API client for this class
+     *
+     * @param HttpClientInterface $client
+     *
+     * @return void
+     */
+    public static function setApiClient(HttpClientInterface $client): void
+    {
+        ApiClientRegistry::setFor(self::class, $client);
+    }
+
     /**
      * Get brand config variables for the current domain
      *
@@ -42,7 +55,7 @@ class BrandConfig
      */
     public static function getBrandVariables(): array
     {
-        $httpClient = new HttpClient();
+        $httpClient = ApiClientRegistry::resolve(self::class);
 
         try {
             // This endpoint redirects to a static JSON file

--- a/src/Api/CalendarEvents/CalendarEvent.php
+++ b/src/Api/CalendarEvents/CalendarEvent.php
@@ -400,14 +400,7 @@ class CalendarEvent extends AbstractBaseApi
      */
     public function __construct(array $data = [])
     {
-        foreach ($data as $key => $value) {
-            $key = lcfirst(str_replace('_', '', ucwords($key, '_')));
-
-            if (property_exists($this, $key) && !is_null($value)) {
-                // Use the magic setter to ensure proper casting
-                $this->__set($key, $value);
-            }
-        }
+        parent::__construct($data);
     }
 
     /**
@@ -592,25 +585,13 @@ class CalendarEvent extends AbstractBaseApi
      */
     public function save(): self
     {
+        // Build DTO data from every non-null property; the DTO constructor
+        // keeps only the fields it defines, so new event fields flow through
+        // without maintaining a hardcoded property list here
+        $data = array_filter(get_object_vars($this), static fn ($value) => $value !== null);
+
         if ($this->id) {
-            // Update existing event
-            $data = [];
-
-            // Map properties to DTO data
-            $properties = [
-                'contextCode', 'title', 'description', 'startAt', 'endAt',
-                'locationName', 'locationAddress', 'allDay', 'blackoutDate',
-            ];
-
-            foreach ($properties as $property) {
-                if (property_exists($this, $property) && $this->{$property} !== null) {
-                    $data[$property] = $this->{$property};
-                }
-            }
-
-            $dto = new UpdateCalendarEventDTO($data);
-
-            $updated = self::update($this->id, $dto);
+            $updated = self::update($this->id, new UpdateCalendarEventDTO($data));
 
             // Update current instance with response data
             foreach (get_object_vars($updated) as $key => $value) {
@@ -618,40 +599,21 @@ class CalendarEvent extends AbstractBaseApi
             }
 
             return $this;
-        } else {
-            // Create new event
-            $dto = new CreateCalendarEventDTO([]);
-
-            // Context code is required for creation
-            if (!$this->contextCode) {
-                throw new CanvasApiException('Context code is required to create a calendar event');
-            }
-
-            // Map properties to DTO
-            $properties = [
-                'contextCode', 'title', 'description', 'startAt', 'endAt',
-                'locationName', 'locationAddress', 'allDay', 'rrule', 'blackoutDate',
-            ];
-
-            foreach ($properties as $property) {
-                if (
-                    property_exists($this, $property) &&
-                    property_exists($dto, $property) &&
-                    $this->{$property} !== null
-                ) {
-                    $dto->{$property} = $this->{$property};
-                }
-            }
-
-            $created = self::create($dto);
-
-            // Update current instance with response data
-            foreach (get_object_vars($created) as $key => $value) {
-                $this->{$key} = $value;
-            }
-
-            return $this;
         }
+
+        // Context code is required for creation
+        if (!$this->contextCode) {
+            throw new CanvasApiException('Context code is required to create a calendar event');
+        }
+
+        $created = self::create(new CreateCalendarEventDTO($data));
+
+        // Update current instance with response data
+        foreach (get_object_vars($created) as $key => $value) {
+            $this->{$key} = $value;
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Api/CalendarEvents/CalendarEvent.php
+++ b/src/Api/CalendarEvents/CalendarEvent.php
@@ -72,6 +72,8 @@ use DateTime;
  * @see https://canvas.instructure.com/doc/api/calendar_events.html
  *
  * @package CanvasLMS\Api\CalendarEvents
+ *
+ * @phpstan-consistent-constructor
  */
 class CalendarEvent extends AbstractBaseApi
 {
@@ -433,16 +435,16 @@ class CalendarEvent extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
         $endpoint = sprintf('calendar_events/%d', $id);
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Conferences/Conference.php
+++ b/src/Api/Conferences/Conference.php
@@ -23,6 +23,8 @@ use DateTime;
  * @package CanvasLMS\Api\Conferences
  *
  * @see https://canvas.instructure.com/doc/api/conferences.html
+ *
+ * @phpstan-consistent-constructor
  */
 class Conference extends AbstractBaseApi
 {
@@ -193,16 +195,16 @@ class Conference extends AbstractBaseApi
      *
      * @param int $id The conference ID
      *
-     * @return self The Conference object
+     * @return static The Conference object
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
         $response = self::getApiClient()->get(sprintf('conferences/%d', $id));
         $data = self::parseJsonResponse($response);
 
-        $conference = new self($data);
+        $conference = new static($data);
         $conference->processRecordings($data);
 
         return $conference;

--- a/src/Api/ContentMigrations/ContentMigration.php
+++ b/src/Api/ContentMigrations/ContentMigration.php
@@ -177,6 +177,7 @@ class ContentMigration extends AbstractBaseApi
      */
     public static function findByContext(string $contextType, int $contextId, int $id): self
     {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         self::checkApiClient();
 
         $endpoint = sprintf('%s/%d/content_migrations/%d', $contextType, $contextId, $id);
@@ -215,6 +216,7 @@ class ContentMigration extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         $endpoint = sprintf('%s/%d/content_migrations', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
         $allData = $paginatedResponse->all();
@@ -238,6 +240,8 @@ class ContentMigration extends AbstractBaseApi
         int $contextId,
         array $params = []
     ): PaginatedResponse {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
+
         return self::getPaginatedResponse(sprintf('%s/%d/content_migrations', $contextType, $contextId), $params);
     }
 
@@ -273,6 +277,7 @@ class ContentMigration extends AbstractBaseApi
         int $contextId,
         array|CreateContentMigrationDTO $data
     ): self {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         self::checkApiClient();
 
         if (is_array($data)) {
@@ -668,6 +673,7 @@ class ContentMigration extends AbstractBaseApi
      */
     public static function getMigrators(string $contextType, int $contextId): array
     {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         self::checkApiClient();
 
         $endpoint = sprintf('%s/%d/content_migrations/migrators', $contextType, $contextId);

--- a/src/Api/ContentMigrations/ContentMigration.php
+++ b/src/Api/ContentMigrations/ContentMigration.php
@@ -155,9 +155,9 @@ class ContentMigration extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'Direct find() not supported for ContentMigration. Use findByContext() instead.'

--- a/src/Api/ContentMigrations/MigrationIssue.php
+++ b/src/Api/ContentMigrations/MigrationIssue.php
@@ -139,6 +139,7 @@ class MigrationIssue extends AbstractBaseApi
      */
     public static function findInMigration(string $contextType, int $contextId, int $migrationId, int $id): self
     {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         self::checkApiClient();
 
         $endpoint = sprintf(
@@ -208,6 +209,8 @@ class MigrationIssue extends AbstractBaseApi
         int $migrationId,
         array $params = []
     ): array {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
+
         return self::allInMigration($contextType, $contextId, $migrationId, $params);
     }
 
@@ -229,6 +232,7 @@ class MigrationIssue extends AbstractBaseApi
         int $migrationId,
         array $params = []
     ): PaginatedResponse {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         $endpoint = sprintf(
             '%s/%d/content_migrations/%d/migration_issues',
             $contextType,
@@ -257,6 +261,7 @@ class MigrationIssue extends AbstractBaseApi
         int $migrationId,
         array $params = []
     ): array {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         $endpoint = sprintf(
             '%s/%d/content_migrations/%d/migration_issues',
             $contextType,
@@ -289,6 +294,7 @@ class MigrationIssue extends AbstractBaseApi
         int $id,
         array|UpdateMigrationIssueDTO $data
     ): self {
+        self::validateContext($contextType, ['accounts', 'courses', 'groups', 'users']);
         self::checkApiClient();
 
         if (is_array($data)) {

--- a/src/Api/ContentMigrations/MigrationIssue.php
+++ b/src/Api/ContentMigrations/MigrationIssue.php
@@ -116,9 +116,9 @@ class MigrationIssue extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'Direct find() not supported for MigrationIssue. Use findInMigration() instead.'

--- a/src/Api/Conversations/Conversation.php
+++ b/src/Api/Conversations/Conversation.php
@@ -38,6 +38,8 @@ use CanvasLMS\Objects\ConversationParticipant;
  * @property bool|null $visible Whether the conversation is visible under current scope/filter
  * @property string|null $contextName Name of the course or group in which the conversation is occurring
  * @property array<array<string, mixed>>|null $messages Array of messages in the conversation
+ *
+ * @phpstan-consistent-constructor
  */
 class Conversation extends AbstractBaseApi
 {
@@ -155,9 +157,9 @@ class Conversation extends AbstractBaseApi
      *                      - filter[]: Used for generating "visible" in response
      *                      - filter_mode: and, or, default or
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -169,7 +171,7 @@ class Conversation extends AbstractBaseApi
         $response = self::getApiClient()->get(self::$endpoint . '/' . $id, $params);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/CourseReports/CourseReports.php
+++ b/src/Api/CourseReports/CourseReports.php
@@ -139,7 +139,7 @@ class CourseReports extends AbstractBaseApi
     {
         self::checkCourse();
 
-        $endpoint = sprintf('courses/%d/reports/%s', self::getContextCourseId(), $reportType);
+        $endpoint = sprintf('courses/%d/reports/%s', self::getContextCourseId(), rawurlencode($reportType));
 
         self::checkApiClient();
 
@@ -183,7 +183,12 @@ class CourseReports extends AbstractBaseApi
     {
         self::checkCourse();
 
-        $endpoint = sprintf('courses/%d/reports/%s/%d', self::getContextCourseId(), $reportType, $reportId);
+        $endpoint = sprintf(
+            'courses/%d/reports/%s/%d',
+            self::getContextCourseId(),
+            rawurlencode($reportType),
+            $reportId
+        );
 
         self::checkApiClient();
 
@@ -206,7 +211,7 @@ class CourseReports extends AbstractBaseApi
     {
         self::checkCourse();
 
-        $endpoint = sprintf('courses/%d/reports/%s', self::getContextCourseId(), $reportType);
+        $endpoint = sprintf('courses/%d/reports/%s', self::getContextCourseId(), rawurlencode($reportType));
 
         self::checkApiClient();
 

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -1740,7 +1740,7 @@ class Course extends AbstractBaseApi
      */
     public function getStudentCount(): int
     {
-        return count($this->getStudentEnrollments());
+        return $this->countEnrollments(['type[]' => ['StudentEnrollment']]);
     }
 
     /**
@@ -1752,7 +1752,7 @@ class Course extends AbstractBaseApi
      */
     public function getTeacherCount(): int
     {
-        return count($this->getTeacherEnrollments());
+        return $this->countEnrollments(['type[]' => ['TeacherEnrollment']]);
     }
 
     /**
@@ -1766,7 +1766,32 @@ class Course extends AbstractBaseApi
      */
     public function getTotalEnrollmentCount(array $params = []): int
     {
-        return count($this->enrollments($params));
+        return $this->countEnrollments($params);
+    }
+
+    /**
+     * Count enrollments from pagination metadata instead of fetching them.
+     *
+     * With per_page=1 the last page number in the Link header equals the
+     * total item count, so counting a 5,000-student course costs one
+     * request instead of one hundred.
+     *
+     * @param mixed[] $params Optional parameters to filter the count
+     *
+     * @throws CanvasApiException If course ID is not set or API request fails
+     *
+     * @return int
+     */
+    private function countEnrollments(array $params = []): int
+    {
+        if (!isset($this->id) || !$this->id) {
+            throw new CanvasApiException('Course ID is required to fetch enrollments');
+        }
+
+        Enrollment::setCourse($this);
+        $result = Enrollment::paginate(array_merge($params, ['per_page' => 1]));
+
+        return $result->getTotalPages() ?? $result->getCount();
     }
 
     /**

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -96,6 +96,8 @@ use Exception;
  *```
  *
  * @package CanvasLMS\Api\Courses
+ *
+ * @phpstan-consistent-constructor
  */
 class Course extends AbstractBaseApi
 {
@@ -119,7 +121,7 @@ class Course extends AbstractBaseApi
      *
      * @var string
      */
-    public string $uuid;
+    public ?string $uuid = null;
 
     /**
      * @var string|null
@@ -137,12 +139,12 @@ class Course extends AbstractBaseApi
     /**
      * @var string
      */
-    public string $name;
+    public ?string $name = null;
 
     /**
      * @var string
      */
-    public string $courseCode;
+    public ?string $courseCode = null;
 
     /**
      * @var string|null
@@ -152,17 +154,17 @@ class Course extends AbstractBaseApi
     /**
      * @var string
      */
-    public string $workflowState;
+    public ?string $workflowState = null;
 
     /**
      * @var int
      */
-    public int $accountId;
+    public ?int $accountId = null;
 
     /**
      * @var int
      */
-    public int $rootAccountId;
+    public ?int $rootAccountId = null;
 
     /**
      * @var int|null
@@ -612,9 +614,9 @@ class Course extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -622,7 +624,7 @@ class Course extends AbstractBaseApi
 
         $courseData = self::parseJsonResponse($response);
 
-        return new self($courseData);
+        return new static($courseData);
     }
 
     /**
@@ -1814,9 +1816,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getUuid(): string
+    public function getUuid(): ?string
     {
         return $this->uuid;
     }
@@ -1862,9 +1864,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -1878,9 +1880,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCourseCode(): string
+    public function getCourseCode(): ?string
     {
         return $this->courseCode;
     }
@@ -1910,9 +1912,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getWorkflowState(): string
+    public function getWorkflowState(): ?string
     {
         return $this->workflowState;
     }
@@ -1926,9 +1928,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getAccountId(): int
+    public function getAccountId(): ?int
     {
         return $this->accountId;
     }
@@ -1942,9 +1944,9 @@ class Course extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getRootAccountId(): int
+    public function getRootAccountId(): ?int
     {
         return $this->rootAccountId;
     }

--- a/src/Api/DeveloperKeys/DeveloperKey.php
+++ b/src/Api/DeveloperKeys/DeveloperKey.php
@@ -207,9 +207,9 @@ class DeveloperKey extends AbstractBaseApi
      */
     public static function find(int $id, array $params = []): static
     {
-        $keys = self::get();
-
-        foreach ($keys as $key) {
+        // Canvas has no direct developer-key-by-ID endpoint; stream()
+        // follows pagination and stops at a match
+        foreach (self::stream(array_merge($params, ['per_page' => 100])) as $key) {
             if ($key->id === $id) {
                 return $key;
             }
@@ -264,17 +264,22 @@ class DeveloperKey extends AbstractBaseApi
     /**
      * Update this developer key instance
      *
-     * @param array<string, mixed>|UpdateDeveloperKeyDTO $data Update data
+     * When called without arguments the current object state is sent,
+     * matching the zero-argument save() contract of other resources.
+     *
+     * @param array<string, mixed>|UpdateDeveloperKeyDTO|null $data Update data (defaults to object state)
      *
      * @throws CanvasApiException If update fails or key has no ID
      *
      * @return self The updated DeveloperKey instance
      */
-    public function save(array|UpdateDeveloperKeyDTO $data): self
+    public function save(array|UpdateDeveloperKeyDTO|null $data = null): self
     {
         if (!$this->id) {
             throw new CanvasApiException('Developer key must have an ID to update');
         }
+
+        $data ??= array_filter($this->toDtoArray(), static fn ($value) => $value !== null);
 
         $updatedKey = self::update($this->id, $data);
 

--- a/src/Api/DeveloperKeys/DeveloperKey.php
+++ b/src/Api/DeveloperKeys/DeveloperKey.php
@@ -203,9 +203,9 @@ class DeveloperKey extends AbstractBaseApi
      *
      * @throws CanvasApiException If key not found
      *
-     * @return self The DeveloperKey instance
+     * @return static The DeveloperKey instance
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $keys = self::get();
 
@@ -224,7 +224,7 @@ class DeveloperKey extends AbstractBaseApi
      *
      * @param array<string, mixed> $params Query parameters (e.g., 'inherited' => true)
      *
-     * @return array<self> Array of DeveloperKey instances
+     * @return array<int, static> Array of DeveloperKey instances
      */
     public static function get(array $params = []): array
     {
@@ -234,7 +234,7 @@ class DeveloperKey extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return array_map(fn (array $item) => new self($item), $data);
+        return array_map(fn (array $item) => new static($item), $data);
     }
 
     /**
@@ -254,7 +254,7 @@ class DeveloperKey extends AbstractBaseApi
     /**
      * Get developer keys with inherited keys from Site Admin
      *
-     * @return array<self> Array of DeveloperKey instances including inherited keys
+     * @return array<int, static> Array of DeveloperKey instances including inherited keys
      */
     public static function getWithInherited(): array
     {

--- a/src/Api/DiscussionTopics/DiscussionTopic.php
+++ b/src/Api/DiscussionTopics/DiscussionTopic.php
@@ -71,6 +71,8 @@ use CanvasLMS\Pagination\PaginationResult;
  * ```
  *
  * @package CanvasLMS\Api\DiscussionTopics
+ *
+ * @phpstan-consistent-constructor
  */
 class DiscussionTopic extends AbstractBaseApi
 {
@@ -1541,9 +1543,9 @@ class DiscussionTopic extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1552,7 +1554,7 @@ class DiscussionTopic extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $discussionData = self::parseJsonResponse($response);
 
-        return new self($discussionData);
+        return new static($discussionData);
     }
 
     /**

--- a/src/Api/Enrollments/Enrollment.php
+++ b/src/Api/Enrollments/Enrollment.php
@@ -238,9 +238,9 @@ class Enrollment extends AbstractBaseApi
      */
 
     /**
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -249,7 +249,7 @@ class Enrollment extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/ExternalTools/ExternalTool.php
+++ b/src/Api/ExternalTools/ExternalTool.php
@@ -66,6 +66,8 @@ use CanvasLMS\Pagination\PaginatedResponse;
  * ```
  *
  * @package CanvasLMS\Api\ExternalTools
+ *
+ * @phpstan-consistent-constructor
  */
 class ExternalTool extends AbstractBaseApi
 {
@@ -1088,9 +1090,9 @@ class ExternalTool extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $accountId = Config::getAccountId();
 
@@ -1106,9 +1108,9 @@ class ExternalTool extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function findByContext(string $contextType, int $contextId, int $id): self
+    public static function findByContext(string $contextType, int $contextId, int $id): static
     {
         self::checkApiClient();
 
@@ -1116,7 +1118,7 @@ class ExternalTool extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint);
         $toolData = self::parseJsonResponse($response);
 
-        $tool = new self($toolData);
+        $tool = new static($toolData);
         // Set context information
         $tool->contextType = rtrim($contextType, 's'); // Remove trailing 's'
         $tool->contextId = $contextId;
@@ -1278,7 +1280,7 @@ class ExternalTool extends AbstractBaseApi
         $response = self::getApiClient()->post($endpoint, ['multipart' => $data->toApiArray()]);
         $toolData = self::parseJsonResponse($response);
 
-        $tool = new self($toolData);
+        $tool = new static($toolData);
         // Set context information
         $tool->contextType = rtrim($contextType, 's'); // Remove trailing 's'
         $tool->contextId = $contextId;
@@ -1331,7 +1333,7 @@ class ExternalTool extends AbstractBaseApi
         $response = self::getApiClient()->put($endpoint, ['multipart' => $data->toApiArray()]);
         $toolData = self::parseJsonResponse($response);
 
-        $tool = new self($toolData);
+        $tool = new static($toolData);
         // Set context information
         $tool->contextType = rtrim($contextType, 's'); // Remove trailing 's'
         $tool->contextId = $contextId;

--- a/src/Api/FeatureFlags/FeatureFlag.php
+++ b/src/Api/FeatureFlags/FeatureFlag.php
@@ -22,9 +22,15 @@ use CanvasLMS\Interfaces\HttpClientInterface;
  * @package CanvasLMS\Api\FeatureFlags
  *
  * @see https://canvas.instructure.com/doc/api/feature_flags.html
+ *
+ * @phpstan-consistent-constructor
  */
 class FeatureFlag
 {
+    public function __construct()
+    {
+    }
+
     /**
      * The symbolic name of the feature
      *
@@ -239,9 +245,9 @@ class FeatureFlag
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(string $featureName): self
+    public static function find(string $featureName): static
     {
         $accountId = Config::getAccountId();
 
@@ -257,9 +263,9 @@ class FeatureFlag
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function findByContext(string $contextType, int $contextId, string $featureName): self
+    public static function findByContext(string $contextType, int $contextId, string $featureName): static
     {
         self::validateContextType($contextType);
 
@@ -267,7 +273,7 @@ class FeatureFlag
         $response = self::getApiClient()->get($endpoint);
         $featureData = self::parseJsonResponse($response);
 
-        $feature = new self();
+        $feature = new static();
         self::hydrateProperties($feature, $featureData);
         $feature->contextType = self::normalizeContextType($contextType);
         $feature->contextId = $contextId;
@@ -322,7 +328,7 @@ class FeatureFlag
         ]);
         $featureData = self::parseJsonResponse($response);
 
-        $feature = new self();
+        $feature = new static();
         self::hydrateProperties($feature, $featureData);
         $feature->contextType = self::normalizeContextType($contextType);
         $feature->contextId = $contextId;

--- a/src/Api/FeatureFlags/FeatureFlag.php
+++ b/src/Api/FeatureFlags/FeatureFlag.php
@@ -269,7 +269,7 @@ class FeatureFlag
     {
         self::validateContextType($contextType);
 
-        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, $featureName);
+        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, rawurlencode($featureName));
         $response = self::getApiClient()->get($endpoint);
         $featureData = self::parseJsonResponse($response);
 
@@ -322,7 +322,7 @@ class FeatureFlag
             $data = new UpdateFeatureFlagDTO($data);
         }
 
-        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, $featureName);
+        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, rawurlencode($featureName));
         $response = self::getApiClient()->put($endpoint, [
             'multipart' => $data->toMultipart(),
         ]);
@@ -367,7 +367,7 @@ class FeatureFlag
     {
         self::validateContextType($contextType);
 
-        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, $featureName);
+        $endpoint = sprintf('%s/%d/features/flags/%s', $contextType, $contextId, rawurlencode($featureName));
 
         try {
             self::getApiClient()->delete($endpoint);

--- a/src/Api/FeatureFlags/FeatureFlag.php
+++ b/src/Api/FeatureFlags/FeatureFlag.php
@@ -7,7 +7,7 @@ namespace CanvasLMS\Api\FeatureFlags;
 use CanvasLMS\Config;
 use CanvasLMS\Dto\FeatureFlags\UpdateFeatureFlagDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Http\HttpClient;
+use CanvasLMS\Http\ApiClientRegistry;
 use CanvasLMS\Interfaces\HttpClientInterface;
 
 /**
@@ -25,11 +25,6 @@ use CanvasLMS\Interfaces\HttpClientInterface;
  */
 class FeatureFlag
 {
-    /**
-     * @var HttpClientInterface
-     */
-    protected static HttpClientInterface $apiClient;
-
     /**
      * The symbolic name of the feature
      *
@@ -110,15 +105,14 @@ class FeatureFlag
     /**
      * Get the API client, initializing if necessary
      *
+     * Resolves through the shared registry so configured middleware
+     * (retry, rate limiting, logging) applies to feature flag calls too.
+     *
      * @return HttpClientInterface
      */
     protected static function getApiClient(): HttpClientInterface
     {
-        if (!isset(self::$apiClient)) {
-            self::$apiClient = new HttpClient();
-        }
-
-        return self::$apiClient;
+        return ApiClientRegistry::resolve(self::class);
     }
 
     /**
@@ -143,13 +137,13 @@ class FeatureFlag
     public ?bool $hidden = null;
 
     /**
-     * Set the API client
+     * Set the API client for this class
      *
      * @param HttpClientInterface $client
      */
     public static function setApiClient(HttpClientInterface $client): void
     {
-        self::$apiClient = $client;
+        ApiClientRegistry::setFor(self::class, $client);
     }
 
     /**

--- a/src/Api/Files/File.php
+++ b/src/Api/Files/File.php
@@ -476,9 +476,9 @@ class File extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -486,7 +486,7 @@ class File extends AbstractBaseApi
 
         $fileData = self::parseJsonResponse($response);
 
-        return new self($fileData);
+        return new static($fileData);
     }
 
     /**

--- a/src/Api/GroupCategories/GroupCategory.php
+++ b/src/Api/GroupCategories/GroupCategory.php
@@ -110,9 +110,9 @@ class GroupCategory extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -120,7 +120,7 @@ class GroupCategory extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Groups/Group.php
+++ b/src/Api/Groups/Group.php
@@ -188,9 +188,9 @@ class Group extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -198,7 +198,7 @@ class Group extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Groups/GroupMembership.php
+++ b/src/Api/Groups/GroupMembership.php
@@ -19,6 +19,8 @@ use CanvasLMS\Exceptions\CanvasApiException;
  * @see https://canvas.instructure.com/doc/api/groups.html#group-memberships
  *
  * @package CanvasLMS\Api\Groups
+ *
+ * @phpstan-consistent-constructor
  */
 class GroupMembership extends AbstractBaseApi
 {
@@ -95,9 +97,9 @@ class GroupMembership extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         if (!isset($params['group_id'])) {
             throw new CanvasApiException(
@@ -114,7 +116,7 @@ class GroupMembership extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Logins/Login.php
+++ b/src/Api/Logins/Login.php
@@ -96,11 +96,9 @@ class Login extends AbstractBaseApi
      */
     public static function find(int $id, array $params = []): static
     {
-        // Canvas doesn't have direct login endpoint by ID
-        // We need to fetch all and filter
-        $logins = self::get();
-
-        foreach ($logins as $login) {
+        // Canvas has no direct login endpoint by ID, so scan account
+        // logins; stream() follows pagination and stops at a match
+        foreach (self::stream(array_merge($params, ['per_page' => 100])) as $login) {
             if ($login->id === $id) {
                 return $login;
             }
@@ -144,15 +142,19 @@ class Login extends AbstractBaseApi
      */
     public static function findByAccountAndId(int $accountId, int $loginId): static
     {
-        // Canvas doesn't have a direct endpoint for individual login fetch
-        // We'll need to get all account logins and filter
-        $logins = self::fetchByContext('accounts', $accountId);
+        // Canvas doesn't have a direct endpoint for individual login fetch;
+        // walk the paginated account logins until a match
+        $paginated = self::fetchByContextPaginated('accounts', $accountId, ['per_page' => 100]);
 
-        foreach ($logins as $login) {
-            if ($login->id === $loginId) {
-                return $login;
+        do {
+            foreach ($paginated->getJsonData() as $item) {
+                $login = new static($item);
+                if ($login->id === $loginId) {
+                    return $login;
+                }
             }
-        }
+            $paginated = $paginated->getNext();
+        } while ($paginated !== null);
 
         throw new CanvasApiException("Login with ID {$loginId} not found in account {$accountId}");
     }

--- a/src/Api/Logins/Login.php
+++ b/src/Api/Logins/Login.php
@@ -252,6 +252,7 @@ class Login extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'users']);
         self::checkApiClient();
         $endpoint = sprintf('%s/%d/logins', $contextType, $contextId);
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
@@ -274,6 +275,7 @@ class Login extends AbstractBaseApi
         int $contextId,
         array $params = []
     ): PaginatedResponse {
+        self::validateContext($contextType, ['accounts', 'users']);
         $endpoint = sprintf('%s/%d/logins', $contextType, $contextId);
 
         return self::getPaginatedResponse($endpoint, $params);

--- a/src/Api/Logins/Login.php
+++ b/src/Api/Logins/Login.php
@@ -74,7 +74,7 @@ class Login extends AbstractBaseApi
      *
      * @param array<string, mixed> $params Optional query parameters
      *
-     * @return array<Login> Array of Login objects
+     * @return array<int, static> Array of Login objects
      */
     public static function get(array $params = []): array
     {
@@ -83,7 +83,7 @@ class Login extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return array_map(fn (array $item) => new self($item), $data);
+        return array_map(fn (array $item) => new static($item), $data);
     }
 
     /**
@@ -92,9 +92,9 @@ class Login extends AbstractBaseApi
      *
      * @param int $id The login ID
      *
-     * @return self The Login instance
+     * @return static The Login instance
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         // Canvas doesn't have direct login endpoint by ID
         // We need to fetch all and filter
@@ -140,9 +140,9 @@ class Login extends AbstractBaseApi
      * @param int $accountId The account ID
      * @param int $loginId The login ID
      *
-     * @return self The Login instance
+     * @return static The Login instance
      */
-    public static function findByAccountAndId(int $accountId, int $loginId): self
+    public static function findByAccountAndId(int $accountId, int $loginId): static
     {
         // Canvas doesn't have a direct endpoint for individual login fetch
         // We'll need to get all account logins and filter
@@ -248,7 +248,7 @@ class Login extends AbstractBaseApi
      * @param int $contextId Account or User ID
      * @param array<string, mixed> $params Query parameters
      *
-     * @return array<Login>
+     * @return array<int, static>
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
@@ -257,7 +257,7 @@ class Login extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return array_map(fn (array $item) => new self($item), $data);
+        return array_map(fn (array $item) => new static($item), $data);
     }
 
     /**

--- a/src/Api/MediaObjects/MediaObject.php
+++ b/src/Api/MediaObjects/MediaObject.php
@@ -223,9 +223,9 @@ class MediaObject extends AbstractBaseApi
      *
      * @throws CanvasApiException Always throws as Canvas doesn't support this operation
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException('Direct media object retrieval is not supported by Canvas API');
     }

--- a/src/Api/Modules/Module.php
+++ b/src/Api/Modules/Module.php
@@ -110,6 +110,8 @@ use Exception;
  * ```
  *
  * @package CanvasLMS\Api\Modules
+ *
+ * @phpstan-consistent-constructor
  */
 class Module extends AbstractBaseApi
 {
@@ -150,21 +152,21 @@ class Module extends AbstractBaseApi
      *
      * @var string
      */
-    public string $workflowState;
+    public ?string $workflowState = null;
 
     /**
      * The position of this module in the course (1-based).
      *
      * @var int
      */
-    public int $position;
+    public ?int $position = null;
 
     /**
      * The name of this module.
      *
      * @var string
      */
-    public string $name;
+    public ?string $name = null;
 
     /**
      * The date this module will unlock (Optional).
@@ -178,7 +180,7 @@ class Module extends AbstractBaseApi
      *
      * @var bool
      */
-    public bool $requireSequentialProgress;
+    public ?bool $requireSequentialProgress = null;
 
     /**
      * Whether module requires all required items or one required item to be
@@ -193,21 +195,21 @@ class Module extends AbstractBaseApi
      *
      * @var int[]
      */
-    public array $prerequisiteModuleIds;
+    public ?array $prerequisiteModuleIds = null;
 
     /**
      * The number of items in the module.
      *
      * @var int
      */
-    public int $itemsCount;
+    public ?int $itemsCount = null;
 
     /**
      * The API URL to retrieve this module's items.
      *
      * @var string
      */
-    public string $itemsUrl;
+    public ?string $itemsUrl = null;
 
     /**
      * The contents of this module, as an array of Module Items.
@@ -409,9 +411,9 @@ class Module extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
         self::checkCourse();
@@ -422,7 +424,7 @@ class Module extends AbstractBaseApi
 
         $moduleData = self::parseJsonResponse($response);
 
-        return new self($moduleData);
+        return new static($moduleData);
     }
 
     /**
@@ -489,9 +491,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getWorkflowState(): string
+    public function getWorkflowState(): ?string
     {
         return $this->workflowState;
     }
@@ -505,9 +507,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getPosition(): int
+    public function getPosition(): ?int
     {
         return $this->position;
     }
@@ -521,9 +523,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -553,9 +555,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
-    public function isRequireSequentialProgress(): bool
+    public function isRequireSequentialProgress(): ?bool
     {
         return $this->requireSequentialProgress;
     }
@@ -571,7 +573,7 @@ class Module extends AbstractBaseApi
     /**
      * @return mixed[]
      */
-    public function getPrerequisiteModuleIds(): array
+    public function getPrerequisiteModuleIds(): ?array
     {
         return $this->prerequisiteModuleIds;
     }
@@ -585,9 +587,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getItemsCount(): int
+    public function getItemsCount(): ?int
     {
         return $this->itemsCount;
     }
@@ -601,9 +603,9 @@ class Module extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getItemsUrl(): string
+    public function getItemsUrl(): ?string
     {
         return $this->itemsUrl;
     }

--- a/src/Api/Modules/ModuleAssignmentOverride.php
+++ b/src/Api/Modules/ModuleAssignmentOverride.php
@@ -32,14 +32,14 @@ class ModuleAssignmentOverride
      *
      * @var int
      */
-    public int $contextModuleId;
+    public ?int $contextModuleId = null;
 
     /**
      * The title of the override
      *
      * @var string
      */
-    public string $title;
+    public ?string $title = null;
 
     /**
      * An array of the override's target students
@@ -97,9 +97,9 @@ class ModuleAssignmentOverride
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getContextModuleId(): int
+    public function getContextModuleId(): ?int
     {
         return $this->contextModuleId;
     }
@@ -113,9 +113,9 @@ class ModuleAssignmentOverride
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }

--- a/src/Api/Modules/ModuleItem.php
+++ b/src/Api/Modules/ModuleItem.php
@@ -69,6 +69,8 @@ use Exception;
  * ```
  *
  * @package CanvasLMS\Api\Modules
+ *
+ * @phpstan-consistent-constructor
  */
 class ModuleItem extends AbstractBaseApi
 {
@@ -123,14 +125,14 @@ class ModuleItem extends AbstractBaseApi
      *
      * @var int
      */
-    public int $moduleId;
+    public ?int $moduleId = null;
 
     /**
      * Content type (File, Page, Discussion, Assignment, Quiz, SubHeader, ExternalUrl, ExternalTool).
      *
      * @var string
      */
-    public string $type;
+    public ?string $type = null;
 
     /**
      * ID of associated content object (not required for ExternalUrl, Page, SubHeader).
@@ -144,21 +146,21 @@ class ModuleItem extends AbstractBaseApi
      *
      * @var string
      */
-    public string $title;
+    public ?string $title = null;
 
     /**
      * 1-based position in module.
      *
      * @var int
      */
-    public int $position;
+    public ?int $position = null;
 
     /**
      * 0-based hierarchy indent level (0-5 allowed).
      *
      * @var int
      */
-    public int $indent;
+    public ?int $indent = null;
 
     /**
      * Visibility flag (optional, requires permissions).
@@ -172,7 +174,7 @@ class ModuleItem extends AbstractBaseApi
      *
      * @var string
      */
-    public string $htmlUrl;
+    public ?string $htmlUrl = null;
 
     /**
      * Optional API endpoint URL.
@@ -442,9 +444,9 @@ class ModuleItem extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
         self::checkCourse();
@@ -455,7 +457,7 @@ class ModuleItem extends AbstractBaseApi
 
         $moduleItemData = self::parseJsonResponse($response);
 
-        return new self($moduleItemData);
+        return new static($moduleItemData);
     }
 
     /**
@@ -659,9 +661,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getModuleId(): int
+    public function getModuleId(): ?int
     {
         return $this->moduleId;
     }
@@ -675,9 +677,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }
@@ -707,9 +709,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getTitle(): string
+    public function getTitle(): ?string
     {
         return $this->title;
     }
@@ -723,9 +725,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getPosition(): int
+    public function getPosition(): ?int
     {
         return $this->position;
     }
@@ -739,9 +741,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getIndent(): int
+    public function getIndent(): ?int
     {
         return $this->indent;
     }
@@ -771,9 +773,9 @@ class ModuleItem extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getHtmlUrl(): string
+    public function getHtmlUrl(): ?string
     {
         return $this->htmlUrl;
     }

--- a/src/Api/OutcomeGroups/OutcomeGroup.php
+++ b/src/Api/OutcomeGroups/OutcomeGroup.php
@@ -155,9 +155,9 @@ class OutcomeGroup extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $accountId = Config::getAccountId();
 
@@ -177,9 +177,9 @@ class OutcomeGroup extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function findByContext(?string $contextType, ?int $contextId, int $id): self
+    public static function findByContext(?string $contextType, ?int $contextId, int $id): static
     {
         if ($contextType === null || $contextId === null) {
             return self::findGlobal($id);
@@ -188,7 +188,7 @@ class OutcomeGroup extends AbstractBaseApi
         $endpoint = sprintf('%s/%d/outcome_groups/%d', $contextType, $contextId, $id);
         $response = self::getApiClient()->get($endpoint);
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -198,14 +198,14 @@ class OutcomeGroup extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function findGlobal(int $id): self
+    public static function findGlobal(int $id): static
     {
         $endpoint = sprintf('global/outcome_groups/%d', $id);
         $response = self::getApiClient()->get($endpoint);
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -223,7 +223,7 @@ class OutcomeGroup extends AbstractBaseApi
         $endpoint = sprintf('%s/%d/root_outcome_group', $contextType, $contextId);
         $response = self::getApiClient()->get($endpoint);
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -237,7 +237,7 @@ class OutcomeGroup extends AbstractBaseApi
     {
         $response = self::getApiClient()->get('global/root_outcome_group');
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -284,7 +284,7 @@ class OutcomeGroup extends AbstractBaseApi
             'multipart' => $data->toApiArray(),
         ]);
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -316,7 +316,7 @@ class OutcomeGroup extends AbstractBaseApi
             'multipart' => $data->toApiArray(),
         ]);
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**

--- a/src/Api/OutcomeGroups/OutcomeGroup.php
+++ b/src/Api/OutcomeGroups/OutcomeGroup.php
@@ -119,6 +119,7 @@ class OutcomeGroup extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/outcome_groups', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
         $allData = $paginatedResponse->all();
@@ -142,6 +143,7 @@ class OutcomeGroup extends AbstractBaseApi
         int $contextId,
         array $params = []
     ): PaginationResult {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/outcome_groups', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
 
@@ -181,6 +183,7 @@ class OutcomeGroup extends AbstractBaseApi
      */
     public static function findByContext(?string $contextType, ?int $contextId, int $id): static
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         if ($contextType === null || $contextId === null) {
             return self::findGlobal($id);
         }
@@ -220,6 +223,7 @@ class OutcomeGroup extends AbstractBaseApi
      */
     public static function getRootGroup(string $contextType, int $contextId): self
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/root_outcome_group', $contextType, $contextId);
         $response = self::getApiClient()->get($endpoint);
 
@@ -305,6 +309,7 @@ class OutcomeGroup extends AbstractBaseApi
         array|CreateOutcomeGroupDTO $data,
         ?int $parentGroupId = null
     ): self {
+        self::validateContext($contextType, ['accounts', 'courses']);
         if (is_array($data)) {
             $data = new CreateOutcomeGroupDTO($data);
         }
@@ -651,6 +656,7 @@ class OutcomeGroup extends AbstractBaseApi
      */
     public static function fetchAllLinksByContext(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/outcome_group_links', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
         $allData = $paginatedResponse->all();

--- a/src/Api/Outcomes/Outcome.php
+++ b/src/Api/Outcomes/Outcome.php
@@ -170,13 +170,13 @@ class Outcome extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $response = self::getApiClient()->get(sprintf('outcomes/%d', $id));
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**

--- a/src/Api/Outcomes/Outcome.php
+++ b/src/Api/Outcomes/Outcome.php
@@ -134,6 +134,7 @@ class Outcome extends AbstractBaseApi
      */
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/outcome_groups/global/outcomes', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
         $allData = $paginatedResponse->all();
@@ -157,6 +158,7 @@ class Outcome extends AbstractBaseApi
         int $contextId,
         array $params = []
     ): PaginationResult {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $endpoint = sprintf('%s/%d/outcome_groups/global/outcomes', $contextType, $contextId);
         $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
 
@@ -217,6 +219,7 @@ class Outcome extends AbstractBaseApi
         ?int $groupId,
         array|CreateOutcomeDTO $data
     ): self {
+        self::validateContext($contextType, ['accounts', 'courses']);
         if (is_array($data)) {
             $data = new CreateOutcomeDTO($data);
         }
@@ -322,6 +325,7 @@ class Outcome extends AbstractBaseApi
      */
     public function deleteFromContext(string $contextType, int $contextId, ?int $groupId = null): bool
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         if (!$this->id) {
             throw new CanvasApiException('Outcome ID is required to delete');
         }
@@ -353,6 +357,7 @@ class Outcome extends AbstractBaseApi
      */
     public function getAlignments(string $contextType, int $contextId, array $params = []): array
     {
+        self::validateContext($contextType, ['accounts', 'courses']);
         if (!$this->id) {
             throw new CanvasApiException('Outcome ID is required to get alignments');
         }
@@ -466,6 +471,7 @@ class Outcome extends AbstractBaseApi
         string $vendorGuid,
         ?int $groupId = null
     ): self {
+        self::validateContext($contextType, ['accounts', 'courses']);
         $groupPath = $groupId ? (string) $groupId : 'global';
         $endpoint = sprintf('%s/%d/outcome_groups/%s/import', $contextType, $contextId, $groupPath);
 

--- a/src/Api/Pages/Page.php
+++ b/src/Api/Pages/Page.php
@@ -817,22 +817,14 @@ class Page extends AbstractBaseApi
         self::checkCourse();
         self::checkApiClient();
 
-        // First, fetch all pages to find the one with matching pageId
-        // Canvas API doesn't provide direct page lookup by numeric ID
-        $endpoint = sprintf('courses/%d/pages', self::getContextCourseId());
-        $response = self::getApiClient()->get($endpoint);
-        $pagesData = self::parseJsonResponse($response);
-
-        foreach ($pagesData as $pageData) {
-            if (isset($pageData['page_id']) && $pageData['page_id'] === $id) {
+        // Canvas has no direct page lookup by numeric ID, so scan the
+        // course pages; stream() follows pagination and stops at a match
+        foreach (self::stream(array_merge($params, ['per_page' => 100])) as $page) {
+            if ($page->pageId === $id) {
                 // Found the page, now fetch full details by URL
-                return self::findByUrl($pageData['url']);
+                return self::findByUrl((string) $page->url);
             }
         }
-
-        // If not found in first page, we need to check all pages
-        // For simplicity in testing, we'll just throw the exception here
-        // In a real implementation, you'd paginate through all results
 
         throw new CanvasApiException("Page with ID {$id} not found in course " . self::getContextCourseId());
     }

--- a/src/Api/Pages/Page.php
+++ b/src/Api/Pages/Page.php
@@ -68,6 +68,8 @@ use CanvasLMS\Objects\PageRevision;
  * ```
  *
  * @package CanvasLMS\Api\Pages
+ *
+ * @phpstan-consistent-constructor
  */
 class Page extends AbstractBaseApi
 {
@@ -808,9 +810,9 @@ class Page extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -842,9 +844,9 @@ class Page extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function findByUrl(string $url): self
+    public static function findByUrl(string $url): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -853,7 +855,7 @@ class Page extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint);
         $pageData = self::parseJsonResponse($response);
 
-        return new self($pageData);
+        return new static($pageData);
     }
 
     /**
@@ -914,7 +916,7 @@ class Page extends AbstractBaseApi
         $response = self::getApiClient()->post($endpoint, ['multipart' => $data->toApiArray()]);
         $pageData = self::parseJsonResponse($response);
 
-        return new self($pageData);
+        return new static($pageData);
     }
 
     /**
@@ -940,7 +942,7 @@ class Page extends AbstractBaseApi
         $response = self::getApiClient()->put($endpoint, ['multipart' => $data->toApiArray()]);
         $pageData = self::parseJsonResponse($response);
 
-        return new self($pageData);
+        return new static($pageData);
     }
 
     /**
@@ -1216,7 +1218,7 @@ class Page extends AbstractBaseApi
         $response = self::getApiClient()->post($endpoint);
         $pageData = self::parseJsonResponse($response);
 
-        return new self($pageData);
+        return new static($pageData);
     }
 
     /**
@@ -1303,7 +1305,7 @@ class Page extends AbstractBaseApi
         $response = self::getApiClient()->put($endpoint, ['multipart' => $data->toApiArray()]);
         $pageData = self::parseJsonResponse($response);
 
-        return new self($pageData);
+        return new static($pageData);
     }
 
     // Relationship Methods

--- a/src/Api/Progress/Progress.php
+++ b/src/Api/Progress/Progress.php
@@ -47,6 +47,8 @@ use Exception;
  * ```
  *
  * @package CanvasLMS\Api\Progress
+ *
+ * @phpstan-consistent-constructor
  */
 class Progress extends AbstractBaseApi
 {
@@ -169,16 +171,16 @@ class Progress extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return Progress
+     * @return static
      */
-    public static function find(int $id, array $params = []): Progress
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
         $response = self::getApiClient()->get("/progress/{$id}");
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/QuizSubmissions/QuizSubmission.php
+++ b/src/Api/QuizSubmissions/QuizSubmission.php
@@ -852,7 +852,9 @@ class QuizSubmission extends AbstractBaseApi
             foreach ($data as $key => $value) {
                 $requestData[] = [
                     'name' => $key,
-                    'contents' => $value,
+                    // Booleans must be stringified: Guzzle's multipart encoder
+                    // turns false into an empty string
+                    'contents' => is_bool($value) ? ($value ? 'true' : 'false') : $value,
                 ];
             }
         }

--- a/src/Api/QuizSubmissions/QuizSubmission.php
+++ b/src/Api/QuizSubmissions/QuizSubmission.php
@@ -681,9 +681,9 @@ class QuizSubmission extends AbstractBaseApi
      *
      * @throws CanvasApiException If course/quiz not set or API error
      *
-     * @return self Quiz submission instance
+     * @return static Quiz submission instance
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkContext();
 
@@ -700,7 +700,7 @@ class QuizSubmission extends AbstractBaseApi
 
         $data = $responseData['quiz_submissions'][0] ?? $responseData;
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Quizzes/Quiz.php
+++ b/src/Api/Quizzes/Quiz.php
@@ -69,6 +69,8 @@ use CanvasLMS\Exceptions\CanvasApiException;
  * ```
  *
  * @package CanvasLMS\Api\Quizzes
+ *
+ * @phpstan-consistent-constructor
  */
 class Quiz extends AbstractBaseApi
 {
@@ -1122,9 +1124,9 @@ class Quiz extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkCourse();
         self::checkApiClient();
@@ -1133,7 +1135,7 @@ class Quiz extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint);
         $quizData = self::parseJsonResponse($response);
 
-        return new self($quizData);
+        return new static($quizData);
     }
 
     /**

--- a/src/Api/Rubrics/Rubric.php
+++ b/src/Api/Rubrics/Rubric.php
@@ -37,15 +37,15 @@ use CanvasLMS\Pagination\PaginatedResponse;
  * $rubrics = $course->rubrics();
  *
  * // Direct context access
- * $rubrics = Rubric::fetchByContext('course', 123);
- * $rubric = Rubric::createInContext('course', 123, [
+ * $rubrics = Rubric::fetchByContext('courses', 123);
+ * $rubric = Rubric::createInContext('courses', 123, [
  *     'title' => 'Course Rubric',
  *     'criteria' => [...]
  * ]);
  *
  * // Finding and updating rubrics
  * $rubric = Rubric::find(456); // Searches in account context
- * $rubric = Rubric::findByContext('course', 123, 456); // Course-specific
+ * $rubric = Rubric::findByContext('courses', 123, 456); // Course-specific
  *
  * $rubric = Rubric::update(456, [
  *     'title' => 'Updated Rubric'

--- a/src/Api/Rubrics/Rubric.php
+++ b/src/Api/Rubrics/Rubric.php
@@ -59,6 +59,8 @@ use CanvasLMS\Pagination\PaginatedResponse;
  * ```
  *
  * @package CanvasLMS\Api\Rubrics
+ *
+ * @phpstan-consistent-constructor
  */
 class Rubric extends AbstractBaseApi
 {
@@ -247,9 +249,9 @@ class Rubric extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         $accountId = Config::getAccountId();
 
@@ -266,21 +268,21 @@ class Rubric extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
     public static function findByContext(
         string $contextType,
         ?int $contextId,
         int $id,
         array $params = []
-    ): self {
+    ): static {
         self::checkApiClient();
 
         $endpoint = sprintf('%s/%d/rubrics/%d', $contextType, $contextId, $id);
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/Rubrics/RubricAssessment.php
+++ b/src/Api/Rubrics/RubricAssessment.php
@@ -489,9 +489,9 @@ class RubricAssessment extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'Finding individual rubric assessments is not supported by the Canvas API. ' .

--- a/src/Api/Rubrics/RubricAssociation.php
+++ b/src/Api/Rubrics/RubricAssociation.php
@@ -387,9 +387,9 @@ class RubricAssociation extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new CanvasApiException(
             'Finding individual rubric associations is not supported by the Canvas API. ' .

--- a/src/Api/Sections/Section.php
+++ b/src/Api/Sections/Section.php
@@ -55,6 +55,8 @@ use CanvasLMS\Exceptions\CanvasApiException;
  * ```
  *
  * @package CanvasLMS\Api\Sections
+ *
+ * @phpstan-consistent-constructor
  */
 class Section extends AbstractBaseApi
 {
@@ -220,9 +222,9 @@ class Section extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
@@ -236,7 +238,7 @@ class Section extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $data = self::parseJsonResponse($response);
 
-        return new self($data);
+        return new static($data);
     }
 
     /**

--- a/src/Api/SharedBrandConfigs/SharedBrandConfig.php
+++ b/src/Api/SharedBrandConfigs/SharedBrandConfig.php
@@ -8,7 +8,8 @@ use CanvasLMS\Config;
 use CanvasLMS\Dto\SharedBrandConfigs\CreateSharedBrandConfigDTO;
 use CanvasLMS\Dto\SharedBrandConfigs\UpdateSharedBrandConfigDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
-use CanvasLMS\Http\HttpClient;
+use CanvasLMS\Http\ApiClientRegistry;
+use CanvasLMS\Interfaces\HttpClientInterface;
 
 /**
  * SharedBrandConfig API
@@ -28,6 +29,18 @@ use CanvasLMS\Http\HttpClient;
  */
 class SharedBrandConfig
 {
+    /**
+     * Set the API client for this class
+     *
+     * @param HttpClientInterface $client
+     *
+     * @return void
+     */
+    public static function setApiClient(HttpClientInterface $client): void
+    {
+        ApiClientRegistry::setFor(self::class, $client);
+    }
+
     /**
      * The shared brand config identifier
      */
@@ -117,7 +130,7 @@ class SharedBrandConfig
             $data = new CreateSharedBrandConfigDTO($data);
         }
 
-        $httpClient = new HttpClient();
+        $httpClient = ApiClientRegistry::resolve(self::class);
         $accountId = Config::getAccountId();
 
         try {
@@ -178,7 +191,7 @@ class SharedBrandConfig
             $data = new UpdateSharedBrandConfigDTO($data);
         }
 
-        $httpClient = new HttpClient();
+        $httpClient = ApiClientRegistry::resolve(self::class);
         $accountId = Config::getAccountId();
 
         try {
@@ -235,7 +248,7 @@ class SharedBrandConfig
      */
     public static function delete(int $id): self
     {
-        $httpClient = new HttpClient();
+        $httpClient = ApiClientRegistry::resolve(self::class);
 
         try {
             // NOTE: Different endpoint pattern - no account_id in path!

--- a/src/Api/SubmissionComments/SubmissionComment.php
+++ b/src/Api/SubmissionComments/SubmissionComment.php
@@ -332,7 +332,7 @@ class SubmissionComment extends AbstractBaseApi
      *
      * @throws Exception
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         throw new Exception(
             'SubmissionComment::find() is not supported by Canvas API. Comments are retrieved through submissions.'

--- a/src/Api/Submissions/Submission.php
+++ b/src/Api/Submissions/Submission.php
@@ -420,8 +420,7 @@ class Submission extends AbstractBaseApi
         $response = self::getApiClient()->get($endpoint, ['query' => $params]);
         $submissionData = self::parseJsonResponse($response);
 
-        /** @phpstan-ignore-next-line */
-        return new self($submissionData);
+        return new static($submissionData);
     }
 
     /**

--- a/src/Api/Users/User.php
+++ b/src/Api/Users/User.php
@@ -105,7 +105,7 @@ class User extends AbstractBaseApi
      *
      * @var string
      */
-    public string $name;
+    public ?string $name = null;
 
     /**
      * The name of the user that it should be used for sorting groups of users, such
@@ -113,21 +113,21 @@ class User extends AbstractBaseApi
      *
      * @var string
      */
-    public string $sortableName;
+    public ?string $sortableName = null;
 
     /**
      * The last name of the user.
      *
      * @var string
      */
-    public string $lastName;
+    public ?string $lastName = null;
 
     /**
      * The first name of the user.
      *
      * @var string
      */
-    public string $firstName;
+    public ?string $firstName = null;
 
     /**
      * A short name the user has selected, for use in conversations or other less
@@ -135,7 +135,7 @@ class User extends AbstractBaseApi
      *
      * @var string
      */
-    public string $shortName;
+    public ?string $shortName = null;
 
     /**
      * The SIS ID associated with the user. This field is only included if the user
@@ -167,7 +167,7 @@ class User extends AbstractBaseApi
      *
      * @var string
      */
-    public string $loginId;
+    public ?string $loginId = null;
 
     /**
      * If avatars are enabled, this field will be included and contain a url to
@@ -373,15 +373,15 @@ class User extends AbstractBaseApi
      *
      * @throws CanvasApiException
      *
-     * @return self
+     * @return static
      */
-    public static function find(int $id, array $params = []): self
+    public static function find(int $id, array $params = []): static
     {
         self::checkApiClient();
 
         $response = self::getApiClient()->get("/users/{$id}");
 
-        return new self(self::parseJsonResponse($response));
+        return new static(self::parseJsonResponse($response));
     }
 
     /**
@@ -716,9 +716,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -732,9 +732,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getSortableName(): string
+    public function getSortableName(): ?string
     {
         return $this->sortableName;
     }
@@ -748,9 +748,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLastName(): string
+    public function getLastName(): ?string
     {
         return $this->lastName;
     }
@@ -764,9 +764,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getFirstName(): string
+    public function getFirstName(): ?string
     {
         return $this->firstName;
     }
@@ -780,9 +780,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getShortName(): string
+    public function getShortName(): ?string
     {
         return $this->shortName;
     }
@@ -844,9 +844,9 @@ class User extends AbstractBaseApi
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLoginId(): string
+    public function getLoginId(): ?string
     {
         return $this->loginId;
     }

--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -13,6 +13,7 @@ use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Traits\ActivityLoggingTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * OAuth 2.0 authentication utility for Canvas LMS
@@ -122,6 +123,16 @@ class OAuth
                 'skipAuth' => true,
             ]);
 
+            if ($response->getStatusCode() >= 400) {
+                $error = self::extractOAuthError($response);
+                $logger->error('OAuth: Failed to exchange authorization code', [
+                    'status' => $response->getStatusCode(),
+                    'error' => $error,
+                ]);
+
+                throw new CanvasApiException('OAuth code exchange failed: ' . $error);
+            }
+
             $body = $response->getBody()->getContents();
 
             if (!$body) {
@@ -220,6 +231,16 @@ class OAuth
                 'skipAuth' => true,
             ]);
 
+            if ($response->getStatusCode() >= 400) {
+                $error = self::extractOAuthError($response);
+                $logger->error('OAuth: Failed to refresh token', [
+                    'status' => $response->getStatusCode(),
+                    'error' => $error,
+                ]);
+
+                throw new OAuthRefreshFailedException('Token refresh failed: ' . $error);
+            }
+
             $body = $response->getBody()->getContents();
 
             if (!$body) {
@@ -293,11 +314,14 @@ class OAuth
         try {
             $client = self::getClient();
 
-            // Note: This endpoint requires authentication, so no skipAuth
+            // The OAuth token being revoked is set manually; skipAuth prevents
+            // HttpClient from overwriting it with the configured credential
+            // (which would be the API key in api_key auth mode)
             $options = [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $token,
                 ],
+                'skipAuth' => true,
             ];
 
             if ($expireSessions) {
@@ -307,7 +331,17 @@ class OAuth
             // HttpClient now handles OAuth URLs properly
             $response = $client->request('DELETE', '/login/oauth2/token', $options);
 
-            // Clear stored tokens
+            if ($response->getStatusCode() >= 400) {
+                $error = self::extractOAuthError($response);
+                $logger->error('OAuth: Failed to revoke token', [
+                    'status' => $response->getStatusCode(),
+                    'error' => $error,
+                ]);
+
+                throw new CanvasApiException('Token revocation failed: ' . $error);
+            }
+
+            // Clear stored tokens only after Canvas confirms the revocation
             Config::clearOAuthTokens();
 
             $logger->info('OAuth: Successfully revoked token', [
@@ -358,12 +392,14 @@ class OAuth
         try {
             $client = self::getClient();
 
-            // Note: This endpoint requires authentication, so no skipAuth
+            // The OAuth token is set manually; skipAuth prevents HttpClient
+            // from overwriting it with the configured credential
             $options = [
                 'headers' => [
                     'Authorization' => 'Bearer ' . $token,
                 ],
                 'json' => [],
+                'skipAuth' => true,
             ];
 
             if ($returnTo) {
@@ -372,6 +408,12 @@ class OAuth
 
             // Note: session_token is a regular API endpoint (gets /api/v1/ prefix)
             $response = $client->request('POST', '/login/session_token', $options);
+
+            if ($response->getStatusCode() >= 400) {
+                $error = self::extractOAuthError($response);
+
+                throw new CanvasApiException('Session token creation failed: ' . $error);
+            }
 
             $body = $response->getBody()->getContents();
 
@@ -406,6 +448,36 @@ class OAuth
     public static function setHttpClient(?HttpClientInterface $client): void
     {
         self::$httpClient = $client;
+    }
+
+    /**
+     * Extract a readable error description from an OAuth endpoint error response
+     *
+     * Prefers the structured OAuth error fields (error, error_description) and
+     * falls back to the HTTP status so raw response bodies never leak into
+     * exception messages.
+     *
+     * @param ResponseInterface $response The error response
+     *
+     * @return string
+     */
+    private static function extractOAuthError(ResponseInterface $response): string
+    {
+        $body = (string) $response->getBody();
+        $data = $body !== '' ? json_decode($body, true) : null;
+
+        if (is_array($data)) {
+            $parts = array_filter([
+                $data['error'] ?? null,
+                $data['error_description'] ?? null,
+            ], 'is_string');
+
+            if ($parts !== []) {
+                return implode(': ', $parts);
+            }
+        }
+
+        return 'HTTP ' . $response->getStatusCode();
     }
 
     /**

--- a/src/Cache/Adapters/FileSystemAdapter.php
+++ b/src/Cache/Adapters/FileSystemAdapter.php
@@ -40,6 +40,10 @@ class FileSystemAdapter implements CacheAdapterInterface
     /**
      * Constructor.
      *
+     * Cached API responses can contain PII (names, emails, grades), so files
+     * and directories default to owner-only permissions. Prefer a dedicated
+     * application cache path over a shared /tmp on multi-user hosts.
+     *
      * @param string $cacheDir        Cache directory path
      * @param bool   $compression     Enable gzip compression
      * @param int    $dirPermissions  Directory permissions (octal)
@@ -48,8 +52,8 @@ class FileSystemAdapter implements CacheAdapterInterface
     public function __construct(
         string $cacheDir = '/tmp/canvas-cache',
         bool $compression = true,
-        int $dirPermissions = 0755,
-        int $filePermissions = 0644
+        int $dirPermissions = 0700,
+        int $filePermissions = 0600
     ) {
         $this->cacheDir = rtrim($cacheDir, '/');
         $this->compression = $compression && function_exists('gzencode') && function_exists('gzdecode');
@@ -92,7 +96,9 @@ class FileSystemAdapter implements CacheAdapterInterface
             }
         }
 
-        $data = @unserialize($content);
+        // allowed_classes=false: the envelope is pure arrays/scalars, and the
+        // cache dir may be writable by others, so object injection must be off
+        $data = @unserialize($content, ['allowed_classes' => false]);
         if ($data === false || !is_array($data)) {
             @unlink($filepath);
             $this->stats['misses']++;
@@ -133,6 +139,9 @@ class FileSystemAdapter implements CacheAdapterInterface
         $expires = $ttl > 0 ? time() + $ttl : 0;
 
         $cacheData = [
+            // Original key kept in the envelope: filenames are md5 hashes,
+            // so pattern-based invalidation needs the key to match against
+            'key' => $key,
             'value' => $data,
             'expires' => $expires,
             'created' => time(),
@@ -215,9 +224,9 @@ class FileSystemAdapter implements CacheAdapterInterface
                 continue;
             }
 
-            // Extract key from filename
-            $filename = $file->getBasename('.cache');
-            if (preg_match($regex, $filename)) {
+            // Filenames are md5 hashes; the original key lives in the envelope
+            $key = $this->readCacheKey($file->getPathname());
+            if ($key !== null && preg_match($regex, $key)) {
                 if (@unlink($file->getPathname())) {
                     $deleted++;
                 }
@@ -225,6 +234,35 @@ class FileSystemAdapter implements CacheAdapterInterface
         }
 
         return $deleted;
+    }
+
+    /**
+     * Read the original cache key stored in a cache file's envelope.
+     *
+     * @param string $filepath The cache file path
+     *
+     * @return string|null The original key, or null if unreadable
+     */
+    private function readCacheKey(string $filepath): ?string
+    {
+        $content = @file_get_contents($filepath);
+        if ($content === false) {
+            return null;
+        }
+
+        if ($this->compression) {
+            $content = @gzdecode($content);
+            if ($content === false) {
+                return null;
+            }
+        }
+
+        $data = @unserialize($content, ['allowed_classes' => false]);
+        if (!is_array($data) || !isset($data['key']) || !is_string($data['key'])) {
+            return null;
+        }
+
+        return $data['key'];
     }
 
     /**
@@ -372,7 +410,7 @@ class FileSystemAdapter implements CacheAdapterInterface
                 }
             }
 
-            $data = @unserialize($content);
+            $data = @unserialize($content, ['allowed_classes' => false]);
             if ($data === false || !is_array($data)) {
                 @unlink($file->getPathname());
                 $cleaned++;

--- a/src/Cache/Adapters/InMemoryAdapter.php
+++ b/src/Cache/Adapters/InMemoryAdapter.php
@@ -59,7 +59,7 @@ class InMemoryAdapter implements CacheAdapterInterface
         $entry = $this->cache[$key];
 
         // Check expiration
-        if ($entry['expires'] > 0 && $entry['expires'] < time()) {
+        if ($entry['expires'] > 0 && $entry['expires'] < $this->currentTime()) {
             $this->removeEntry($key);
             $this->stats['misses']++;
 
@@ -84,7 +84,7 @@ class InMemoryAdapter implements CacheAdapterInterface
             $this->evictOldest();
         }
 
-        $expires = $ttl > 0 ? time() + $ttl : 0;
+        $expires = $ttl > 0 ? $this->currentTime() + $ttl : 0;
 
         // Size is computed once at write time and stored with the entry so
         // reads/deletes never pay a serialize() just to track memory
@@ -138,7 +138,7 @@ class InMemoryAdapter implements CacheAdapterInterface
         $entry = $this->cache[$key];
 
         // Check expiration
-        if ($entry['expires'] > 0 && $entry['expires'] < time()) {
+        if ($entry['expires'] > 0 && $entry['expires'] < $this->currentTime()) {
             $this->removeEntry($key);
 
             return false;
@@ -202,7 +202,7 @@ class InMemoryAdapter implements CacheAdapterInterface
      */
     private function cleanExpired(): void
     {
-        $now = time();
+        $now = $this->currentTime();
 
         foreach ($this->cache as $key => $entry) {
             if ($entry['expires'] > 0 && $entry['expires'] < $now) {
@@ -240,5 +240,16 @@ class InMemoryAdapter implements CacheAdapterInterface
             $this->cacheMemoryUsage -= $this->cache[$key]['size'];
             unset($this->cache[$key]);
         }
+    }
+
+    /**
+     * Current Unix timestamp; a seam so tests can control TTL expiry
+     * without real sleeps.
+     *
+     * @return int
+     */
+    protected function currentTime(): int
+    {
+        return time();
     }
 }

--- a/src/Cache/Adapters/InMemoryAdapter.php
+++ b/src/Cache/Adapters/InMemoryAdapter.php
@@ -14,7 +14,7 @@ namespace CanvasLMS\Cache\Adapters;
 class InMemoryAdapter implements CacheAdapterInterface
 {
     /**
-     * @var array<string, array{data: array<string, mixed>, expires: int}> Cache storage
+     * @var array<string, array{data: array<string, mixed>, expires: int, size: int}> Cache storage
      */
     private array $cache = [];
 
@@ -60,7 +60,7 @@ class InMemoryAdapter implements CacheAdapterInterface
 
         // Check expiration
         if ($entry['expires'] > 0 && $entry['expires'] < time()) {
-            unset($this->cache[$key]);
+            $this->removeEntry($key);
             $this->stats['misses']++;
 
             return null;
@@ -86,20 +86,19 @@ class InMemoryAdapter implements CacheAdapterInterface
 
         $expires = $ttl > 0 ? time() + $ttl : 0;
 
-        // Estimate memory usage of the data being stored
+        // Size is computed once at write time and stored with the entry so
+        // reads/deletes never pay a serialize() just to track memory
         $dataSize = strlen(serialize($data));
 
-        // Update memory tracking
         if (isset($this->cache[$key])) {
-            // Subtract old size if updating existing entry
-            $oldSize = strlen(serialize($this->cache[$key]['data']));
-            $this->cacheMemoryUsage -= $oldSize;
+            $this->cacheMemoryUsage -= $this->cache[$key]['size'];
         }
         $this->cacheMemoryUsage += $dataSize;
 
         $this->cache[$key] = [
             'data' => $data,
             'expires' => $expires,
+            'size' => $dataSize,
         ];
     }
 
@@ -109,11 +108,7 @@ class InMemoryAdapter implements CacheAdapterInterface
     public function delete(string $key): bool
     {
         if (isset($this->cache[$key])) {
-            // Update memory tracking
-            $dataSize = strlen(serialize($this->cache[$key]['data']));
-            $this->cacheMemoryUsage -= $dataSize;
-
-            unset($this->cache[$key]);
+            $this->removeEntry($key);
 
             return true;
         }
@@ -144,7 +139,7 @@ class InMemoryAdapter implements CacheAdapterInterface
 
         // Check expiration
         if ($entry['expires'] > 0 && $entry['expires'] < time()) {
-            unset($this->cache[$key]);
+            $this->removeEntry($key);
 
             return false;
         }
@@ -162,7 +157,7 @@ class InMemoryAdapter implements CacheAdapterInterface
 
         foreach (array_keys($this->cache) as $key) {
             if (preg_match($regex, $key)) {
-                unset($this->cache[$key]);
+                $this->removeEntry($key);
                 $deleted++;
             }
         }
@@ -211,11 +206,7 @@ class InMemoryAdapter implements CacheAdapterInterface
 
         foreach ($this->cache as $key => $entry) {
             if ($entry['expires'] > 0 && $entry['expires'] < $now) {
-                // Update memory tracking
-                $dataSize = strlen(serialize($entry['data']));
-                $this->cacheMemoryUsage -= $dataSize;
-
-                unset($this->cache[$key]);
+                $this->removeEntry($key);
             }
         }
     }
@@ -231,12 +222,23 @@ class InMemoryAdapter implements CacheAdapterInterface
             reset($this->cache);
             $oldestKey = key($this->cache);
             if ($oldestKey !== null) {
-                // Update memory tracking
-                $dataSize = strlen(serialize($this->cache[$oldestKey]['data']));
-                $this->cacheMemoryUsage -= $dataSize;
-
-                unset($this->cache[$oldestKey]);
+                $this->removeEntry($oldestKey);
             }
+        }
+    }
+
+    /**
+     * Remove an entry and keep memory accounting in sync.
+     *
+     * @param string $key The cache key
+     *
+     * @return void
+     */
+    private function removeEntry(string $key): void
+    {
+        if (isset($this->cache[$key])) {
+            $this->cacheMemoryUsage -= $this->cache[$key]['size'];
+            unset($this->cache[$key]);
         }
     }
 }

--- a/src/Cache/Strategies/TtlStrategy.php
+++ b/src/Cache/Strategies/TtlStrategy.php
@@ -103,7 +103,9 @@ class TtlStrategy
     private function getTtlForPath(string $path): int
     {
         foreach ($this->rules as $pattern => $ttl) {
-            if (preg_match('#' . $pattern . '#i', $path)) {
+            // Suppress and skip invalid patterns: a bad user rule must not
+            // silently disable every rule after it
+            if (@preg_match('#' . $pattern . '#i', $path) === 1) {
                 return $ttl;
             }
         }
@@ -121,6 +123,10 @@ class TtlStrategy
      */
     public function addRule(string $pattern, int $ttl): void
     {
+        if (@preg_match('#' . $pattern . '#i', '') === false) {
+            throw new \InvalidArgumentException("Invalid TTL rule pattern: {$pattern}");
+        }
+
         $this->rules[$pattern] = $ttl;
     }
 

--- a/src/Dto/AbstractBaseDto.php
+++ b/src/Dto/AbstractBaseDto.php
@@ -44,6 +44,41 @@ abstract class AbstractBaseDto
     }
 
     /**
+     * Cached property type info, keyed by class name.
+     *
+     * Avoids constructing a ReflectionClass per property per instantiation.
+     *
+     * @var array<class-string, array<string, array{name: string, builtin: bool}|null>>
+     */
+    private static array $propertyTypeCache = [];
+
+    /**
+     * Get type info for each property of this class.
+     *
+     * @return array<string, array{name: string, builtin: bool}|null>
+     */
+    private static function getPropertyTypeMap(): array
+    {
+        $class = static::class;
+
+        if (!isset(self::$propertyTypeCache[$class])) {
+            $map = [];
+            $reflection = new \ReflectionClass($class);
+
+            foreach ($reflection->getProperties() as $property) {
+                $type = $property->getType();
+                $map[$property->getName()] = $type instanceof \ReflectionNamedType
+                    ? ['name' => $type->getName(), 'builtin' => $type->isBuiltin()]
+                    : null;
+            }
+
+            self::$propertyTypeCache[$class] = $map;
+        }
+
+        return self::$propertyTypeCache[$class];
+    }
+
+    /**
      * Cast the value to the correct type
      *
      * @param mixed $value
@@ -55,52 +90,47 @@ abstract class AbstractBaseDto
      */
     private function cast($value, string $key)
     {
-        // Check if the property expects a DateTimeInterface
-        $reflection = new \ReflectionClass($this);
-        if ($reflection->hasProperty($key)) {
-            $property = $reflection->getProperty($key);
-            $type = $property->getType();
+        $typeMap = self::getPropertyTypeMap();
+        $type = $typeMap[$key] ?? null;
 
-            if ($type instanceof \ReflectionNamedType) {
-                $typeName = $type->getName();
+        if ($type !== null) {
+            $typeName = $type['name'];
 
-                // Handle DateTimeInterface
-                if (!$type->isBuiltin()) {
-                    if ($typeName === 'DateTimeInterface' || is_subclass_of($typeName, 'DateTimeInterface')) {
-                        if (is_string($value) && !empty($value)) {
-                            return new DateTime($value);
-                        }
-
-                        return null;
+            // Handle DateTimeInterface
+            if (!$type['builtin']) {
+                if ($typeName === 'DateTimeInterface' || is_subclass_of($typeName, 'DateTimeInterface')) {
+                    if (is_string($value) && !empty($value)) {
+                        return new DateTime($value);
                     }
+
+                    return null;
                 }
+            }
 
-                // Handle built-in types for strict_types compatibility
-                if ($type->isBuiltin()) {
-                    switch ($typeName) {
-                        case 'int':
-                            return $value === null ? null : (int) $value;
-                        case 'float':
-                            return $value === null ? null : (float) $value;
-                        case 'string':
-                            return $value === null ? null : (string) $value;
-                        case 'bool':
-                            return $value === null ? null : (bool) $value;
-                    }
+            // Handle built-in types for strict_types compatibility
+            if ($type['builtin']) {
+                switch ($typeName) {
+                    case 'int':
+                        return $value === null ? null : (int) $value;
+                    case 'float':
+                        return $value === null ? null : (float) $value;
+                    case 'string':
+                        return $value === null ? null : (string) $value;
+                    case 'bool':
+                        return $value === null ? null : (bool) $value;
                 }
             }
         }
 
         // Legacy support for known date fields ONLY if they're typed as DateTime/DateTimeInterface
-        if (in_array($key, ['startAt', 'endAt'], true) && is_string($value) && !empty($value)) {
-            $reflection = new \ReflectionClass($this);
-            if ($reflection->hasProperty($key)) {
-                $property = $reflection->getProperty($key);
-                $type = $property->getType();
-                if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
-                    return new DateTime($value);
-                }
-            }
+        if (
+            in_array($key, ['startAt', 'endAt'], true)
+            && is_string($value)
+            && !empty($value)
+            && $type !== null
+            && !$type['builtin']
+        ) {
+            return new DateTime($value);
         }
 
         return $value;

--- a/src/Dto/AbstractBaseDto.php
+++ b/src/Dto/AbstractBaseDto.php
@@ -176,19 +176,38 @@ abstract class AbstractBaseDto
                 foreach ($value as $arrayValue) {
                     $modifiedProperties[] = [
                         'name' => $propertyName . '[]',
-                        'contents' => $arrayValue,
+                        'contents' => self::formatMultipartValue($arrayValue),
                     ];
                 }
                 continue;
             }
 
-            // Handle scalar values (int, string, bool) as they don't need special treatment.
             $modifiedProperties[] = [
                 'name' => $propertyName,
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 
         return $modifiedProperties;
+    }
+
+    /**
+     * Format a value for multipart form contents
+     *
+     * Booleans must be converted explicitly: Guzzle's multipart encoder
+     * string-casts contents, turning false into an empty string instead of
+     * 'false', which Canvas may interpret differently than an unset flag.
+     *
+     * @param mixed $value The value to format
+     *
+     * @return mixed
+     */
+    protected static function formatMultipartValue(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return $value;
     }
 }

--- a/src/Dto/ContentMigrations/CreateContentMigrationDTO.php
+++ b/src/Dto/ContentMigrations/CreateContentMigrationDTO.php
@@ -95,7 +95,7 @@ class CreateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
             foreach ($this->preAttachment as $key => $value) {
                 $result[] = [
                     'name' => 'pre_attachment[' . $key . ']',
-                    'contents' => (string) $value,
+                    'contents' => is_bool($value) ? ($value ? '1' : '0') : (string) $value,
                 ];
             }
         }
@@ -108,13 +108,13 @@ class CreateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
                     foreach ($value as $subKey => $subValue) {
                         $result[] = [
                             'name' => 'settings[' . $key . '][' . $subKey . ']',
-                            'contents' => (string) $subValue,
+                            'contents' => is_bool($subValue) ? ($subValue ? '1' : '0') : (string) $subValue,
                         ];
                     }
                 } else {
                     $result[] = [
                         'name' => 'settings[' . $key . ']',
-                        'contents' => (string) $value,
+                        'contents' => is_bool($value) ? ($value ? '1' : '0') : (string) $value,
                     ];
                 }
             }
@@ -128,13 +128,13 @@ class CreateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
                     foreach ($value as $day => $substitution) {
                         $result[] = [
                             'name' => 'date_shift_options[day_substitutions][' . $day . ']',
-                            'contents' => (string) $substitution,
+                            'contents' => is_bool($substitution) ? ($substitution ? '1' : '0') : (string) $substitution,
                         ];
                     }
                 } else {
                     $result[] = [
                         'name' => 'date_shift_options[' . $key . ']',
-                        'contents' => (string) $value,
+                        'contents' => is_bool($value) ? ($value ? '1' : '0') : (string) $value,
                     ];
                 }
             }

--- a/src/Dto/ContentMigrations/UpdateContentMigrationDTO.php
+++ b/src/Dto/ContentMigrations/UpdateContentMigrationDTO.php
@@ -77,7 +77,7 @@ class UpdateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
             foreach ($this->preAttachment as $key => $value) {
                 $result[] = [
                     'name' => 'pre_attachment[' . $key . ']',
-                    'contents' => (string) $value,
+                    'contents' => is_bool($value) ? ($value ? '1' : '0') : (string) $value,
                 ];
             }
         }
@@ -94,7 +94,7 @@ class UpdateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
                     foreach ($value as $subKey => $subValue) {
                         $result[] = [
                             'name' => 'settings[' . $key . '][' . $subKey . ']',
-                            'contents' => (string) $subValue,
+                            'contents' => is_bool($subValue) ? ($subValue ? '1' : '0') : (string) $subValue,
                         ];
                     }
                 } else {
@@ -113,7 +113,7 @@ class UpdateContentMigrationDTO extends AbstractBaseDto implements DTOInterface
                     foreach ($value as $day => $substitution) {
                         $result[] = [
                             'name' => 'date_shift_options[day_substitutions][' . $day . ']',
-                            'contents' => (string) $substitution,
+                            'contents' => is_bool($substitution) ? ($substitution ? '1' : '0') : (string) $substitution,
                         ];
                     }
                 } else {

--- a/src/Dto/Courses/CreateCourseDTO.php
+++ b/src/Dto/Courses/CreateCourseDTO.php
@@ -274,7 +274,7 @@ class CreateCourseDTO extends AbstractBaseDto implements DTOInterface
             // Rename keys to this format course[{key}]
             $modifiedProperties[] = [
                 'name' => 'course[' . Str::toSnakeCase($key) . ']',
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 

--- a/src/Dto/Courses/UpdateCourseDTO.php
+++ b/src/Dto/Courses/UpdateCourseDTO.php
@@ -326,7 +326,7 @@ class UpdateCourseDTO extends AbstractBaseDto implements DTOInterface
             // Rename keys to this format course[{key}]
             $modifiedProperties[] = [
                 'name' => 'course[' . Str::toSnakeCase($key) . ']',
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 

--- a/src/Dto/Modules/CreateModuleItemDTO.php
+++ b/src/Dto/Modules/CreateModuleItemDTO.php
@@ -332,7 +332,7 @@ class CreateModuleItemDTO extends AbstractBaseDto implements DTOInterface
                 foreach ($value as $key => $arrayValue) {
                     $modifiedProperties[] = [
                         'name' => $propertyName . '[' . $key . ']',
-                        'contents' => $arrayValue,
+                        'contents' => self::formatMultipartValue($arrayValue),
                     ];
                 }
                 continue;
@@ -341,7 +341,7 @@ class CreateModuleItemDTO extends AbstractBaseDto implements DTOInterface
             // Handle scalar values
             $modifiedProperties[] = [
                 'name' => $propertyName,
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 

--- a/src/Dto/Modules/UpdateModuleItemDTO.php
+++ b/src/Dto/Modules/UpdateModuleItemDTO.php
@@ -311,7 +311,7 @@ class UpdateModuleItemDTO extends AbstractBaseDto implements DTOInterface
                 foreach ($value as $key => $arrayValue) {
                     $modifiedProperties[] = [
                         'name' => $propertyName . '[' . $key . ']',
-                        'contents' => $arrayValue,
+                        'contents' => self::formatMultipartValue($arrayValue),
                     ];
                 }
                 continue;
@@ -320,7 +320,7 @@ class UpdateModuleItemDTO extends AbstractBaseDto implements DTOInterface
             // Handle scalar values
             $modifiedProperties[] = [
                 'name' => $propertyName,
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 

--- a/src/Dto/Sections/CreateSectionDTO.php
+++ b/src/Dto/Sections/CreateSectionDTO.php
@@ -100,7 +100,7 @@ class CreateSectionDTO extends AbstractBaseDto implements DTOInterface
                 foreach ($value as $arrayValue) {
                     $modifiedProperties[] = [
                         'name' => $propertyName . '[]',
-                        'contents' => $arrayValue,
+                        'contents' => self::formatMultipartValue($arrayValue),
                     ];
                 }
                 continue;
@@ -109,7 +109,7 @@ class CreateSectionDTO extends AbstractBaseDto implements DTOInterface
             // Handle regular values
             $modifiedProperties[] = [
                 'name' => $propertyName,
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 
@@ -117,7 +117,7 @@ class CreateSectionDTO extends AbstractBaseDto implements DTOInterface
         if ($this->enableSisReactivation !== null) {
             $modifiedProperties[] = [
                 'name' => 'enable_sis_reactivation',
-                'contents' => $this->enableSisReactivation,
+                'contents' => self::formatMultipartValue($this->enableSisReactivation),
             ];
         }
 

--- a/src/Dto/Sections/UpdateSectionDTO.php
+++ b/src/Dto/Sections/UpdateSectionDTO.php
@@ -100,7 +100,7 @@ class UpdateSectionDTO extends AbstractBaseDto implements DTOInterface
                 foreach ($value as $arrayValue) {
                     $modifiedProperties[] = [
                         'name' => $propertyName . '[]',
-                        'contents' => $arrayValue,
+                        'contents' => self::formatMultipartValue($arrayValue),
                     ];
                 }
                 continue;
@@ -109,7 +109,7 @@ class UpdateSectionDTO extends AbstractBaseDto implements DTOInterface
             // Handle regular values
             $modifiedProperties[] = [
                 'name' => $propertyName,
-                'contents' => $value,
+                'contents' => self::formatMultipartValue($value),
             ];
         }
 
@@ -117,7 +117,7 @@ class UpdateSectionDTO extends AbstractBaseDto implements DTOInterface
         if ($this->overrideSisStickiness !== null) {
             $modifiedProperties[] = [
                 'name' => 'override_sis_stickiness',
-                'contents' => $this->overrideSisStickiness,
+                'contents' => self::formatMultipartValue($this->overrideSisStickiness),
             ];
         }
 

--- a/src/Dto/Tabs/UpdateTabDTO.php
+++ b/src/Dto/Tabs/UpdateTabDTO.php
@@ -129,7 +129,7 @@ class UpdateTabDTO extends AbstractBaseDto
         if ($this->hidden !== null) {
             $modifiedProperties[] = [
                 'name' => 'tab[hidden]',
-                'contents' => $this->hidden,
+                'contents' => self::formatMultipartValue($this->hidden),
             ];
         }
 

--- a/src/Http/ApiClientRegistry.php
+++ b/src/Http/ApiClientRegistry.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace CanvasLMS\Http;
 
+use CanvasLMS\Cache\Adapters\APCuAdapter;
+use CanvasLMS\Cache\Adapters\FileSystemAdapter;
+use CanvasLMS\Cache\Adapters\InMemoryAdapter;
 use CanvasLMS\Config;
+use CanvasLMS\Http\Middleware\CacheMiddleware;
 use CanvasLMS\Http\Middleware\LoggingMiddleware;
 use CanvasLMS\Http\Middleware\RateLimitMiddleware;
 use CanvasLMS\Http\Middleware\RetryMiddleware;
@@ -120,6 +124,12 @@ final class ApiClientRegistry
 
         // If middleware config is empty, HttpClient will use defaults
         if (!empty($middlewareConfig)) {
+            // Cache goes first so cache hits short-circuit the retry and
+            // rate-limit layers entirely
+            if (isset($middlewareConfig['cache'])) {
+                $middleware[] = self::createCacheMiddleware($middlewareConfig['cache']);
+            }
+
             // Build middleware instances from configuration
             if (isset($middlewareConfig['retry'])) {
                 $middleware[] = new RetryMiddleware($middlewareConfig['retry']);
@@ -137,5 +147,39 @@ final class ApiClientRegistry
         }
 
         return new HttpClient(null, $logger, $middleware);
+    }
+
+    /**
+     * Build a CacheMiddleware from Config::setMiddleware()'s 'cache' entry.
+     *
+     * Accepts an 'adapter' as either an instance or a shorthand string
+     * ('memory', 'file', 'apcu'); 'cache_dir' applies to the file adapter.
+     * Configuring the cache implies enabling it unless 'enabled' is set
+     * explicitly.
+     *
+     * @param array<string, mixed> $config Cache middleware configuration
+     *
+     * @return CacheMiddleware
+     */
+    private static function createCacheMiddleware(array $config): CacheMiddleware
+    {
+        $config['enabled'] ??= true;
+
+        if (isset($config['adapter']) && is_string($config['adapter'])) {
+            $config['adapter'] = match ($config['adapter']) {
+                'memory' => new InMemoryAdapter(),
+                'file', 'filesystem' => new FileSystemAdapter($config['cache_dir'] ?? '/tmp/canvas-cache'),
+                'apcu' => new APCuAdapter(),
+                default => throw new \InvalidArgumentException(sprintf(
+                    "Unknown cache adapter '%s'. Use 'memory', 'file', 'apcu', " .
+                    'or pass a CacheAdapterInterface instance.',
+                    $config['adapter']
+                )),
+            };
+        }
+
+        unset($config['cache_dir']);
+
+        return new CacheMiddleware($config);
     }
 }

--- a/src/Http/ApiClientRegistry.php
+++ b/src/Http/ApiClientRegistry.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Http;
+
+use CanvasLMS\Config;
+use CanvasLMS\Http\Middleware\LoggingMiddleware;
+use CanvasLMS\Http\Middleware\RateLimitMiddleware;
+use CanvasLMS\Http\Middleware\RetryMiddleware;
+use CanvasLMS\Interfaces\HttpClientInterface;
+
+/**
+ * Central registry for the HTTP clients used by API resource classes.
+ *
+ * All resources share one lazily-created, middleware-configured default
+ * client. Individual classes can be given their own client without
+ * affecting the rest (test isolation, custom transports).
+ */
+final class ApiClientRegistry
+{
+    /**
+     * @var array<class-string, HttpClientInterface> Per-class client overrides
+     */
+    private static array $overrides = [];
+
+    /**
+     * @var HttpClientInterface|null Shared default client
+     */
+    private static ?HttpClientInterface $default = null;
+
+    /**
+     * Set the shared default client used by every API class without an override.
+     *
+     * @param HttpClientInterface $client The HTTP client
+     *
+     * @return void
+     */
+    public static function setDefault(HttpClientInterface $client): void
+    {
+        self::$default = $client;
+    }
+
+    /**
+     * Set a client for one specific class only.
+     *
+     * @param class-string $class The API class to scope the client to
+     * @param HttpClientInterface $client The HTTP client
+     *
+     * @return void
+     */
+    public static function setFor(string $class, HttpClientInterface $client): void
+    {
+        self::$overrides[$class] = $client;
+    }
+
+    /**
+     * Remove the override for one specific class.
+     *
+     * @param class-string $class The API class
+     *
+     * @return void
+     */
+    public static function removeFor(string $class): void
+    {
+        unset(self::$overrides[$class]);
+    }
+
+    /**
+     * Resolve the client for a class: its override if set, otherwise the
+     * shared default (created from Config middleware settings on first use).
+     *
+     * @param class-string $class The API class requesting a client
+     *
+     * @return HttpClientInterface
+     */
+    public static function resolve(string $class): HttpClientInterface
+    {
+        if (isset(self::$overrides[$class])) {
+            return self::$overrides[$class];
+        }
+
+        if (self::$default === null) {
+            self::$default = self::createConfiguredHttpClient();
+        }
+
+        return self::$default;
+    }
+
+    /**
+     * Clear the default client and all per-class overrides.
+     *
+     * Intended for test teardown so a mock set in one test never leaks
+     * into the next.
+     *
+     * @return void
+     */
+    public static function reset(): void
+    {
+        self::$overrides = [];
+        self::$default = null;
+    }
+
+    /**
+     * Create an HttpClient with middleware built from Config settings.
+     *
+     * @return HttpClient
+     */
+    public static function createConfiguredHttpClient(): HttpClient
+    {
+        $middlewareConfig = Config::getMiddleware();
+        $middleware = [];
+        $logger = null;
+
+        // Check if logging is configured
+        if (isset($middlewareConfig['logging']) && $middlewareConfig['logging']['enabled'] !== false) {
+            // Use the configured logger from Config, defaults to NullLogger if not configured
+            $logger = Config::getLogger();
+        }
+
+        // If middleware config is empty, HttpClient will use defaults
+        if (!empty($middlewareConfig)) {
+            // Build middleware instances from configuration
+            if (isset($middlewareConfig['retry'])) {
+                $middleware[] = new RetryMiddleware($middlewareConfig['retry']);
+            }
+
+            if (isset($middlewareConfig['rate_limit'])) {
+                $middleware[] = new RateLimitMiddleware($middlewareConfig['rate_limit']);
+            }
+
+            if (isset($middlewareConfig['logging']) && $logger !== null) {
+                $loggingConfig = $middlewareConfig['logging'];
+                unset($loggingConfig['enabled']); // Remove the enabled flag
+                $middleware[] = new LoggingMiddleware($logger, $loggingConfig);
+            }
+        }
+
+        return new HttpClient(null, $logger, $middleware);
+    }
+}

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -55,8 +55,8 @@ class HttpClient implements HttpClientInterface
      * @param array<MiddlewareInterface> $middleware
      */
     public function __construct(
-        ClientInterface $client = null,
-        LoggerInterface $logger = null,
+        ?ClientInterface $client = null,
+        ?LoggerInterface $logger = null,
         array $middleware = []
     ) {
         $this->logger = $logger ?? new \Psr\Log\NullLogger();

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -91,8 +91,9 @@ class RateLimitMiddleware extends AbstractMiddleware
                         ));
                     }
 
-                    // Wait for the bucket to refill
-                    usleep($delay * 1000000);
+                    // Wait for the bucket to refill; sleep() instead of
+                    // usleep(), which is unreliable beyond ~1s on some platforms
+                    sleep($delay);
                 }
 
                 // Pre-charge the initial cost

--- a/src/Http/Middleware/RetryMiddleware.php
+++ b/src/Http/Middleware/RetryMiddleware.php
@@ -154,8 +154,16 @@ class RetryMiddleware extends AbstractMiddleware
         $options['retry_attempt']++;
         $delay = $this->calculateDelay($options['retry_attempt']);
 
-        // Sleep for the calculated delay
-        usleep($delay * 1000);
+        // Sleep for the calculated delay (milliseconds); usleep is
+        // unreliable beyond ~1s on some platforms, so split the wait
+        $seconds = intdiv($delay, 1000);
+        $microseconds = ($delay % 1000) * 1000;
+        if ($seconds > 0) {
+            sleep($seconds);
+        }
+        if ($microseconds > 0) {
+            usleep($microseconds);
+        }
 
         // Reset the request body if needed
         if ($request->getBody()->isSeekable()) {

--- a/src/Pagination/LinkHeaderParser.php
+++ b/src/Pagination/LinkHeaderParser.php
@@ -41,8 +41,10 @@ class LinkHeaderParser
             return $links;
         }
 
-        // Split by comma to get individual link entries
-        $linkEntries = explode(',', $linkHeader);
+        // Split on commas only outside <...>: URLs may contain commas in
+        // query parameters (e.g. context_codes), and a naive split would
+        // break the entry mid-URL and silently drop the pagination link
+        $linkEntries = preg_split('/,(?![^<]*>)/', $linkHeader) ?: [];
 
         foreach ($linkEntries as $linkEntry) {
             $linkEntry = trim($linkEntry);

--- a/src/Pagination/PaginatedResponse.php
+++ b/src/Pagination/PaginatedResponse.php
@@ -88,6 +88,13 @@ class PaginatedResponse
     private ?string $bodyCache = null;
 
     /**
+     * Cached decoded JSON body
+     *
+     * @var mixed[]|null
+     */
+    private ?array $jsonCache = null;
+
+    /**
      * PaginatedResponse constructor
      *
      * @param ResponseInterface $response The HTTP response
@@ -147,10 +154,12 @@ class PaginatedResponse
      */
     public function getJsonData(): array
     {
-        $body = $this->getBody();
-        $data = json_decode($body, true);
+        if ($this->jsonCache === null) {
+            $data = json_decode($this->getBody(), true);
+            $this->jsonCache = is_array($data) ? $data : [];
+        }
 
-        return is_array($data) ? $data : [];
+        return $this->jsonCache;
     }
 
     /**
@@ -474,7 +483,8 @@ class PaginatedResponse
     {
         $this->logger->info('Pagination: Starting to fetch all pages');
 
-        $allData = [];
+        $pages = [];
+        $totalItems = 0;
         $currentResponse = $this;
         $pageCount = 0;
         $startTime = microtime(true);
@@ -482,18 +492,23 @@ class PaginatedResponse
         do {
             $pageCount++;
             $data = $currentResponse->getJsonData();
-            $itemCount = count((array) $data);
+            $itemCount = count($data);
+            $totalItems += $itemCount;
 
             $this->logger->debug('Pagination: Processing page', [
                 'page_number' => $pageCount,
                 'items_on_page' => $itemCount,
-                'total_items_so_far' => count($allData) + $itemCount,
+                'total_items_so_far' => $totalItems,
             ]);
 
-            $allData = array_merge($allData, $data);
+            // Collect pages and merge once at the end: merging per page
+            // copies the accumulated array on every iteration
+            $pages[] = $data;
 
             $currentResponse = $currentResponse->getNext();
         } while ($currentResponse !== null);
+
+        $allData = array_merge(...$pages);
 
         $duration = microtime(true) - $startTime;
 

--- a/src/Pagination/PaginationResult.php
+++ b/src/Pagination/PaginationResult.php
@@ -13,11 +13,11 @@ namespace CanvasLMS\Pagination;
  *
  * Usage:
  * ```php
- * $result = Course::fetchAllPaginated(['per_page' => 50]);
+ * $result = Course::paginate(['per_page' => 50]);
  * $courses = $result->getData();
  *
  * if ($result->hasNext()) {
- *     $nextResult = $result->getNext();
+ *     $next = Course::paginate(['page' => $result->getCurrentPage() + 1, 'per_page' => 50]);
  * }
  *
  * echo "Page {$result->getCurrentPage()} of {$result->getTotalPages()}";

--- a/src/Version.php
+++ b/src/Version.php
@@ -14,14 +14,14 @@ class Version
      *
      * @var string
      */
-    public const VERSION = '1.6.1';
+    public const VERSION = '1.7.0';
 
     /**
      * Release date of current version
      *
      * @var string
      */
-    public const RELEASE_DATE = '2025-10-22';
+    public const RELEASE_DATE = '2026-06-11';
 
     /**
      * Minimum PHP version required

--- a/src/Version.php
+++ b/src/Version.php
@@ -14,14 +14,14 @@ class Version
      *
      * @var string
      */
-    public const VERSION = '1.5.3';
+    public const VERSION = '1.6.1';
 
     /**
      * Release date of current version
      *
      * @var string
      */
-    public const RELEASE_DATE = '2025-09-18';
+    public const RELEASE_DATE = '2025-10-22';
 
     /**
      * Minimum PHP version required

--- a/tests/Api/AbstractBaseApiTest.php
+++ b/tests/Api/AbstractBaseApiTest.php
@@ -315,7 +315,7 @@ class AbstractBaseApiTest extends TestCase
             {
                 self::checkApiClient();
 
-                $response = self::$apiClient->get('/test', ['query' => $params]);
+                $response = self::getApiClient()->get('/test', ['query' => $params]);
                 $data = json_decode($response->getBody()->getContents(), true);
 
                 return array_map(function ($item) {

--- a/tests/Api/AbstractBaseApiTest.php
+++ b/tests/Api/AbstractBaseApiTest.php
@@ -588,6 +588,17 @@ class AbstractBaseApiTest extends TestCase
         $this->assertEquals('Smith', $instance->lastName);
         $this->assertEquals(456, $instance->userId);
         $this->assertFalse($instance->isActive);
+
+        // Scalar coercion must apply on populate exactly as on construction:
+        // Canvas may return numeric values as strings, and save() round-trips
+        // go through populate()
+        $instance->testPopulate([
+            'user_id' => '789',
+            'is_active' => 1,
+        ]);
+
+        $this->assertSame(789, $instance->userId);
+        $this->assertTrue($instance->isActive);
     }
 
     /**

--- a/tests/Api/AbstractBaseApiTest.php
+++ b/tests/Api/AbstractBaseApiTest.php
@@ -460,6 +460,41 @@ class AbstractBaseApiTest extends TestCase
     }
 
     /**
+     * Test that stream() lazily yields hydrated items across all pages
+     */
+    public function testStreamYieldsAllItemsAcrossPages(): void
+    {
+        $page2Data = [['id' => 3, 'name' => 'Item 3']];
+        $page1Data = [
+            ['id' => 1, 'name' => 'Item 1'],
+            ['id' => 2, 'name' => 'Item 2'],
+        ];
+
+        $mockPage2 = $this->createMock(PaginatedResponse::class);
+        $mockPage2->method('getJsonData')->willReturn($page2Data);
+        $mockPage2->method('getNext')->willReturn(null);
+
+        $mockPage1 = $this->createMock(PaginatedResponse::class);
+        $mockPage1->method('getJsonData')->willReturn($page1Data);
+        $mockPage1->method('getNext')->willReturn($mockPage2);
+
+        $this->mockHttpClient->expects($this->once())
+            ->method('getPaginated')
+            ->willReturn($mockPage1);
+
+        $generator = $this->testApiClass::stream();
+        $this->assertInstanceOf(\Generator::class, $generator);
+
+        $ids = [];
+        foreach ($generator as $item) {
+            $this->assertInstanceOf($this->testApiClass, $item);
+            $ids[] = $item->id;
+        }
+
+        $this->assertSame([1, 2, 3], $ids);
+    }
+
+    /**
      * Test that invalid method calls throw appropriate exceptions
      */
     public function testInvalidMethodCallThrowsException(): void

--- a/tests/Api/Accounts/AccountTest.php
+++ b/tests/Api/Accounts/AccountTest.php
@@ -260,7 +260,7 @@ class AccountTest extends TestCase
         $this->httpClientMock
             ->expects($this->once())
             ->method('get')
-            ->with($this->equalTo('accounts/sis_account_id:SIS_ACCT_123'))
+            ->with($this->equalTo('accounts/sis_account_id%3ASIS_ACCT_123'))
             ->willReturn($response);
 
         $account = Account::find('sis_account_id:SIS_ACCT_123');

--- a/tests/Api/Bookmarks/BookmarkTest.php
+++ b/tests/Api/Bookmarks/BookmarkTest.php
@@ -13,7 +13,6 @@ use CanvasLMS\Pagination\PaginatedResponse;
 use CanvasLMS\Pagination\PaginationResult;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 class BookmarkTest extends TestCase
 {
@@ -28,10 +27,7 @@ class BookmarkTest extends TestCase
 
     protected function tearDown(): void
     {
-        $reflection = new ReflectionClass(AbstractBaseApi::class);
-        $property = $reflection->getProperty('apiClient');
-        $property->setAccessible(true);
-        $property->setValue(null, null);
+        AbstractBaseApi::resetApiClients();
         parent::tearDown();
     }
 

--- a/tests/Api/Courses/CourseTest.php
+++ b/tests/Api/Courses/CourseTest.php
@@ -12,6 +12,7 @@ use CanvasLMS\Dto\Courses\UpdateCourseDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Http\HttpClient;
 use CanvasLMS\Pagination\PaginatedResponse;
+use CanvasLMS\Pagination\PaginationResult;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -1075,35 +1076,21 @@ class CourseTest extends TestCase
         $courseData = ['id' => 123, 'name' => 'Test Course'];
         $course = new Course($courseData);
 
-        $enrollmentData = [
-            [
-                'id' => 1,
-                'user_id' => 101,
-                'course_id' => 123,
-                'type' => 'StudentEnrollment',
-                'enrollment_state' => 'active',
-            ],
-            [
-                'id' => 2,
-                'user_id' => 102,
-                'course_id' => 123,
-                'type' => 'StudentEnrollment',
-                'enrollment_state' => 'active',
-            ],
-        ];
+        // Counting now reads pagination metadata with per_page=1: the last
+        // page number equals the total item count
+        $linkHeader = '<https://canvas.test/api/v1/courses/123/enrollments?page=1&per_page=1>; rel="current", ' .
+            '<https://canvas.test/api/v1/courses/123/enrollments?page=2&per_page=1>; rel="last"';
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getJsonData')
-            ->willReturn($enrollmentData);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getNext')
-            ->willReturn(null); // No more pages
+        $mockPaginatedResponse->method('getJsonData')->willReturn([['id' => 1]]);
+        $mockPaginatedResponse->method('toPaginationResult')->willReturnCallback(
+            fn (array $data) => PaginationResult::fromLinkHeader($data, $linkHeader)
+        );
 
         $this->httpClientMock
             ->expects($this->once())
             ->method('getPaginated')
-            ->with('courses/123/enrollments', ['query' => ['type[]' => ['StudentEnrollment']]])
+            ->with('courses/123/enrollments', ['query' => ['type[]' => ['StudentEnrollment'], 'per_page' => 1]])
             ->willReturn($mockPaginatedResponse);
 
         $count = $course->getStudentCount();
@@ -1119,28 +1106,21 @@ class CourseTest extends TestCase
         $courseData = ['id' => 123, 'name' => 'Test Course'];
         $course = new Course($courseData);
 
-        $enrollmentData = [
-            [
-                'id' => 1,
-                'user_id' => 101,
-                'course_id' => 123,
-                'type' => 'TeacherEnrollment',
-                'enrollment_state' => 'active',
-            ],
-        ];
+        // Counting now reads pagination metadata with per_page=1: the last
+        // page number equals the total item count
+        $linkHeader = '<https://canvas.test/api/v1/courses/123/enrollments?page=1&per_page=1>; rel="current", ' .
+            '<https://canvas.test/api/v1/courses/123/enrollments?page=1&per_page=1>; rel="last"';
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getJsonData')
-            ->willReturn($enrollmentData);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getNext')
-            ->willReturn(null); // No more pages
+        $mockPaginatedResponse->method('getJsonData')->willReturn([['id' => 1]]);
+        $mockPaginatedResponse->method('toPaginationResult')->willReturnCallback(
+            fn (array $data) => PaginationResult::fromLinkHeader($data, $linkHeader)
+        );
 
         $this->httpClientMock
             ->expects($this->once())
             ->method('getPaginated')
-            ->with('courses/123/enrollments', ['query' => ['type[]' => ['TeacherEnrollment']]])
+            ->with('courses/123/enrollments', ['query' => ['type[]' => ['TeacherEnrollment'], 'per_page' => 1]])
             ->willReturn($mockPaginatedResponse);
 
         $count = $course->getTeacherCount();
@@ -1156,35 +1136,21 @@ class CourseTest extends TestCase
         $courseData = ['id' => 123, 'name' => 'Test Course'];
         $course = new Course($courseData);
 
-        $enrollmentData = [
-            [
-                'id' => 1,
-                'user_id' => 101,
-                'course_id' => 123,
-                'type' => 'StudentEnrollment',
-                'enrollment_state' => 'active',
-            ],
-            [
-                'id' => 2,
-                'user_id' => 102,
-                'course_id' => 123,
-                'type' => 'TeacherEnrollment',
-                'enrollment_state' => 'active',
-            ],
-        ];
+        // Counting now reads pagination metadata with per_page=1: the last
+        // page number equals the total item count
+        $linkHeader = '<https://canvas.test/api/v1/courses/123/enrollments?page=1&per_page=1>; rel="current", ' .
+            '<https://canvas.test/api/v1/courses/123/enrollments?page=2&per_page=1>; rel="last"';
 
         $mockPaginatedResponse = $this->createMock(PaginatedResponse::class);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getJsonData')
-            ->willReturn($enrollmentData);
-        $mockPaginatedResponse->expects($this->once())
-            ->method('getNext')
-            ->willReturn(null); // No more pages
+        $mockPaginatedResponse->method('getJsonData')->willReturn([['id' => 1]]);
+        $mockPaginatedResponse->method('toPaginationResult')->willReturnCallback(
+            fn (array $data) => PaginationResult::fromLinkHeader($data, $linkHeader)
+        );
 
         $this->httpClientMock
             ->expects($this->once())
             ->method('getPaginated')
-            ->with('courses/123/enrollments', ['query' => []])
+            ->with('courses/123/enrollments', ['query' => ['per_page' => 1]])
             ->willReturn($mockPaginatedResponse);
 
         $count = $course->getTotalEnrollmentCount();

--- a/tests/Api/DeveloperKeys/DeveloperKeyTest.php
+++ b/tests/Api/DeveloperKeys/DeveloperKeyTest.php
@@ -278,12 +278,14 @@ class DeveloperKeyTest extends TestCase
             ],
         ];
 
-        $response = new Response(200, [], json_encode($expectedResponse));
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn($expectedResponse);
+        $mockPaginated->method('getNext')->willReturn(null);
 
         $this->httpClientMock->expects($this->once())
-            ->method('get')
-            ->with('accounts/1/developer_keys', ['query' => []])
-            ->willReturn($response);
+            ->method('getPaginated')
+            ->with('accounts/1/developer_keys', ['query' => ['per_page' => 100]])
+            ->willReturn($mockPaginated);
 
         $key = DeveloperKey::find(2);
 
@@ -302,11 +304,13 @@ class DeveloperKeyTest extends TestCase
             ],
         ];
 
-        $response = new Response(200, [], json_encode($expectedResponse));
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn($expectedResponse);
+        $mockPaginated->method('getNext')->willReturn(null);
 
         $this->httpClientMock->expects($this->once())
-            ->method('get')
-            ->willReturn($response);
+            ->method('getPaginated')
+            ->willReturn($mockPaginated);
 
         $this->expectException(CanvasApiException::class);
         $this->expectExceptionMessage('Developer key with ID 999 not found');

--- a/tests/Api/Logins/LoginTest.php
+++ b/tests/Api/Logins/LoginTest.php
@@ -8,6 +8,7 @@ use CanvasLMS\Api\Logins\Login;
 use CanvasLMS\Config;
 use CanvasLMS\Dto\Logins\CreateLoginDTO;
 use CanvasLMS\Http\HttpClient;
+use CanvasLMS\Pagination\PaginatedResponse;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
@@ -77,12 +78,14 @@ class LoginTest extends TestCase
      */
     public function testFind(array $loginData): void
     {
-        $response = new Response(200, [], json_encode([$loginData]));
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn([$loginData]);
+        $mockPaginated->method('getNext')->willReturn(null);
 
         $this->httpClientMock
-            ->method('get')
+            ->method('getPaginated')
             ->with('accounts/1/logins')
-            ->willReturn($response);
+            ->willReturn($mockPaginated);
 
         $login = Login::find(2);
 
@@ -96,11 +99,13 @@ class LoginTest extends TestCase
      */
     public function testFindThrowsExceptionWhenNotFound(): void
     {
-        $response = new Response(200, [], json_encode([]));
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn([]);
+        $mockPaginated->method('getNext')->willReturn(null);
 
         $this->httpClientMock
-            ->method('get')
-            ->willReturn($response);
+            ->method('getPaginated')
+            ->willReturn($mockPaginated);
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Login with ID 999 not found');

--- a/tests/Api/Pages/PageTest.php
+++ b/tests/Api/Pages/PageTest.php
@@ -11,6 +11,7 @@ use CanvasLMS\Dto\Pages\UpdatePageDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Objects\PageRevision;
+use CanvasLMS\Pagination\PaginatedResponse;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -190,19 +191,16 @@ class PageTest extends TestCase
             'published' => true,
         ];
 
-        // Mock for list request - simplified for initial fetch
-        $listResponseMock = $this->createMock(ResponseInterface::class);
-        $listStreamMock = $this->createMock(StreamInterface::class);
+        // List request goes through stream()/getPaginated; the detail
+        // request (findByUrl) uses a plain get
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn($pagesListResponse);
+        $mockPaginated->method('getNext')->willReturn(null);
 
-        $listStreamMock->expects($this->once())
-            ->method('getContents')
-            ->willReturn(json_encode($pagesListResponse));
+        $this->httpClientMock->expects($this->once())
+            ->method('getPaginated')
+            ->willReturn($mockPaginated);
 
-        $listResponseMock->expects($this->once())
-            ->method('getBody')
-            ->willReturn($listStreamMock);
-
-        // Mock for detail request
         $detailResponseMock = $this->createMock(ResponseInterface::class);
         $detailStreamMock = $this->createMock(StreamInterface::class);
 
@@ -214,15 +212,10 @@ class PageTest extends TestCase
             ->method('getBody')
             ->willReturn($detailStreamMock);
 
-        $this->httpClientMock->expects($this->exactly(2))
+        $this->httpClientMock->expects($this->once())
             ->method('get')
-            ->willReturnCallback(function ($endpoint, $options = []) use ($listResponseMock, $detailResponseMock) {
-                if (str_contains($endpoint, 'pages/test-page')) {
-                    return $detailResponseMock;
-                }
-
-                return $listResponseMock;
-            });
+            ->with($this->stringContains('pages/test-page'))
+            ->willReturn($detailResponseMock);
 
         Page::setApiClient($this->httpClientMock);
         Page::setCourse($this->course);
@@ -242,23 +235,13 @@ class PageTest extends TestCase
             ['page_id' => 200, 'url' => 'another-page', 'title' => 'Another Page'],
         ];
 
-        $responseMock = $this->createMock(ResponseInterface::class);
-        $streamMock = $this->createMock(StreamInterface::class);
-
-        $streamMock->expects($this->once())
-            ->method('getContents')
-            ->willReturn(json_encode($pagesListResponse));
-
-        $responseMock->expects($this->once())
-            ->method('getBody')
-            ->willReturn($streamMock);
-
-        // No need to check headers in simplified implementation
+        $mockPaginated = $this->createMock(PaginatedResponse::class);
+        $mockPaginated->method('getJsonData')->willReturn($pagesListResponse);
+        $mockPaginated->method('getNext')->willReturn(null);
 
         $this->httpClientMock->expects($this->once())
-            ->method('get')
-            ->with('courses/123/pages')
-            ->willReturn($responseMock);
+            ->method('getPaginated')
+            ->willReturn($mockPaginated);
 
         Page::setApiClient($this->httpClientMock);
         Page::setCourse($this->course);

--- a/tests/Api/QuizSubmissions/QuizSubmissionTest.php
+++ b/tests/Api/QuizSubmissions/QuizSubmissionTest.php
@@ -416,7 +416,7 @@ class QuizSubmissionTest extends TestCase
 
         $expectedRequestData = [
             ['name' => 'access_code', 'contents' => 'secret123'],
-            ['name' => 'preview', 'contents' => false],
+            ['name' => 'preview', 'contents' => 'false'],
         ];
 
         $this->httpClient->expects($this->once())

--- a/tests/Auth/OAuthTest.php
+++ b/tests/Auth/OAuthTest.php
@@ -223,7 +223,7 @@ class OAuthTest extends TestCase
             ])));
 
         $this->expectException(OAuthRefreshFailedException::class);
-        $this->expectExceptionMessage('Invalid response from token refresh');
+        $this->expectExceptionMessage('Token refresh failed: invalid_grant: Invalid refresh token');
 
         OAuth::refreshToken();
     }
@@ -244,6 +244,7 @@ class OAuthTest extends TestCase
                     'headers' => [
                         'Authorization' => 'Bearer token_to_revoke',
                     ],
+                    'skipAuth' => true,
                 ])
             )
             ->willReturn(new Response(200, [], json_encode(['success' => true])));
@@ -273,6 +274,7 @@ class OAuthTest extends TestCase
                     'headers' => [
                         'Authorization' => 'Bearer token_to_revoke',
                     ],
+                    'skipAuth' => true,
                     'query' => [
                         'expire_sessions' => 1,
                     ],
@@ -306,6 +308,7 @@ class OAuthTest extends TestCase
                         'Authorization' => 'Bearer test_token',
                     ],
                     'json' => [],
+                    'skipAuth' => true,
                 ])
             )
             ->willReturn(new Response(200, [], json_encode([
@@ -338,6 +341,7 @@ class OAuthTest extends TestCase
                     'json' => [
                         'return_to' => '/courses/123',
                     ],
+                    'skipAuth' => true,
                 ])
             )
             ->willReturn(new Response(200, [], json_encode([
@@ -553,7 +557,7 @@ class OAuthTest extends TestCase
     }
 
     /**
-     * Test that OAuth token revocation still requires authentication
+     * Test that token revocation sends the token being revoked explicitly
      */
     public function testTokenRevocationStillRequiresAuthentication(): void
     {
@@ -571,8 +575,9 @@ class OAuthTest extends TestCase
                 $this->equalTo('DELETE'),
                 $this->stringContains('/login/oauth2/token'),
                 $this->callback(function ($options) {
-                    // Verify that skipAuth is NOT present (authentication should be applied)
-                    return !isset($options['skipAuth']) &&
+                    // skipAuth must be set so HttpClient does not overwrite
+                    // the manually-set token with the configured credential
+                    return isset($options['skipAuth']) && $options['skipAuth'] === true &&
                            isset($options['headers']['Authorization']) &&
                            $options['headers']['Authorization'] === 'Bearer token_to_revoke';
                 })
@@ -587,7 +592,7 @@ class OAuthTest extends TestCase
     }
 
     /**
-     * Test that OAuth session token creation still requires authentication
+     * Test that session token creation sends the OAuth token explicitly
      */
     public function testSessionTokenCreationStillRequiresAuthentication(): void
     {
@@ -607,8 +612,9 @@ class OAuthTest extends TestCase
                 $this->equalTo('POST'),
                 $this->stringContains('/login/session_token'),
                 $this->callback(function ($options) {
-                    // Verify that skipAuth is NOT present (authentication should be applied)
-                    return !isset($options['skipAuth']) &&
+                    // skipAuth must be set so HttpClient does not overwrite
+                    // the manually-set token with the configured credential
+                    return isset($options['skipAuth']) && $options['skipAuth'] === true &&
                            isset($options['headers']['Authorization']) &&
                            $options['headers']['Authorization'] === 'Bearer test_token';
                 })

--- a/tests/Cache/Adapters/FileSystemAdapterTest.php
+++ b/tests/Cache/Adapters/FileSystemAdapterTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Cache\Adapters;
+
+use CanvasLMS\Cache\Adapters\FileSystemAdapter;
+use PHPUnit\Framework\TestCase;
+
+class FileSystemAdapterTest extends TestCase
+{
+    private string $tempDir;
+
+    private FileSystemAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tempDir = sys_get_temp_dir() . '/canvas-cache-test-' . uniqid('', true);
+        $this->adapter = new FileSystemAdapter($this->tempDir, false);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->removeDirectory($this->tempDir);
+    }
+
+    // -----------------------------------------------------------------------
+    // Basic operations
+    // -----------------------------------------------------------------------
+
+    public function testSetAndGetRoundTrip(): void
+    {
+        $key = 'test-key';
+        $data = ['status' => 200, 'body' => 'hello world', 'headers' => ['Content-Type' => ['application/json']]];
+
+        $this->adapter->set($key, $data);
+        $result = $this->adapter->get($key);
+
+        $this->assertSame($data, $result);
+    }
+
+    public function testGetReturnNullForMissingKey(): void
+    {
+        $result = $this->adapter->get('does-not-exist');
+
+        $this->assertNull($result);
+    }
+
+    public function testHasReturnsTrueForExistingKey(): void
+    {
+        $this->adapter->set('exists', ['v' => 1]);
+
+        $this->assertTrue($this->adapter->has('exists'));
+    }
+
+    public function testHasReturnsFalseForMissingKey(): void
+    {
+        $this->assertFalse($this->adapter->has('missing-key'));
+    }
+
+    public function testDeleteRemovesExistingKey(): void
+    {
+        $this->adapter->set('to-delete', ['v' => 1]);
+        $this->assertTrue($this->adapter->has('to-delete'));
+
+        $result = $this->adapter->delete('to-delete');
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->adapter->has('to-delete'));
+    }
+
+    public function testDeleteReturnsFalseForNonExistentKey(): void
+    {
+        $result = $this->adapter->delete('ghost-key');
+
+        $this->assertFalse($result);
+    }
+
+    public function testClearRemovesAllEntries(): void
+    {
+        $this->adapter->set('k1', ['a' => 1]);
+        $this->adapter->set('k2', ['b' => 2]);
+        $this->adapter->set('k3', ['c' => 3]);
+
+        $this->adapter->clear();
+
+        $this->assertFalse($this->adapter->has('k1'));
+        $this->assertFalse($this->adapter->has('k2'));
+        $this->assertFalse($this->adapter->has('k3'));
+    }
+
+    // -----------------------------------------------------------------------
+    // TTL behaviour
+    // -----------------------------------------------------------------------
+
+    public function testZeroTtlMeansNoExpiry(): void
+    {
+        $this->adapter->set('permanent', ['value' => 'stays'], 0);
+
+        $result = $this->adapter->get('permanent');
+
+        $this->assertSame(['value' => 'stays'], $result);
+    }
+
+    public function testExpiredEntryReturnsNull(): void
+    {
+        // Write a cache file whose envelope already shows a past expiry time
+        // without relying on sleep().
+        $key = 'already-expired';
+        $this->adapter->set($key, ['v' => 'old'], 3600);
+
+        // Locate the file and overwrite it with an expired envelope
+        $hash = md5($key);
+        $subdir = substr($hash, 0, 2) . '/' . substr($hash, 2, 2);
+        $filepath = $this->tempDir . '/' . $subdir . '/' . $hash . '.cache';
+
+        $expiredEnvelope = [
+            'key' => $key,
+            'value' => ['v' => 'old'],
+            'expires' => time() - 1,  // one second in the past
+            'created' => time() - 10,
+        ];
+
+        file_put_contents($filepath, serialize($expiredEnvelope));
+
+        $result = $this->adapter->get($key);
+
+        $this->assertNull($result);
+    }
+
+    public function testTtlExpirySleepBased(): void
+    {
+        // Only use sleep as a last resort — kept isolated in its own test.
+        $key = 'sleep-expiry';
+        $this->adapter->set($key, ['data' => 'temp'], 1);
+
+        $this->assertNotNull($this->adapter->get($key), 'Entry should exist before expiry');
+
+        sleep(2);
+
+        $this->assertNull($this->adapter->get($key));
+        $this->assertFalse($this->adapter->has($key));
+    }
+
+    // -----------------------------------------------------------------------
+    // Compression
+    // -----------------------------------------------------------------------
+
+    public function testCompressionEnabledRoundTrip(): void
+    {
+        $compressedDir = $this->tempDir . '-compressed-' . uniqid('', true);
+        $adapter = new FileSystemAdapter($compressedDir, true);
+
+        try {
+            $data = ['body' => str_repeat('compress me', 100)];
+            $adapter->set('comp-key', $data);
+            $result = $adapter->get('comp-key');
+
+            $this->assertSame($data, $result);
+        } finally {
+            $this->removeDirectory($compressedDir);
+        }
+    }
+
+    public function testCompressionDisabledRoundTrip(): void
+    {
+        $data = ['body' => str_repeat('no-compress', 100)];
+        $this->adapter->set('plain-key', $data);
+        $result = $this->adapter->get('plain-key');
+
+        $this->assertSame($data, $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // getStats
+    // -----------------------------------------------------------------------
+
+    public function testGetStatsReflectsEntryCount(): void
+    {
+        $this->adapter->set('s1', ['x' => 1]);
+        $this->adapter->set('s2', ['x' => 2]);
+
+        $stats = $this->adapter->getStats();
+
+        $this->assertArrayHasKey('entries', $stats);
+        $this->assertArrayHasKey('hits', $stats);
+        $this->assertArrayHasKey('misses', $stats);
+        $this->assertArrayHasKey('size', $stats);
+        $this->assertSame(2, $stats['entries']);
+    }
+
+    public function testGetStatsTracksHitsAndMisses(): void
+    {
+        $this->adapter->set('hit-key', ['data' => 'x']);
+
+        $this->adapter->get('hit-key');    // hit
+        $this->adapter->get('miss-key');   // miss
+
+        $stats = $this->adapter->getStats();
+
+        $this->assertSame(1, $stats['hits']);
+        $this->assertSame(1, $stats['misses']);
+    }
+
+    // -----------------------------------------------------------------------
+    // deleteByPattern — key stored in envelope, not filename
+    // -----------------------------------------------------------------------
+
+    public function testDeleteByPatternMatchesOriginalKeys(): void
+    {
+        $this->adapter->set('abc:GET:/api/v1/courses', ['data' => 'courses']);
+        $this->adapter->set('abc:GET:/api/v1/users', ['data' => 'users']);
+
+        $deleted = $this->adapter->deleteByPattern('*GET:/api/v1/courses*');
+
+        $this->assertSame(1, $deleted);
+        $this->assertNull($this->adapter->get('abc:GET:/api/v1/courses'));
+        $this->assertNotNull($this->adapter->get('abc:GET:/api/v1/users'));
+    }
+
+    public function testDeleteByPatternDeletesNothingWhenNoMatch(): void
+    {
+        $this->adapter->set('abc:GET:/api/v1/courses', ['d' => 1]);
+
+        $deleted = $this->adapter->deleteByPattern('*PATCH:/api/v1/no-match*');
+
+        $this->assertSame(0, $deleted);
+        $this->assertNotNull($this->adapter->get('abc:GET:/api/v1/courses'));
+    }
+
+    public function testDeleteByPatternWithWildcardDeletesMultiple(): void
+    {
+        $this->adapter->set('prefix:GET:/api/v1/courses', ['d' => 1]);
+        $this->adapter->set('prefix:GET:/api/v1/courses/123', ['d' => 2]);
+        $this->adapter->set('prefix:GET:/api/v1/users', ['d' => 3]);
+
+        $deleted = $this->adapter->deleteByPattern('*:GET:/api/v1/courses*');
+
+        $this->assertSame(2, $deleted);
+        $this->assertNull($this->adapter->get('prefix:GET:/api/v1/courses'));
+        $this->assertNull($this->adapter->get('prefix:GET:/api/v1/courses/123'));
+        $this->assertNotNull($this->adapter->get('prefix:GET:/api/v1/users'));
+    }
+
+    // -----------------------------------------------------------------------
+    // Security: unserialize hardening
+    // -----------------------------------------------------------------------
+
+    public function testGetReturnsNullForCorruptedCacheFile(): void
+    {
+        // Write a cache file containing completely invalid serialized data.
+        // The adapter must return null rather than crash on corrupt content.
+        $key = 'corrupt-cache';
+        $hash = md5($key);
+        $subdir = substr($hash, 0, 2) . '/' . substr($hash, 2, 2);
+        $dir = $this->tempDir . '/' . $subdir;
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0700, true);
+        }
+
+        $filepath = $dir . '/' . $hash . '.cache';
+        // Garbage bytes that are not valid serialized PHP
+        file_put_contents($filepath, 'NOT_VALID_SERIALIZED_DATA!!!!!!');
+
+        $result = $this->adapter->get($key);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetReturnsNullWhenEnvelopeIsNotArray(): void
+    {
+        // Write a cache file whose serialized content is a scalar, not an array.
+        // The adapter guards `!is_array($data)` and must return null.
+        $key = 'scalar-envelope';
+        $hash = md5($key);
+        $subdir = substr($hash, 0, 2) . '/' . substr($hash, 2, 2);
+        $dir = $this->tempDir . '/' . $subdir;
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0700, true);
+        }
+
+        $filepath = $dir . '/' . $hash . '.cache';
+        // Serialize a plain string — valid PHP serialization but not the expected array envelope
+        file_put_contents($filepath, serialize('just-a-string'));
+
+        $result = $this->adapter->get($key);
+
+        $this->assertNull($result);
+    }
+
+    // -----------------------------------------------------------------------
+    // File permissions (POSIX only)
+    // -----------------------------------------------------------------------
+
+    public function testDefaultFilePermissionsAreOwnerOnly(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('File permission check not applicable on Windows');
+        }
+
+        $this->adapter->set('perm-key', ['v' => 1]);
+
+        $hash = md5('perm-key');
+        $subdir = substr($hash, 0, 2) . '/' . substr($hash, 2, 2);
+        $filepath = $this->tempDir . '/' . $subdir . '/' . $hash . '.cache';
+
+        $perms = fileperms($filepath) & 0777;
+
+        $this->assertSame(0600, $perms, sprintf('Expected 0600, got %04o', $perms));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Cache/Adapters/InMemoryAdapterTest.php
+++ b/tests/Cache/Adapters/InMemoryAdapterTest.php
@@ -82,19 +82,20 @@ class InMemoryAdapterTest extends TestCase
 
     public function testTtlExpiration(): void
     {
+        $adapter = $this->createAdapterWithControllableClock();
         $key = 'expiring-key';
         $data = ['test' => 'data'];
 
-        // Set with 1 second TTL
-        $this->adapter->set($key, $data, 1);
-        $this->assertTrue($this->adapter->has($key));
-        $this->assertSame($data, $this->adapter->get($key));
+        // Set with 60 second TTL
+        $adapter->set($key, $data, 60);
+        $this->assertTrue($adapter->has($key));
+        $this->assertSame($data, $adapter->get($key));
 
-        // Wait for expiration
-        sleep(2);
+        // Advance the clock past expiry instead of sleeping
+        $adapter->advanceClock(61);
 
-        $this->assertFalse($this->adapter->has($key));
-        $this->assertNull($this->adapter->get($key));
+        $this->assertFalse($adapter->has($key));
+        $this->assertNull($adapter->get($key));
     }
 
     public function testDeleteByPattern(): void
@@ -172,22 +173,23 @@ class InMemoryAdapterTest extends TestCase
 
     public function testExpiredEntriesCleanup(): void
     {
-        $this->adapter->set('permanent', ['data'], 0); // No expiry
-        $this->adapter->set('expiring1', ['data'], 1); // 1 second
-        $this->adapter->set('expiring2', ['data'], 1); // 1 second
+        $adapter = $this->createAdapterWithControllableClock();
+        $adapter->set('permanent', ['data'], 0); // No expiry
+        $adapter->set('expiring1', ['data'], 60);
+        $adapter->set('expiring2', ['data'], 60);
 
-        $stats = $this->adapter->getStats();
+        $stats = $adapter->getStats();
         $this->assertEquals(3, $stats['entries']);
 
-        sleep(2);
+        $adapter->advanceClock(61);
 
         // Getting stats should clean expired entries
-        $stats = $this->adapter->getStats();
+        $stats = $adapter->getStats();
         $this->assertEquals(1, $stats['entries']); // Only permanent remains
 
-        $this->assertTrue($this->adapter->has('permanent'));
-        $this->assertFalse($this->adapter->has('expiring1'));
-        $this->assertFalse($this->adapter->has('expiring2'));
+        $this->assertTrue($adapter->has('permanent'));
+        $this->assertFalse($adapter->has('expiring1'));
+        $this->assertFalse($adapter->has('expiring2'));
     }
 
     public function testComplexPatternMatching(): void
@@ -205,5 +207,27 @@ class InMemoryAdapterTest extends TestCase
         $this->assertFalse($this->adapter->has('canvas:v1:GET:/courses/123'));
         $this->assertTrue($this->adapter->has('canvas:v1:POST:/courses'));
         $this->assertTrue($this->adapter->has('canvas:v1:GET:/users'));
+    }
+
+    /**
+     * Build an adapter whose clock the test can advance directly.
+     *
+     * @return InMemoryAdapter&object{advanceClock: callable}
+     */
+    private function createAdapterWithControllableClock(): InMemoryAdapter
+    {
+        return new class () extends InMemoryAdapter {
+            private int $offset = 0;
+
+            public function advanceClock(int $seconds): void
+            {
+                $this->offset += $seconds;
+            }
+
+            protected function currentTime(): int
+            {
+                return time() + $this->offset;
+            }
+        };
     }
 }

--- a/tests/Cache/ResponseSerializerTest.php
+++ b/tests/Cache/ResponseSerializerTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Cache;
+
+use CanvasLMS\Cache\ResponseSerializer;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class ResponseSerializerTest extends TestCase
+{
+    private ResponseSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = new ResponseSerializer();
+    }
+
+    // -----------------------------------------------------------------------
+    // serialize()
+    // -----------------------------------------------------------------------
+
+    public function testSerializePreservesStatusCode(): void
+    {
+        $response = new Response(201, [], 'created');
+        $data = $this->serializer->serialize($response);
+
+        $this->assertTrue($data['cacheable']);
+        $this->assertSame(201, $data['status']);
+    }
+
+    public function testSerializePreservesHeaders(): void
+    {
+        $response = new Response(200, ['Content-Type' => 'application/json', 'X-Custom' => 'value'], '{}');
+        $data = $this->serializer->serialize($response);
+
+        $this->assertArrayHasKey('headers', $data);
+        $this->assertArrayHasKey('Content-Type', $data['headers']);
+        $this->assertSame(['application/json'], $data['headers']['Content-Type']);
+        $this->assertSame(['value'], $data['headers']['X-Custom']);
+    }
+
+    public function testSerializePreservesBody(): void
+    {
+        $body = '{"courses":[{"id":1}]}';
+        $response = new Response(200, [], $body);
+        $data = $this->serializer->serialize($response);
+
+        $this->assertSame($body, $data['body']);
+    }
+
+    public function testSerializePreservesProtocolVersion(): void
+    {
+        $response = new Response(200, [], '', '1.0');
+        $data = $this->serializer->serialize($response);
+
+        $this->assertSame('1.0', $data['version']);
+    }
+
+    public function testSerializePreservesReasonPhrase(): void
+    {
+        $response = new Response(404, [], '', '1.1', 'Not Found');
+        $data = $this->serializer->serialize($response);
+
+        $this->assertSame('Not Found', $data['reason']);
+    }
+
+    public function testBodyRemainsReadableAfterSerialize(): void
+    {
+        // The stream should be rewound after serialize reads it, so reading
+        // the original response body again should still return the content.
+        $body = 'rewind-me';
+        $response = new Response(200, [], $body);
+
+        $this->serializer->serialize($response);
+
+        $this->assertSame($body, (string) $response->getBody());
+    }
+
+    public function testSerializeReturnsCacheableFlagTrue(): void
+    {
+        $response = new Response(200, [], 'ok');
+        $data = $this->serializer->serialize($response);
+
+        $this->assertArrayHasKey('cacheable', $data);
+        $this->assertTrue($data['cacheable']);
+    }
+
+    public function testSerializeReturnsNonCacheableWhenBodyExceedsMaxSize(): void
+    {
+        // Construct a serializer with a tiny max-body limit.
+        $smallSerializer = new ResponseSerializer(10);
+
+        // Guzzle's stream knows its size when built from a string.
+        $body = str_repeat('x', 11); // 11 bytes > 10 byte limit
+        $response = new Response(200, [], $body);
+
+        $data = $smallSerializer->serialize($response);
+
+        $this->assertArrayHasKey('cacheable', $data);
+        $this->assertFalse($data['cacheable']);
+    }
+
+    // -----------------------------------------------------------------------
+    // deserialize()
+    // -----------------------------------------------------------------------
+
+    public function testDeserializeRoundTripPreservesStatusHeadersAndBody(): void
+    {
+        $original = new Response(200, ['Content-Type' => 'application/json'], '{"id":1}');
+        $serialized = $this->serializer->serialize($original);
+        $restored = $this->serializer->deserialize($serialized);
+
+        $this->assertNotNull($restored);
+        $this->assertSame(200, $restored->getStatusCode());
+        $this->assertSame(['application/json'], $restored->getHeader('Content-Type'));
+        $this->assertSame('{"id":1}', (string) $restored->getBody());
+    }
+
+    public function testDeserializeReturnsNullWhenCacheableFalse(): void
+    {
+        $data = ['cacheable' => false, 'reason' => 'Response too large'];
+        $result = $this->serializer->deserialize($data);
+
+        $this->assertNull($result);
+    }
+
+    public function testDeserializeReturnsNullWhenCacheableKeyMissing(): void
+    {
+        $data = ['status' => 200, 'headers' => [], 'body' => 'no-cacheable-flag'];
+        $result = $this->serializer->deserialize($data);
+
+        $this->assertNull($result);
+    }
+
+    public function testDeserializeUsesDefaultsForMissingFields(): void
+    {
+        $data = ['cacheable' => true];  // minimal envelope
+        $result = $this->serializer->deserialize($data);
+
+        $this->assertNotNull($result);
+        $this->assertSame(200, $result->getStatusCode());
+        $this->assertSame('', (string) $result->getBody());
+    }
+
+    public function testDeserializePreservesProtocolVersion(): void
+    {
+        $original = new Response(200, [], '', '2.0');
+        $serialized = $this->serializer->serialize($original);
+        $restored = $this->serializer->deserialize($serialized);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('2.0', $restored->getProtocolVersion());
+    }
+
+    public function testDeserializePreservesReasonPhrase(): void
+    {
+        $original = new Response(422, [], '', '1.1', 'Unprocessable Entity');
+        $serialized = $this->serializer->serialize($original);
+        $restored = $this->serializer->deserialize($serialized);
+
+        $this->assertNotNull($restored);
+        $this->assertSame('Unprocessable Entity', $restored->getReasonPhrase());
+    }
+
+    // -----------------------------------------------------------------------
+    // Full round-trip integration
+    // -----------------------------------------------------------------------
+
+    public function testFullRoundTripWithComplexResponse(): void
+    {
+        $original = new Response(
+            200,
+            [
+                'Content-Type' => 'application/json',
+                'Link' => '<https://canvas.example.com/api/v1/courses?page=2>; rel="next"',
+            ],
+            '{"courses":[{"id":1,"name":"Bio 101"},{"id":2,"name":"Chem 201"}]}'
+        );
+
+        $serialized = $this->serializer->serialize($original);
+        $restored = $this->serializer->deserialize($serialized);
+
+        $this->assertNotNull($restored);
+        $this->assertSame($original->getStatusCode(), $restored->getStatusCode());
+        $this->assertSame((string) $original->getBody(), (string) $restored->getBody());
+        $this->assertSame($original->getHeaders(), $restored->getHeaders());
+    }
+
+    public function testBodySizeAtExactLimitIsCacheable(): void
+    {
+        $maxSize = 100;
+        $serializer = new ResponseSerializer($maxSize);
+
+        // Exactly at limit — must be cacheable
+        $body = str_repeat('a', $maxSize);
+        $response = new Response(200, [], $body);
+        $data = $serializer->serialize($response);
+
+        $this->assertTrue($data['cacheable']);
+    }
+
+    public function testBodySizeOneOverLimitIsNotCacheable(): void
+    {
+        $maxSize = 100;
+        $serializer = new ResponseSerializer($maxSize);
+
+        $body = str_repeat('a', $maxSize + 1);
+        $response = new Response(200, [], $body);
+        $data = $serializer->serialize($response);
+
+        $this->assertFalse($data['cacheable']);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -192,9 +192,9 @@ class ConfigTest extends TestCase
         Config::setBaseUrl('https://valid.canvas.com');
         Config::setApiVersion('v1');
 
-        // Should not throw exception
+        // The contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         Config::validate();
-        $this->assertTrue(true);
     }
 
     public function testValidateConfigurationMissingApiKey(): void

--- a/tests/Dto/Announcements/CreateAnnouncementDTOTest.php
+++ b/tests/Dto/Announcements/CreateAnnouncementDTOTest.php
@@ -165,11 +165,11 @@ class CreateAnnouncementDTOTest extends TestCase
                 $titleFound = true;
             }
             if ($field['name'] === 'discussion_topic[is_announcement]') {
-                $this->assertEquals('1', $field['contents']);
+                $this->assertSame('true', $field['contents']);
                 $isAnnouncementFound = true;
             }
             if ($field['name'] === 'discussion_topic[require_initial_post]') {
-                $this->assertEquals('', $field['contents']);
+                $this->assertSame('false', $field['contents']);
                 $requireInitialPostFound = true;
             }
         }

--- a/tests/Dto/Announcements/UpdateAnnouncementDTOTest.php
+++ b/tests/Dto/Announcements/UpdateAnnouncementDTOTest.php
@@ -151,7 +151,7 @@ class UpdateAnnouncementDTOTest extends TestCase
                     $titleFound = true;
                 }
                 if ($field['name'] === 'discussion_topic[locked]') {
-                    $this->assertEquals('1', $field['contents']);
+                    $this->assertSame('true', $field['contents']);
                     $lockedFound = true;
                 }
             }

--- a/tests/Dto/Courses/CreateCourseDTOTest.php
+++ b/tests/Dto/Courses/CreateCourseDTOTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Dto\Courses;
+
+use CanvasLMS\Dto\Courses\CreateCourseDTO;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class CreateCourseDTOTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // toApiArray() key format
+    // -----------------------------------------------------------------------
+
+    public function testToApiArrayKeysUseCourseBracketSnakeCase(): void
+    {
+        $dto = new CreateCourseDTO(['name' => 'Physics 101', 'course_code' => 'PHY-101']);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[name]', $result);
+        $this->assertArrayHasKey('course[course_code]', $result);
+        $this->assertArrayHasKey('course[license]', $result);
+        $this->assertArrayHasKey('course[time_zone]', $result);
+        $this->assertArrayHasKey('course[default_view]', $result);
+    }
+
+    public function testToApiArrayKeyForCamelCasePropertyIsSnakeCased(): void
+    {
+        $dto = new CreateCourseDTO(['name' => 'Bio']);
+        $result = $this->indexByName($dto->toApiArray());
+
+        // isPublicToAuthUsers → course[is_public_to_auth_users]
+        $this->assertArrayHasKey('course[is_public_to_auth_users]', $result);
+        $this->assertArrayHasKey('course[allow_student_wiki_edits]', $result);
+        $this->assertArrayHasKey('course[restrict_enrollments_to_course_dates]', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() null / empty string omission
+    // -----------------------------------------------------------------------
+
+    public function testNullPropertiesAreOmittedFromToApiArray(): void
+    {
+        $dto = new CreateCourseDTO(['name' => 'Test']);
+
+        // Nullable properties that default to null
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayNotHasKey('course[start_at]', $result);
+        $this->assertArrayNotHasKey('course[end_at]', $result);
+        $this->assertArrayNotHasKey('course[public_description]', $result);
+        $this->assertArrayNotHasKey('course[term_id]', $result);
+        $this->assertArrayNotHasKey('course[sis_course_id]', $result);
+        $this->assertArrayNotHasKey('course[integration_id]', $result);
+        $this->assertArrayNotHasKey('course[syllabus_body]', $result);
+        $this->assertArrayNotHasKey('course[grading_standard_id]', $result);
+        $this->assertArrayNotHasKey('course[grade_passback_setting]', $result);
+        $this->assertArrayNotHasKey('course[course_format]', $result);
+    }
+
+    public function testEmptyStringPropertyIsOmitted(): void
+    {
+        // courseCode defaults to '' and must be omitted
+        $dto = new CreateCourseDTO(['name' => 'No Code']);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayNotHasKey('course[course_code]', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() boolean handling
+    // -----------------------------------------------------------------------
+
+    public function testBooleanFalseIsIncludedAsNativePhpBool(): void
+    {
+        // CreateCourseDTO::toApiArray() does NOT use formatMultipartValue,
+        // so booleans remain native PHP bool (not 'true'/'false' strings).
+        $dto = new CreateCourseDTO(['name' => 'Test', 'is_public' => false]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[is_public]', $result);
+        $this->assertSame('false', $result['course[is_public]']);
+    }
+
+    public function testBooleanTrueIsIncludedAsNativePhpBool(): void
+    {
+        $dto = new CreateCourseDTO(['name' => 'Test', 'is_public' => true]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[is_public]', $result);
+        $this->assertSame('true', $result['course[is_public]']);
+    }
+
+    public function testAllDefaultFalseBoolsAppearInOutput(): void
+    {
+        // All bool properties default to false, and false is NOT filtered out.
+        $dto = new CreateCourseDTO(['name' => 'Bool Defaults']);
+        $result = $this->indexByName($dto->toApiArray());
+
+        foreach ([
+            'course[is_public]',
+            'course[is_public_to_auth_users]',
+            'course[public_syllabus]',
+            'course[public_syllabus_to_auth]',
+            'course[allow_student_wiki_edits]',
+            'course[allow_wiki_comments]',
+            'course[allow_student_forum_attachments]',
+            'course[open_enrollment]',
+            'course[self_enrollment]',
+            'course[restrict_enrollments_to_course_dates]',
+            'course[hide_final_grades]',
+            'course[apply_assignment_group_weights]',
+            'course[offer]',
+            'course[enroll_me]',
+            'course[enable_sis_reactivation]',
+            'course[post_manually]',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $result, "Expected bool key '$key' to be present");
+            $this->assertSame('false', $result[$key], "Expected '$key' to be 'false' by default");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() DateTime serialization
+    // -----------------------------------------------------------------------
+
+    public function testDateTimePropertiesSerializeAsIso8601(): void
+    {
+        $startAt = new DateTime('2024-01-15T08:00:00Z');
+        $endAt = new DateTime('2024-06-15T17:00:00Z');
+
+        $dto = new CreateCourseDTO([
+            'name' => 'Date Test',
+            'restrict_enrollments_to_course_dates' => true,
+            'start_at' => $startAt,
+            'end_at' => $endAt,
+        ]);
+
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[start_at]', $result);
+        $this->assertArrayHasKey('course[end_at]', $result);
+
+        // format('c') produces ISO 8601 with offset, e.g. 2024-01-15T08:00:00+00:00
+        $this->assertSame($startAt->format('c'), $result['course[start_at]']);
+        $this->assertSame($endAt->format('c'), $result['course[end_at]']);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() string / int content values
+    // -----------------------------------------------------------------------
+
+    public function testStringValuesArePreserved(): void
+    {
+        $dto = new CreateCourseDTO([
+            'name' => 'My Course',
+            'license' => 'cc_by',
+            'time_zone' => 'America/New_York',
+        ]);
+
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertSame('My Course', $result['course[name]']);
+        $this->assertSame('cc_by', $result['course[license]']);
+        $this->assertSame('America/New_York', $result['course[time_zone]']);
+    }
+
+    public function testIntValuesArePreserved(): void
+    {
+        $dto = new CreateCourseDTO([
+            'name' => 'Graded Course',
+            'term_id' => 42,
+            'grading_standard_id' => 7,
+        ]);
+
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertSame(42, $result['course[term_id]']);
+        $this->assertSame(7, $result['course[grading_standard_id]']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructor / defaults
+    // -----------------------------------------------------------------------
+
+    public function testDefaultNameIsUnnamedCourse(): void
+    {
+        $dto = new CreateCourseDTO([]);
+        $this->assertSame('Unnamed Course', $dto->name);
+    }
+
+    public function testConstructorPopulatesSnakeCaseKeys(): void
+    {
+        $dto = new CreateCourseDTO([
+            'name' => 'Chem 101',
+            'course_code' => 'CHEM-101',
+            'license' => 'cc_by_nc',
+            'is_public' => true,
+            'time_zone' => 'UTC',
+        ]);
+
+        $this->assertSame('Chem 101', $dto->name);
+        $this->assertSame('CHEM-101', $dto->courseCode);
+        $this->assertSame('cc_by_nc', $dto->license);
+        $this->assertTrue($dto->isPublic);
+        $this->assertSame('UTC', $dto->timeZone);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    /**
+     * Index a multipart-format array by name for easy keyed lookup.
+     *
+     * @param array<int, array{name: string, contents: mixed}> $apiArray
+     *
+     * @return array<string, mixed>
+     */
+    private function indexByName(array $apiArray): array
+    {
+        $indexed = [];
+        foreach ($apiArray as $item) {
+            $indexed[$item['name']] = $item['contents'];
+        }
+
+        return $indexed;
+    }
+}

--- a/tests/Dto/Courses/UpdateCourseDTOTest.php
+++ b/tests/Dto/Courses/UpdateCourseDTOTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Dto\Courses;
+
+use CanvasLMS\Dto\Courses\UpdateCourseDTO;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class UpdateCourseDTOTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // toApiArray() key format
+    // -----------------------------------------------------------------------
+
+    public function testToApiArrayKeysUseCourseBracketSnakeCase(): void
+    {
+        $dto = new UpdateCourseDTO(['name' => 'Updated Course', 'course_code' => 'UPD-101']);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[name]', $result);
+        $this->assertArrayHasKey('course[course_code]', $result);
+        $this->assertArrayHasKey('course[default_view]', $result);
+    }
+
+    public function testToApiArrayCamelCasePropertiesAreSnakeCased(): void
+    {
+        $dto = new UpdateCourseDTO([
+            'name' => 'Test',
+            'hide_final_grades' => true,
+            'apply_assignment_group_weights' => true,
+            'storage_quota_mb' => 500,
+        ]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[hide_final_grades]', $result);
+        $this->assertArrayHasKey('course[apply_assignment_group_weights]', $result);
+        $this->assertArrayHasKey('course[storage_quota_mb]', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() null omission
+    // -----------------------------------------------------------------------
+
+    public function testNullPropertiesAreOmittedFromToApiArray(): void
+    {
+        // UpdateCourseDTO has all-nullable properties. With no values set, only
+        // defaultView ('syllabus') should appear.
+        $dto = new UpdateCourseDTO([]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayNotHasKey('course[name]', $result);
+        $this->assertArrayNotHasKey('course[course_code]', $result);
+        $this->assertArrayNotHasKey('course[account_id]', $result);
+        $this->assertArrayNotHasKey('course[start_at]', $result);
+        $this->assertArrayNotHasKey('course[end_at]', $result);
+        $this->assertArrayNotHasKey('course[license]', $result);
+        $this->assertArrayNotHasKey('course[is_public]', $result);
+        $this->assertArrayNotHasKey('course[term_id]', $result);
+        $this->assertArrayNotHasKey('course[sis_course_id]', $result);
+        $this->assertArrayNotHasKey('course[image_id]', $result);
+        $this->assertArrayNotHasKey('course[image_url]', $result);
+    }
+
+    public function testDefaultViewAlwaysAppearsEvenWithNoOtherProperties(): void
+    {
+        // defaultView has a non-null default ('syllabus') so it always appears.
+        $dto = new UpdateCourseDTO([]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[default_view]', $result);
+        $this->assertSame('syllabus', $result['course[default_view]']);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() boolean handling
+    // -----------------------------------------------------------------------
+
+    public function testBooleanTrueIsIncludedAsNativePhpBool(): void
+    {
+        $dto = new UpdateCourseDTO(['name' => 'Test', 'is_public' => true]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[is_public]', $result);
+        $this->assertSame('true', $result['course[is_public]']);
+    }
+
+    public function testBooleanFalseIsIncludedAsNativePhpBool(): void
+    {
+        $dto = new UpdateCourseDTO(['name' => 'Test', 'hide_final_grades' => false]);
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[hide_final_grades]', $result);
+        $this->assertSame('false', $result['course[hide_final_grades]']);
+    }
+
+    public function testNullBooleanIsOmitted(): void
+    {
+        // In UpdateCourseDTO all bool properties are nullable. If null → excluded.
+        $dto = new UpdateCourseDTO(['name' => 'Test']);
+        // is_public defaults to null
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayNotHasKey('course[is_public]', $result);
+        $this->assertArrayNotHasKey('course[blueprint]', $result);
+        $this->assertArrayNotHasKey('course[template]', $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() DateTime serialization
+    // -----------------------------------------------------------------------
+
+    public function testDateTimePropertiesSerializeAsIso8601(): void
+    {
+        $startAt = new DateTime('2024-03-01T09:00:00Z');
+        $endAt = new DateTime('2024-12-15T23:59:59Z');
+
+        $dto = new UpdateCourseDTO([
+            'name' => 'Dated Course',
+            'start_at' => $startAt,
+            'end_at' => $endAt,
+        ]);
+
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[start_at]', $result);
+        $this->assertArrayHasKey('course[end_at]', $result);
+        $this->assertSame($startAt->format('c'), $result['course[start_at]']);
+        $this->assertSame($endAt->format('c'), $result['course[end_at]']);
+    }
+
+    // -----------------------------------------------------------------------
+    // toApiArray() array property
+    // -----------------------------------------------------------------------
+
+    public function testArrayPropertyIsIncludedDirectlyAsArray(): void
+    {
+        // UpdateCourseDTO::toApiArray() puts array values directly into
+        // 'contents' without flattening — unlike AbstractBaseDto::toApiArray().
+        $restrictions = ['assignment' => ['content' => true], 'quiz' => ['content' => false]];
+        $dto = new UpdateCourseDTO([
+            'name' => 'Blueprint',
+            'blueprint_restrictions_by_object_type' => $restrictions,
+        ]);
+
+        $result = $this->indexByName($dto->toApiArray());
+
+        $this->assertArrayHasKey('course[blueprint_restrictions_by_object_type]', $result);
+        $this->assertSame($restrictions, $result['course[blueprint_restrictions_by_object_type]']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructor / defaults
+    // -----------------------------------------------------------------------
+
+    public function testDefaultViewIsSetToSyllabus(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+        $this->assertSame('syllabus', $dto->defaultView);
+    }
+
+    public function testAllNullablePropertiesDefaultToNull(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+
+        $this->assertNull($dto->name);
+        $this->assertNull($dto->courseCode);
+        $this->assertNull($dto->startAt);
+        $this->assertNull($dto->endAt);
+        $this->assertNull($dto->license);
+        $this->assertNull($dto->isPublic);
+        $this->assertNull($dto->termId);
+        $this->assertNull($dto->sisCourseId);
+        $this->assertNull($dto->imageId);
+        $this->assertNull($dto->imageUrl);
+        $this->assertNull($dto->blueprint);
+        $this->assertNull($dto->template);
+        $this->assertNull($dto->postManually);
+    }
+
+    public function testConstructorPopulatesSnakeCaseKeys(): void
+    {
+        $dto = new UpdateCourseDTO([
+            'name' => 'Updated',
+            'course_code' => 'UPD-001',
+            'license' => 'cc_by_sa',
+            'is_public' => true,
+            'term_id' => 5,
+            'storage_quota_mb' => 1024,
+            'event' => 'offer',
+            'default_view' => 'modules',
+        ]);
+
+        $this->assertSame('Updated', $dto->name);
+        $this->assertSame('UPD-001', $dto->courseCode);
+        $this->assertSame('cc_by_sa', $dto->license);
+        $this->assertTrue($dto->isPublic);
+        $this->assertSame(5, $dto->termId);
+        $this->assertSame(1024, $dto->storageQuotaMb);
+        $this->assertSame('offer', $dto->event);
+        $this->assertSame('modules', $dto->defaultView);
+    }
+
+    // -----------------------------------------------------------------------
+    // setCourseColor validation
+    // -----------------------------------------------------------------------
+
+    public function testSetCourseColorAcceptsValidHexWithHash(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+        $dto->setCourseColor('#ff0000');
+
+        $this->assertSame('#ff0000', $dto->courseColor);
+    }
+
+    public function testSetCourseColorAcceptsValidHexWithoutHash(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+        $dto->setCourseColor('aabbcc');
+
+        $this->assertSame('aabbcc', $dto->courseColor);
+    }
+
+    public function testSetCourseColorThrowsOnInvalidFormat(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $dto->setCourseColor('not-a-color');
+    }
+
+    public function testSetCourseColorAcceptsNull(): void
+    {
+        $dto = new UpdateCourseDTO([]);
+        $dto->setCourseColor(null);
+
+        $this->assertNull($dto->courseColor);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    /**
+     * Index a multipart-format array by name for easy keyed lookup.
+     *
+     * @param array<int, array{name: string, contents: mixed}> $apiArray
+     *
+     * @return array<string, mixed>
+     */
+    private function indexByName(array $apiArray): array
+    {
+        $indexed = [];
+        foreach ($apiArray as $item) {
+            $indexed[$item['name']] = $item['contents'];
+        }
+
+        return $indexed;
+    }
+}

--- a/tests/Dto/Modules/CreateModuleItemDTOTest.php
+++ b/tests/Dto/Modules/CreateModuleItemDTOTest.php
@@ -150,7 +150,7 @@ class CreateModuleItemDTOTest extends TestCase
 
         $this->assertContains(['name' => 'module_item[type]', 'contents' => 'ExternalTool'], $apiArray);
         $this->assertContains(['name' => 'module_item[external_url]', 'contents' => 'https://example.com/tool'], $apiArray);
-        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => 'true'], $apiArray);
 
         // Check iframe array conversion
         $this->assertContains(['name' => 'module_item[iframe][width]', 'contents' => 800], $apiArray);

--- a/tests/Dto/Modules/UpdateModuleItemDTOTest.php
+++ b/tests/Dto/Modules/UpdateModuleItemDTOTest.php
@@ -130,7 +130,7 @@ class UpdateModuleItemDTOTest extends TestCase
         $apiArray = $dto->toApiArray();
 
         $this->assertContains(['name' => 'module_item[external_url]', 'contents' => 'https://new-tool.example.com'], $apiArray);
-        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => 'true'], $apiArray);
         $this->assertContains(['name' => 'module_item[iframe][width]', 'contents' => 1000], $apiArray);
         $this->assertContains(['name' => 'module_item[iframe][height]', 'contents' => 700], $apiArray);
     }
@@ -305,7 +305,7 @@ class UpdateModuleItemDTOTest extends TestCase
         $apiArray = $dto->toApiArray();
 
         // Both false boolean and string should be included
-        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => false], $apiArray);
+        $this->assertContains(['name' => 'module_item[new_tab]', 'contents' => 'false'], $apiArray);
         $this->assertContains(['name' => 'module_item[title]', 'contents' => 'Test Title'], $apiArray);
     }
 

--- a/tests/Dto/Pages/CreatePageDTOTest.php
+++ b/tests/Dto/Pages/CreatePageDTOTest.php
@@ -162,9 +162,9 @@ class CreatePageDTOTest extends TestCase
             $valueMap[$item['name']] = $item['contents'];
         }
 
-        $this->assertEquals(true, $valueMap['wiki_page[published]']);
-        $this->assertEquals(false, $valueMap['wiki_page[front_page]']);
-        $this->assertEquals(true, $valueMap['wiki_page[notify_of_update]']);
+        $this->assertSame('true', $valueMap['wiki_page[published]']);
+        $this->assertSame('false', $valueMap['wiki_page[front_page]']);
+        $this->assertSame('true', $valueMap['wiki_page[notify_of_update]']);
     }
 
     public function testApiPropertyName(): void

--- a/tests/Dto/Pages/UpdatePageDTOTest.php
+++ b/tests/Dto/Pages/UpdatePageDTOTest.php
@@ -155,9 +155,9 @@ class UpdatePageDTOTest extends TestCase
             $valueMap[$item['name']] = $item['contents'];
         }
 
-        $this->assertEquals(false, $valueMap['wiki_page[published]']);
-        $this->assertEquals(true, $valueMap['wiki_page[front_page]']);
-        $this->assertEquals(false, $valueMap['wiki_page[notify_of_update]']);
+        $this->assertSame('false', $valueMap['wiki_page[published]']);
+        $this->assertSame('true', $valueMap['wiki_page[front_page]']);
+        $this->assertSame('false', $valueMap['wiki_page[notify_of_update]']);
     }
 
     public function testApiPropertyName(): void

--- a/tests/Dto/QuizSubmissions/CreateQuizSubmissionDTOTest.php
+++ b/tests/Dto/QuizSubmissions/CreateQuizSubmissionDTOTest.php
@@ -75,7 +75,7 @@ class CreateQuizSubmissionDTOTest extends TestCase
             }
         }
         $this->assertNotNull($previewEntry);
-        $this->assertEquals('1', $previewEntry['contents']); // true converts to '1'
+        $this->assertSame('true', $previewEntry['contents']);
     }
 
     public function testApiPropertyName(): void
@@ -142,7 +142,7 @@ class CreateQuizSubmissionDTOTest extends TestCase
             $entryMap[$entry['name']] = $entry['contents'];
         }
 
-        $this->assertEquals('1', $entryMap['quiz_submission[preview]']);
+        $this->assertSame('true', $entryMap['quiz_submission[preview]']);
 
         // Test false value
         $dto = new CreateQuizSubmissionDTO([
@@ -156,6 +156,6 @@ class CreateQuizSubmissionDTOTest extends TestCase
             $entryMap[$entry['name']] = $entry['contents'];
         }
 
-        $this->assertEquals('0', $entryMap['quiz_submission[preview]']);
+        $this->assertSame('false', $entryMap['quiz_submission[preview]']);
     }
 }

--- a/tests/Dto/Quizzes/UpdateQuizDTOTest.php
+++ b/tests/Dto/Quizzes/UpdateQuizDTOTest.php
@@ -167,7 +167,7 @@ class UpdateQuizDTOTest extends TestCase
             }
         }
         $this->assertNotNull($publishedEntry);
-        $this->assertEquals('0', $publishedEntry['contents']); // false converts to '0'
+        $this->assertSame('false', $publishedEntry['contents']);
     }
 
     public function testApiPropertyName(): void
@@ -256,10 +256,10 @@ class UpdateQuizDTOTest extends TestCase
             $entryMap[$entry['name']] = $entry['contents'];
         }
 
-        $this->assertEquals('1', $entryMap['quiz[published]']);
-        $this->assertEquals('0', $entryMap['quiz[shuffle_answers]']);
-        $this->assertEquals('1', $entryMap['quiz[one_question_at_a_time]']);
-        $this->assertEquals('0', $entryMap['quiz[require_lockdown_browser]']);
+        $this->assertSame('true', $entryMap['quiz[published]']);
+        $this->assertSame('false', $entryMap['quiz[shuffle_answers]']);
+        $this->assertSame('true', $entryMap['quiz[one_question_at_a_time]']);
+        $this->assertSame('false', $entryMap['quiz[require_lockdown_browser]']);
     }
 
     public function testNumericValues(): void

--- a/tests/Dto/Sections/CreateSectionDTOTest.php
+++ b/tests/Dto/Sections/CreateSectionDTOTest.php
@@ -118,9 +118,9 @@ class CreateSectionDTOTest extends TestCase
     {
         $dto = new CreateSectionDTO(['name' => 'Valid Section']);
 
-        // Should not throw an exception
+        // The contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         $dto->validate();
-        $this->assertTrue(true);
     }
 
     public function testValidateWithEmptyName(): void

--- a/tests/Dto/Sections/CreateSectionDTOTest.php
+++ b/tests/Dto/Sections/CreateSectionDTOTest.php
@@ -169,7 +169,7 @@ class CreateSectionDTOTest extends TestCase
             $formattedArray1[$item['name']] = $item['contents'];
         }
 
-        $this->assertTrue($formattedArray1['course_section[restrict_enrollments_to_section_dates]']);
+        $this->assertSame('true', $formattedArray1['course_section[restrict_enrollments_to_section_dates]']);
 
         // Test with false
         $dto2 = new CreateSectionDTO([
@@ -185,7 +185,7 @@ class CreateSectionDTOTest extends TestCase
             $formattedArray2[$item['name']] = $item['contents'];
         }
 
-        $this->assertFalse($formattedArray2['course_section[restrict_enrollments_to_section_dates]']);
+        $this->assertSame('false', $formattedArray2['course_section[restrict_enrollments_to_section_dates]']);
 
         // Test with null (should be excluded)
         $dto3 = new CreateSectionDTO([

--- a/tests/Dto/Sections/UpdateSectionDTOTest.php
+++ b/tests/Dto/Sections/UpdateSectionDTOTest.php
@@ -82,7 +82,7 @@ class UpdateSectionDTOTest extends TestCase
 
         $expected = [
             'course_section[name]' => 'Section with Override',
-            'override_sis_stickiness' => false,
+            'override_sis_stickiness' => 'false',
         ];
 
         $this->assertEquals($expected, $formattedArray);
@@ -209,8 +209,8 @@ class UpdateSectionDTOTest extends TestCase
             $formattedArray1[$item['name']] = $item['contents'];
         }
 
-        $this->assertTrue($formattedArray1['course_section[restrict_enrollments_to_section_dates]']);
-        $this->assertTrue($formattedArray1['override_sis_stickiness']);
+        $this->assertSame('true', $formattedArray1['course_section[restrict_enrollments_to_section_dates]']);
+        $this->assertSame('true', $formattedArray1['override_sis_stickiness']);
 
         // Test with false
         $dto2 = new UpdateSectionDTO([
@@ -226,8 +226,8 @@ class UpdateSectionDTOTest extends TestCase
             $formattedArray2[$item['name']] = $item['contents'];
         }
 
-        $this->assertFalse($formattedArray2['course_section[restrict_enrollments_to_section_dates]']);
-        $this->assertFalse($formattedArray2['override_sis_stickiness']);
+        $this->assertSame('false', $formattedArray2['course_section[restrict_enrollments_to_section_dates]']);
+        $this->assertSame('false', $formattedArray2['override_sis_stickiness']);
     }
 
     public function testDefaultValues(): void
@@ -269,8 +269,8 @@ class UpdateSectionDTOTest extends TestCase
             'course_section[integration_id]' => 'INT-COMPLETE-001',
             'course_section[start_at]' => '2024-01-01T00:00:00+00:00',
             'course_section[end_at]' => '2024-12-31T23:59:59+00:00',
-            'course_section[restrict_enrollments_to_section_dates]' => true,
-            'override_sis_stickiness' => false,
+            'course_section[restrict_enrollments_to_section_dates]' => 'true',
+            'override_sis_stickiness' => 'false',
         ];
 
         $this->assertEquals($expected, $formattedArray);

--- a/tests/Dto/SharedBrandConfigs/CreateSharedBrandConfigDTOTest.php
+++ b/tests/Dto/SharedBrandConfigs/CreateSharedBrandConfigDTOTest.php
@@ -100,9 +100,9 @@ class CreateSharedBrandConfigDTOTest extends TestCase
             'brand_config_md5' => 'valid_hash',
         ]);
 
-        // Act & Assert - No exception should be thrown
+        // Act & Assert - the contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         $dto->validate();
-        $this->assertTrue(true); // Test passes if no exception
     }
 
     public function testToApiArrayReturnsCorrectFormat(): void

--- a/tests/Dto/SharedBrandConfigs/UpdateSharedBrandConfigDTOTest.php
+++ b/tests/Dto/SharedBrandConfigs/UpdateSharedBrandConfigDTOTest.php
@@ -77,9 +77,9 @@ class UpdateSharedBrandConfigDTOTest extends TestCase
             'name' => 'Valid Name',
         ]);
 
-        // Act & Assert - No exception should be thrown
+        // Act & Assert - the contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         $dto->validate();
-        $this->assertTrue(true);
     }
 
     public function testValidatePassesWithOnlyMd5(): void
@@ -89,9 +89,9 @@ class UpdateSharedBrandConfigDTOTest extends TestCase
             'brand_config_md5' => 'valid_hash',
         ]);
 
-        // Act & Assert - No exception should be thrown
+        // Act & Assert - the contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         $dto->validate();
-        $this->assertTrue(true);
     }
 
     public function testValidatePassesWithBothFields(): void
@@ -102,9 +102,9 @@ class UpdateSharedBrandConfigDTOTest extends TestCase
             'brand_config_md5' => 'valid_hash',
         ]);
 
-        // Act & Assert - No exception should be thrown
+        // Act & Assert - the contract is simply that no exception is thrown
+        $this->expectNotToPerformAssertions();
         $dto->validate();
-        $this->assertTrue(true);
     }
 
     public function testToApiArrayWithOnlyName(): void

--- a/tests/Dto/SubmissionComments/CreateSubmissionCommentDTOTest.php
+++ b/tests/Dto/SubmissionComments/CreateSubmissionCommentDTOTest.php
@@ -112,7 +112,7 @@ class CreateSubmissionCommentDTOTest extends TestCase
 
         $this->assertIsArray($apiArray);
         $this->assertContains(['name' => 'comment[text_comment]', 'contents' => 'Good teamwork everyone'], $apiArray);
-        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => 'true'], $apiArray);
     }
 
     public function testToApiArrayForMediaComment(): void
@@ -213,7 +213,7 @@ class CreateSubmissionCommentDTOTest extends TestCase
         $apiArray = $dto->toApiArray();
 
         $this->assertContains(['name' => 'comment[text_comment]', 'contents' => 'Boolean test'], $apiArray);
-        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => false], $apiArray);
+        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => 'false'], $apiArray);
     }
 
     public function testMediaCommentTypes(): void
@@ -279,7 +279,7 @@ class CreateSubmissionCommentDTOTest extends TestCase
 
         // Verify all components are present
         $this->assertContains(['name' => 'comment[text_comment]', 'contents' => 'See attached rubric and listen to audio feedback'], $apiArray);
-        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'comment[group_comment]', 'contents' => 'true'], $apiArray);
         $this->assertContains(['name' => 'comment[media_comment_id]', 'contents' => 'detailed_feedback_123'], $apiArray);
         $this->assertContains(['name' => 'comment[media_comment_type]', 'contents' => 'audio'], $apiArray);
         $this->assertContains(['name' => 'comment[file_ids][]', 'contents' => 111], $apiArray);

--- a/tests/Dto/Submissions/UpdateSubmissionDTOTest.php
+++ b/tests/Dto/Submissions/UpdateSubmissionDTOTest.php
@@ -166,7 +166,7 @@ class UpdateSubmissionDTOTest extends TestCase
         $apiArray = $dto->toApiArray();
 
         $this->assertIsArray($apiArray);
-        $this->assertContains(['name' => 'submission[excuse]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'submission[excuse]', 'contents' => 'true'], $apiArray);
         $this->assertContains(['name' => 'submission[comment]', 'contents' => 'Excused due to illness'], $apiArray);
     }
 
@@ -227,7 +227,7 @@ class UpdateSubmissionDTOTest extends TestCase
 
         $this->assertIsArray($apiArray);
         $this->assertContains(['name' => 'submission[posted_grade]', 'contents' => '80'], $apiArray);
-        $this->assertContains(['name' => 'submission[late]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'submission[late]', 'contents' => 'true'], $apiArray);
         $this->assertContains(['name' => 'submission[points_deducted]', 'contents' => 10.0], $apiArray);
         $this->assertContains(['name' => 'submission[comment]', 'contents' => 'Grade reduced due to late submission'], $apiArray);
     }
@@ -304,9 +304,9 @@ class UpdateSubmissionDTOTest extends TestCase
 
         $apiArray = $dto->toApiArray();
 
-        $this->assertContains(['name' => 'submission[excuse]', 'contents' => true], $apiArray);
-        $this->assertContains(['name' => 'submission[group_comment]', 'contents' => false], $apiArray);
-        $this->assertContains(['name' => 'submission[late]', 'contents' => true], $apiArray);
+        $this->assertContains(['name' => 'submission[excuse]', 'contents' => 'true'], $apiArray);
+        $this->assertContains(['name' => 'submission[group_comment]', 'contents' => 'false'], $apiArray);
+        $this->assertContains(['name' => 'submission[late]', 'contents' => 'true'], $apiArray);
     }
 
     public function testNumericValuesInApiArray(): void

--- a/tests/Dto/Tabs/UpdateTabDTOTest.php
+++ b/tests/Dto/Tabs/UpdateTabDTOTest.php
@@ -85,7 +85,7 @@ class UpdateTabDTOTest extends TestCase
         // The AbstractBaseDto creates multipart form data format
         $expected = [
             ['name' => 'tab[position]', 'contents' => 3],
-            ['name' => 'tab[hidden]', 'contents' => false],
+            ['name' => 'tab[hidden]', 'contents' => 'false'],
         ];
 
         $this->assertEquals($expected, $result);

--- a/tests/Exceptions/CanvasApiExceptionTest.php
+++ b/tests/Exceptions/CanvasApiExceptionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Exceptions;
+
+use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Exceptions\MissingOAuthTokenException;
+use CanvasLMS\Exceptions\OAuthRefreshFailedException;
+use CanvasLMS\Exceptions\OAuthTokenExpiredException;
+use PHPUnit\Framework\TestCase;
+
+class CanvasApiExceptionTest extends TestCase
+{
+    public function testMessageCodeAndErrorsAreExposed(): void
+    {
+        $errors = [
+            ['message' => 'Course name is required', 'field' => 'name'],
+            ['message' => 'Course code is required', 'field' => 'course_code'],
+        ];
+
+        $exception = new CanvasApiException('Validation failed', 422, $errors);
+
+        $this->assertSame('Validation failed', $exception->getMessage());
+        $this->assertSame(422, $exception->getCode());
+        $this->assertSame($errors, $exception->getErrors());
+    }
+
+    public function testDefaultsToEmptyMessageCodeAndErrors(): void
+    {
+        $exception = new CanvasApiException();
+
+        $this->assertSame('', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame([], $exception->getErrors());
+    }
+
+    public function testIsCatchableAsPlainException(): void
+    {
+        $this->assertInstanceOf(\Exception::class, new CanvasApiException('boom'));
+    }
+
+    public function testOAuthExceptionsExtendCanvasApiException(): void
+    {
+        // Catching CanvasApiException must cover the OAuth failure family
+        $this->assertInstanceOf(CanvasApiException::class, new OAuthRefreshFailedException());
+        $this->assertInstanceOf(CanvasApiException::class, new OAuthTokenExpiredException());
+        $this->assertInstanceOf(CanvasApiException::class, new MissingOAuthTokenException());
+    }
+
+    public function testOAuthExceptionsProvideDefaultMessages(): void
+    {
+        $this->assertSame(
+            'Failed to refresh OAuth token',
+            (new OAuthRefreshFailedException())->getMessage()
+        );
+        $this->assertSame(
+            'OAuth token has expired and could not be refreshed. Please re-authenticate.',
+            (new OAuthTokenExpiredException())->getMessage()
+        );
+        $this->assertStringContainsString(
+            'OAuth token not configured',
+            (new MissingOAuthTokenException())->getMessage()
+        );
+    }
+
+    public function testOAuthExceptionsAcceptCustomMessages(): void
+    {
+        $exception = new OAuthRefreshFailedException('Token refresh failed: invalid_grant');
+
+        $this->assertSame('Token refresh failed: invalid_grant', $exception->getMessage());
+    }
+}

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Http;
 
 use CanvasLMS\Config;
+use CanvasLMS\Exceptions\CanvasApiException;
 use CanvasLMS\Http\HttpClient;
 use CanvasLMS\Pagination\PaginatedResponse;
 use GuzzleHttp\Client;
@@ -518,5 +519,74 @@ class HttpClientTest extends TestCase
 
         // Reset timeout to default
         Config::setTimeout(30);
+    }
+
+    /**
+     * @dataProvider httpErrorStatusProvider
+     */
+    public function testHttpErrorsAreWrappedInCanvasApiException(int $status, string $body): void
+    {
+        $mock = new MockHandler([
+            new Response($status, [], $body),
+        ]);
+
+        $guzzleClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        try {
+            $httpClient->get('/endpoint');
+            $this->fail("Expected CanvasApiException for HTTP {$status}");
+        } catch (CanvasApiException $e) {
+            $this->assertSame($status, $e->getCode());
+        }
+    }
+
+    /**
+     * @return array<string, array{int, string}>
+     */
+    public static function httpErrorStatusProvider(): array
+    {
+        return [
+            '401 unauthorized' => [401, json_encode(['errors' => [['message' => 'Invalid access token']]])],
+            '403 forbidden' => [403, json_encode(['errors' => [['message' => 'Insufficient permission']]])],
+            '404 not found' => [404, json_encode(['errors' => [['message' => 'Not found']]])],
+            '422 unprocessable' => [422, json_encode(['errors' => ['name' => [['message' => 'Required']]]])],
+            '500 server error' => [500, ''],
+            '503 unavailable' => [503, ''],
+        ];
+    }
+
+    public function testCanvasErrorsArePreservedInException(): void
+    {
+        $errors = [['message' => 'Course name is required', 'field' => 'name']];
+        $mock = new MockHandler([
+            new Response(422, [], json_encode(['errors' => $errors])),
+        ]);
+
+        $guzzleClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        try {
+            $httpClient->post('/endpoint', []);
+            $this->fail('Expected CanvasApiException');
+        } catch (CanvasApiException $e) {
+            $this->assertSame($errors, $e->getErrors());
+        }
+    }
+
+    public function testConnectionErrorsAreWrappedInCanvasApiException(): void
+    {
+        $mock = new MockHandler([
+            new \GuzzleHttp\Exception\ConnectException(
+                'Connection refused',
+                new \GuzzleHttp\Psr7\Request('GET', '/endpoint')
+            ),
+        ]);
+
+        $guzzleClient = new Client(['handler' => HandlerStack::create($mock)]);
+        $httpClient = new HttpClient($guzzleClient, $this->loggerMock);
+
+        $this->expectException(CanvasApiException::class);
+        $httpClient->get('/endpoint');
     }
 }

--- a/tests/Http/Middleware/CacheMiddlewareTest.php
+++ b/tests/Http/Middleware/CacheMiddlewareTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Tests\Http\Middleware;
+
+use CanvasLMS\Cache\Adapters\InMemoryAdapter;
+use CanvasLMS\Cache\ResponseSerializer;
+use CanvasLMS\Cache\Strategies\CacheKeyGenerator;
+use CanvasLMS\Cache\Strategies\TtlStrategy;
+use CanvasLMS\Http\Middleware\CacheMiddleware;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class CacheMiddlewareTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a Guzzle Client wired with the given middleware and mock responses.
+     *
+     * @param CacheMiddleware   $middleware
+     * @param Response[]        $responses
+     *
+     * @return array{Client, MockHandler}
+     */
+    private function buildClient(CacheMiddleware $middleware, array $responses): array
+    {
+        $mock = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push($middleware(), 'cache');
+
+        $client = new Client([
+            'handler' => $stack,
+            'http_errors' => false,
+            'base_uri' => 'https://canvas.example.com',
+        ]);
+
+        return [$client, $mock];
+    }
+
+    /**
+     * Build a CacheMiddleware pre-configured with shared dependencies so tests
+     * can also inspect the adapter directly.
+     *
+     * @param InMemoryAdapter $adapter
+     * @param array<string, mixed> $extraConfig
+     *
+     * @return CacheMiddleware
+     */
+    private function buildMiddleware(InMemoryAdapter $adapter, array $extraConfig = []): CacheMiddleware
+    {
+        $ttlStrategy = new TtlStrategy(300);
+
+        return new CacheMiddleware(array_merge([
+            'enabled' => true,
+            'adapter' => $adapter,
+            'ttl_strategy' => $ttlStrategy,
+            'serializer' => new ResponseSerializer(),
+            'key_generator' => new CacheKeyGenerator('test'),
+        ], $extraConfig));
+    }
+
+    // -----------------------------------------------------------------------
+    // (a) Second identical GET returns cached response — handler called once
+    // -----------------------------------------------------------------------
+
+    public function testSecondIdenticalGetReturnsCachedResponseWithoutHittingHandler(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter);
+
+        // Queue only ONE response; if the second call hits the handler it would throw.
+        [$client, $mock] = $this->buildClient($middleware, [
+            new Response(200, [], 'courses-payload'),
+        ]);
+
+        $first = $client->get('/api/v1/courses');
+        $this->assertSame(200, $first->getStatusCode());
+        $this->assertSame('courses-payload', (string) $first->getBody());
+
+        // Second call — must be served from cache (no additional handler invocation).
+        $second = $client->get('/api/v1/courses');
+        $this->assertSame(200, $second->getStatusCode());
+        $this->assertSame('courses-payload', (string) $second->getBody());
+
+        // MockHandler queue is now empty, confirming the second call never reached it.
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testCachedResponseBodyMatchesOriginal(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter);
+        $body = '{"id":1,"name":"Bio 101"}';
+
+        [$client] = $this->buildClient($middleware, [new Response(200, [], $body)]);
+
+        $client->get('/api/v1/courses/1');
+        $cached = $client->get('/api/v1/courses/1');
+
+        $this->assertSame($body, (string) $cached->getBody());
+    }
+
+    // -----------------------------------------------------------------------
+    // (b) Disabled middleware passes through without caching
+    // -----------------------------------------------------------------------
+
+    public function testDisabledMiddlewarePassesThroughBothRequests(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = new CacheMiddleware([
+            'enabled' => false,  // explicitly disabled (default)
+            'adapter' => $adapter,
+            'ttl_strategy' => new TtlStrategy(300),
+            'serializer' => new ResponseSerializer(),
+            'key_generator' => new CacheKeyGenerator('test'),
+        ]);
+
+        // Two responses queued — both must be consumed because no caching occurs.
+        [$client, $mock] = $this->buildClient($middleware, [
+            new Response(200, [], 'first'),
+            new Response(200, [], 'second'),
+        ]);
+
+        $r1 = $client->get('/api/v1/courses');
+        $r2 = $client->get('/api/v1/courses');
+
+        $this->assertSame('first', (string) $r1->getBody());
+        $this->assertSame('second', (string) $r2->getBody());
+        $this->assertSame(0, $mock->count(), 'Both mock responses should have been consumed');
+    }
+
+    public function testDefaultConfigurationIsDisabled(): void
+    {
+        // CacheMiddleware is opt-in — no config → disabled.
+        $middleware = new CacheMiddleware();
+        $config = new \ReflectionClass($middleware);
+        $prop = $config->getProperty('config');
+        $prop->setAccessible(true);
+        $cfg = $prop->getValue($middleware);
+
+        $this->assertFalse($cfg['enabled']);
+    }
+
+    // -----------------------------------------------------------------------
+    // (c) POST invalidates related GET cache entry
+    // -----------------------------------------------------------------------
+
+    public function testPostRequestInvalidatesRelatedGetCacheEntry(): void
+    {
+        $adapter = new InMemoryAdapter();
+
+        // Use the same CacheKeyGenerator the middleware uses so we can plant a
+        // realistic cache key and verify it gets deleted on mutation.
+        // invalidateOnMutation requires a path matching /api/v1/{resource}/{id}
+        // to extract the resource type. Using courses/123 satisfies this.
+        $keyGenerator = new CacheKeyGenerator('test');
+        $middleware = $this->buildMiddleware($adapter, ['key_generator' => $keyGenerator]);
+
+        $serializer = new ResponseSerializer();
+
+        // Plant GET /api/v1/courses list entry — matches pattern *:GET:/api/v1/courses*
+        $listRequest = new Request('GET', 'https://canvas.example.com/api/v1/courses');
+        $listKey = $keyGenerator->generate($listRequest);
+        $adapter->set($listKey, $serializer->serialize(new Response(200, [], 'courses-list')));
+
+        // Plant GET /api/v1/courses/123 entry — also matched by *:GET:/api/v1/courses*
+        $itemRequest = new Request('GET', 'https://canvas.example.com/api/v1/courses/123');
+        $itemKey = $keyGenerator->generate($itemRequest);
+        $adapter->set($itemKey, $serializer->serialize(new Response(200, [], 'course-123')));
+
+        $this->assertNotNull($adapter->get($listKey), 'Pre-condition: list key must exist');
+        $this->assertNotNull($adapter->get($itemKey), 'Pre-condition: item key must exist');
+
+        // POST to /api/v1/courses/123 — triggers invalidateOnMutation with resource=courses, id=123
+        [$client] = $this->buildClient($middleware, [
+            new Response(201, [], 'created'),
+        ]);
+
+        $postResponse = $client->post('/api/v1/courses/123');
+        $this->assertSame(201, $postResponse->getStatusCode());
+
+        // Both GET entries should be removed via deleteByPattern('*:GET:/api/v1/courses*')
+        $this->assertNull($adapter->get($listKey), 'GET list entry must be invalidated after POST');
+        $this->assertNull($adapter->get($itemKey), 'GET item entry must be invalidated after POST');
+    }
+
+    // -----------------------------------------------------------------------
+    // (d) Non-2xx responses are not cached when cache_success_only=true
+    // -----------------------------------------------------------------------
+
+    public function testNon2xxResponseIsNotCachedWhenCacheSuccessOnlyEnabled(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter, ['cache_success_only' => true]);
+
+        // First call returns 500 — should NOT be cached.
+        // Second call returns 200 — the mock must be consumed twice.
+        [$client, $mock] = $this->buildClient($middleware, [
+            new Response(500, [], 'error'),
+            new Response(200, [], 'ok'),
+        ]);
+
+        $first = $client->get('/api/v1/courses');
+        $this->assertSame(500, $first->getStatusCode());
+
+        $second = $client->get('/api/v1/courses');
+        $this->assertSame(200, $second->getStatusCode());
+
+        // Both responses consumed — 500 was not cached and didn't short-circuit the second call.
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function testSuccessful2xxResponseIsCached(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter, ['cache_success_only' => true]);
+
+        [$client, $mock] = $this->buildClient($middleware, [
+            new Response(200, [], 'success'),
+        ]);
+
+        $client->get('/api/v1/courses');
+        $second = $client->get('/api/v1/courses');
+
+        $this->assertSame(200, $second->getStatusCode());
+        // Only 1 mock response queued and not thrown — second came from cache.
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function test404ResponseIsNotCachedWhenCacheSuccessOnlyEnabled(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter, ['cache_success_only' => true]);
+
+        [$client, $mock] = $this->buildClient($middleware, [
+            new Response(404, [], 'not found'),
+            new Response(404, [], 'not found again'),
+        ]);
+
+        $first = $client->get('/api/v1/courses/999');
+        $second = $client->get('/api/v1/courses/999');
+
+        $this->assertSame(404, $first->getStatusCode());
+        $this->assertSame(404, $second->getStatusCode());
+        $this->assertSame(0, $mock->count(), '404 must not be cached; both calls hit the handler');
+    }
+
+    // -----------------------------------------------------------------------
+    // Adapter accessors
+    // -----------------------------------------------------------------------
+
+    public function testGetAdapterReturnsConfiguredAdapter(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter);
+
+        $this->assertSame($adapter, $middleware->getAdapter());
+    }
+
+    public function testSetAdapterReplacesAdapter(): void
+    {
+        $original = new InMemoryAdapter();
+        $replacement = new InMemoryAdapter();
+
+        $middleware = $this->buildMiddleware($original);
+        $middleware->setAdapter($replacement);
+
+        $this->assertSame($replacement, $middleware->getAdapter());
+    }
+
+    public function testGetStatisticsReturnsAdapterStats(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter);
+
+        $stats = $middleware->getStatistics();
+
+        $this->assertArrayHasKey('hits', $stats);
+        $this->assertArrayHasKey('misses', $stats);
+        $this->assertArrayHasKey('entries', $stats);
+        $this->assertArrayHasKey('size', $stats);
+    }
+
+    public function testClearCacheRemovesAllEntries(): void
+    {
+        $adapter = new InMemoryAdapter();
+        $middleware = $this->buildMiddleware($adapter);
+
+        [$client] = $this->buildClient($middleware, [
+            new Response(200, [], 'data'),
+        ]);
+
+        $client->get('/api/v1/courses');
+
+        $this->assertSame(1, $middleware->getStatistics()['entries']);
+
+        $middleware->clearCache();
+
+        $this->assertSame(0, $middleware->getStatistics()['entries']);
+    }
+}

--- a/tests/Http/Middleware/OAuth2RefreshMiddlewareTest.php
+++ b/tests/Http/Middleware/OAuth2RefreshMiddlewareTest.php
@@ -123,30 +123,99 @@ class OAuth2RefreshMiddlewareTest extends TestCase
     }
 
     /**
-     * Test retry on 401 response - simplified version
-     * Note: Full integration testing of Guzzle middleware promises is complex
-     * This test validates the middleware configuration
+     * Test the full 401 -> refresh -> retry flow
      */
     public function testRetryOn401Response(): void
     {
         Config::setOAuthToken('expired_token');
         Config::setOAuthRefreshToken('refresh_token');
-        Config::setOAuthExpiresAt(time() + 3600); // Token appears valid
+        Config::setOAuthExpiresAt(time() + 3600); // Token appears valid, server rejects it
 
-        // Configure middleware for retry
-        $this->middleware->configure(['retry_on_401' => true]);
+        // OAuth token endpoint returns a fresh token during the retry
+        $mockOAuthClient = $this->createMock(\CanvasLMS\Interfaces\HttpClientInterface::class);
+        $mockOAuthClient->expects($this->once())
+            ->method('request')
+            ->with(
+                $this->equalTo('POST'),
+                $this->stringContains('/login/oauth2/token'),
+                $this->arrayHasKey('form_params')
+            )
+            ->willReturn(new Response(200, [], json_encode([
+                'access_token' => 'refreshed_token',
+                'expires_in' => 3600,
+            ])));
+        \CanvasLMS\Auth\OAuth::setHttpClient($mockOAuthClient);
 
-        // Verify configuration was applied
-        $reflection = new \ReflectionClass($this->middleware);
-        $configProperty = $reflection->getProperty('config');
-        $configProperty->setAccessible(true);
-        $config = $configProperty->getValue($this->middleware);
+        // First call 401s, the retried call succeeds
+        $this->mockHandler->append(
+            new RequestException(
+                'Unauthorized',
+                new Request('GET', '/api/v1/courses'),
+                new Response(401, [], json_encode(['errors' => [['message' => 'Invalid access token']]]))
+            ),
+            new Response(200, [], json_encode(['courses' => []]))
+        );
 
-        $this->assertTrue($config['retry_on_401']);
+        $client = new Client([
+            'handler' => $this->handlerStack,
+            'base_uri' => 'https://canvas.test.com',
+        ]);
 
-        // The actual retry logic is tested in integration tests
-        // where the full HTTP client stack is available
-        $this->assertTrue(true);
+        $response = $client->get('/api/v1/courses', [
+            'headers' => ['Authorization' => 'Bearer expired_token'],
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('refreshed_token', Config::getOAuthToken());
+
+        // Both queued responses were consumed (the request really was retried)
+        $this->assertEquals(0, $this->mockHandler->count());
+
+        // The retried request carried the refreshed token
+        $lastRequest = $this->mockHandler->getLastRequest();
+        $this->assertEquals('Bearer refreshed_token', $lastRequest->getHeaderLine('Authorization'));
+    }
+
+    /**
+     * Test that a failed refresh after a 401 rethrows the original error
+     */
+    public function testRetryOn401RethrowsWhenRefreshFails(): void
+    {
+        Config::setOAuthToken('expired_token');
+        Config::setOAuthRefreshToken('bad_refresh_token');
+        Config::setOAuthExpiresAt(time() + 3600);
+
+        // Refresh attempt fails at the token endpoint
+        $mockOAuthClient = $this->createMock(\CanvasLMS\Interfaces\HttpClientInterface::class);
+        $mockOAuthClient->expects($this->once())
+            ->method('request')
+            ->willReturn(new Response(401, [], json_encode([
+                'error' => 'invalid_grant',
+                'error_description' => 'refresh token revoked',
+            ])));
+        \CanvasLMS\Auth\OAuth::setHttpClient($mockOAuthClient);
+
+        $this->mockHandler->append(
+            new RequestException(
+                'Unauthorized',
+                new Request('GET', '/api/v1/courses'),
+                new Response(401)
+            )
+        );
+
+        $client = new Client([
+            'handler' => $this->handlerStack,
+            'base_uri' => 'https://canvas.test.com',
+        ]);
+
+        try {
+            $client->get('/api/v1/courses', [
+                'headers' => ['Authorization' => 'Bearer expired_token'],
+            ]);
+            $this->fail('Expected the original 401 RequestException to be rethrown');
+        } catch (RequestException $e) {
+            $this->assertEquals(401, $e->getResponse()->getStatusCode());
+        }
     }
 
     /**

--- a/tests/Pagination/EdgeCaseTest.php
+++ b/tests/Pagination/EdgeCaseTest.php
@@ -194,10 +194,11 @@ class EdgeCaseTest extends TestCase
         // Execute - all() should handle timeout and return partial results
         $modules = Course::all();
 
-        // With timeout, we should get at least the first page
-        // The actual behavior depends on error handling implementation
-        // For now, we expect it to fail gracefully and return what it has
-        $this->assertNotNull($modules);
+        // The first page was fetched successfully before the timeout, so
+        // exactly its two items must be returned
+        $this->assertCount(2, $modules);
+        $this->assertEquals('Module 1', $modules[0]->name);
+        $this->assertEquals('Module 2', $modules[1]->name);
     }
 
     /**

--- a/tests/Pagination/LinkHeaderParserTest.php
+++ b/tests/Pagination/LinkHeaderParserTest.php
@@ -93,6 +93,33 @@ class LinkHeaderParserTest extends TestCase
     }
 
     /**
+     * Test parsing Link header with commas inside URLs
+     *
+     * Canvas array parameters (e.g. context_codes) can put commas in
+     * pagination URLs; the parser must only split entries on commas
+     * outside the angle brackets.
+     */
+    public function testParseUrlContainingCommas(): void
+    {
+        $linkHeader = '<https://canvas.example.com/api/v1/calendar_events?' .
+                      'context_codes[]=course_1,account_2&page=2>; rel="next", ' .
+                      '<https://canvas.example.com/api/v1/calendar_events?' .
+                      'context_codes[]=course_1,account_2&page=1>; rel="current"';
+
+        $result = $this->parser->parse($linkHeader);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals(
+            'https://canvas.example.com/api/v1/calendar_events?context_codes[]=course_1,account_2&page=2',
+            $result['next']
+        );
+        $this->assertEquals(
+            'https://canvas.example.com/api/v1/calendar_events?context_codes[]=course_1,account_2&page=1',
+            $result['current']
+        );
+    }
+
+    /**
      * Test parsing Link header with spaces and different formatting
      */
     public function testParseWithVariousSpacing(): void

--- a/tests/Support/ApiTestCase.php
+++ b/tests/Support/ApiTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use CanvasLMS\Config;
+use CanvasLMS\Interfaces\HttpClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base test case for API resource tests.
+ *
+ * Provides the mock HTTP client + Config setup that resource tests
+ * otherwise duplicate, and guarantees the shared client registry is
+ * reset in teardown so mocks never leak between tests.
+ */
+abstract class ApiTestCase extends TestCase
+{
+    protected HttpClientInterface&MockObject $httpClientMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->httpClientMock = $this->createMock(HttpClientInterface::class);
+        AbstractBaseApi::setApiClient($this->httpClientMock);
+
+        Config::setBaseUrl('https://canvas.example.com/');
+        Config::setApiKey('test-api-key');
+        Config::setAccountId(1);
+    }
+
+    protected function tearDown(): void
+    {
+        AbstractBaseApi::resetApiClients();
+        parent::tearDown();
+    }
+}

--- a/tests/Support/ResetStaticStateExtension.php
+++ b/tests/Support/ResetStaticStateExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+/**
+ * Registers the subscriber that clears SDK static state between tests.
+ *
+ * API classes share a process-global HTTP client registry; without this,
+ * a mock set in one test leaks into every later test in the run, making
+ * failures depend on test ordering.
+ */
+final class ResetStaticStateExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscriber(new ResetStaticStateSubscriber());
+    }
+}

--- a/tests/Support/ResetStaticStateSubscriber.php
+++ b/tests/Support/ResetStaticStateSubscriber.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use CanvasLMS\Api\AbstractBaseApi;
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+
+/**
+ * Clears the shared HTTP client registry after every test.
+ */
+final class ResetStaticStateSubscriber implements FinishedSubscriber
+{
+    public function notify(Finished $event): void
+    {
+        AbstractBaseApi::resetApiClients();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the full remediation plan from the deep code review: 15 commits covering correctness fixes, security hardening, performance, API consistency, CI/CD, and test coverage. Prepares the v1.7.0 release.

### Highlights
- **Correctness**: filesystem cache invalidation repaired (deleteByPattern never matched hashed filenames), boolean multipart encoding (`false` no longer serializes as an empty string), OAuth revoke/session token header overwrite, RFC 5988 comma-safe Link parsing, populate() type coercion
- **Security**: hardened `unserialize`, owner-only cache permissions, encoded path parameters, context-type allowlists, Guzzle floor ^7.4.5, SHA-pinned CI actions, author-association gates on Claude workflows
- **Performance**: per-class reflection caches for hydration, new `stream()` generator for memory-safe pagination, metadata-based enrollment counts, single-merge page accumulation
- **API consistency**: `find(): static` everywhere, nullable model properties (no more uninitialized-property fatals on partial responses), `DeveloperKey::save()` zero-arg contract, full-pagination find() scans
- **Architecture**: ApiClientRegistry (per-class overrides + reset), FeatureFlag/Analytics/BrandConfig/SharedBrandConfig no longer bypass middleware, cache middleware reachable via `Config::setMiddleware(['cache' => ...])`
- **Testing**: +93 tests; first coverage for FileSystemAdapter/ResponseSerializer/CacheMiddleware, real OAuth 401-refresh-retry tests, HttpClient error paths, per-test static state reset extension
- **CI/CD**: PHP 8.4 matrix, platform-pin fix, composer audit, dependabot, release version gate, codecov v5

### Release prep
- `Version.php` → 1.7.0, CHANGELOG `[Unreleased]` → `[1.7.0] - 2026-06-11`

Full details in [CHANGELOG.md](https://github.com/jjuanrivvera/canvas-lms-kit/blob/feature/deep-review-fixes/CHANGELOG.md).