### PR TITLE
feat: expose file uploader via include[]=user on course files (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `File::getUser()`/`setUser()` expose the uploader of a file as a `CanvasLMS\Objects\UserDisplay` (id, `displayName`, `avatarImageUrl`, `htmlUrl`, `pronouns`, `anonymousId`) when the listing request includes `include[]=user`, e.g. `$course->files(['include' => ['user']])`; useful for tracking down who uploaded a given file (copyright/ownership follow-up). Returns `null` when the include was not requested
+- `File::fetchByContext()`, `fetchCourseFiles()`, `get()`, `paginate()`, and `all()` now normalize a caller-friendly `['include' => [...]]` array parameter into Canvas's `include[]=...` query form, so both `['include' => ['user']]` and the SDK-wide `['include[]' => ['user']]` convention work
+
 ## [1.7.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -665,6 +665,28 @@ $file = File::upload([
 ]);
 ```
 
+#### Finding Who Uploaded a File
+
+Pass Canvas's `include[]=user` option when listing a course's files to get the uploader
+alongside each file - handy for tracking down who to contact about a given file:
+
+```php
+use CanvasLMS\Api\Courses\Course;
+
+$course = Course::find(123);
+
+// 'include' arrays are normalized to Canvas's include[]=user query form automatically
+$files = $course->files(['include' => ['user']]);
+
+foreach ($files as $file) {
+    $uploader = $file->getUser(); // CanvasLMS\Objects\UserDisplay|null
+
+    if ($uploader !== null) {
+        echo "{$file->getDisplayName()} uploaded by {$uploader->displayName} ({$uploader->htmlUrl})\n";
+    }
+}
+```
+
 ### Feature Flags
 
 ```php

--- a/src/Api/Courses/Course.php
+++ b/src/Api/Courses/Course.php
@@ -3070,7 +3070,21 @@ class Course extends AbstractBaseApi
     /**
      * Get files for this course
      *
-     * @param array<string, mixed> $params Query parameters
+     * @example
+     * ```php
+     * // Find who uploaded each file (e.g. for a copyright takedown request)
+     * $files = $course->files(['include' => ['user']]);
+     * foreach ($files as $file) {
+     *     $uploader = $file->getUser();
+     *     if ($uploader !== null) {
+     *         echo "{$file->getDisplayName()} uploaded by {$uploader->displayName}\n";
+     *     }
+     * }
+     * ```
+     *
+     * @param array<string, mixed> $params Query parameters. Supports Canvas's `include[]`
+     *                                     options - e.g. `['include' => ['user']]` embeds
+     *                                     the uploader on each file (see `File::getUser()`)
      *
      * @throws CanvasApiException
      *

--- a/src/Api/Files/File.php
+++ b/src/Api/Files/File.php
@@ -8,6 +8,7 @@ use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Config;
 use CanvasLMS\Dto\Files\UploadFileDTO;
 use CanvasLMS\Exceptions\CanvasApiException;
+use CanvasLMS\Objects\UserDisplay;
 use CanvasLMS\Pagination\PaginationResult;
 use Exception;
 
@@ -54,9 +55,15 @@ use Exception;
  *
  * // Fetch all files from all pages
  * $allFiles = File::all(['per_page' => 50]);
+ *
+ * // Fetch course files together with the uploader (Canvas include[]=user)
+ * $files = File::fetchCourseFiles(456, ['include' => ['user']]);
+ * $uploader = $files[0]->getUser(); // UserDisplay|null
  * ```
  *
  * @package CanvasLMS\Api\Files
+ *
+ * @phpstan-consistent-constructor
  */
 class File extends AbstractBaseApi
 {
@@ -187,6 +194,14 @@ class File extends AbstractBaseApi
     public ?string $thumbnailUrl = null;
 
     /**
+     * The user who uploaded the file. Only present when the listing request includes
+     * `include[]=user` (e.g. `$course->files(['include' => ['user']])`).
+     *
+     * @var UserDisplay|null
+     */
+    public ?UserDisplay $user = null;
+
+    /**
      * Context type where the file belongs
      *
      * @var string|null
@@ -242,6 +257,28 @@ class File extends AbstractBaseApi
     public function setContextId(?int $contextId): void
     {
         $this->contextId = $contextId;
+    }
+
+    /**
+     * Constructor override to hydrate the nested `user` object (present only when the
+     * response was requested with `include[]=user`).
+     *
+     * @param mixed[] $data
+     */
+    public function __construct(array $data)
+    {
+        $userData = null;
+
+        if (isset($data['user']) && is_array($data['user'])) {
+            $userData = $data['user'];
+            unset($data['user']);
+        }
+
+        parent::__construct($data);
+
+        if ($userData !== null) {
+            $this->user = new UserDisplay($userData);
+        }
     }
 
     /**
@@ -501,6 +538,36 @@ class File extends AbstractBaseApi
     }
 
     /**
+     * Normalize a caller-friendly `include` array parameter into Canvas's bracketed
+     * `include[]` query form.
+     *
+     * Canvas expects repeated `include[]=value` query parameters for multi-value
+     * includes (e.g. `include[]=user`, `include[]=usage_rights`). Guzzle's query
+     * builder does not append the brackets automatically for a plain array value
+     * (it repeats the given key verbatim), so a friendlier `['include' => ['user']]`
+     * has to be rewritten to `['include[]' => ['user']]` before it reaches the HTTP
+     * client. The `include[]` key form (used elsewhere in this SDK, e.g.
+     * `Course::enrollments()`) is passed through untouched.
+     *
+     * @param array<string, mixed> $params Query parameters
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeIncludeParam(array $params): array
+    {
+        if (isset($params['include']) && is_array($params['include'])) {
+            $existing = isset($params['include[]']) && is_array($params['include[]'])
+                ? $params['include[]']
+                : [];
+
+            $params['include[]'] = array_merge($existing, $params['include']);
+            unset($params['include']);
+        }
+
+        return $params;
+    }
+
+    /**
      * Get first page of files from current user's personal files.
      * Overrides base to set context information.
      *
@@ -510,7 +577,7 @@ class File extends AbstractBaseApi
      */
     public static function get(array $params = []): array
     {
-        $files = parent::get($params);
+        $files = parent::get(self::normalizeIncludeParam($params));
 
         // Set context information on each file
         foreach ($files as $file) {
@@ -531,7 +598,7 @@ class File extends AbstractBaseApi
      */
     public static function paginate(array $params = []): PaginationResult
     {
-        $paginatedResponse = parent::getPaginatedResponse(self::getEndpoint(), $params);
+        $paginatedResponse = parent::getPaginatedResponse(self::getEndpoint(), self::normalizeIncludeParam($params));
 
         // Convert data to models with context information
         $data = [];
@@ -555,7 +622,7 @@ class File extends AbstractBaseApi
      */
     public static function all(array $params = []): array
     {
-        $files = parent::all($params);
+        $files = parent::all(self::normalizeIncludeParam($params));
 
         // Set context information on each file
         foreach ($files as $file) {
@@ -571,7 +638,9 @@ class File extends AbstractBaseApi
      *
      * @param string $contextType Context type ('courses', 'groups', 'users', 'folders')
      * @param int $contextId Context ID (course_id, group_id, user_id, or folder_id)
-     * @param array<string, mixed> $params Query parameters
+     * @param array<string, mixed> $params Query parameters. Supports Canvas's `include[]`
+     *                                     options (e.g. `['include' => ['user']]` to embed
+     *                                     the uploader, accessible via `File::getUser()`)
      *
      * @throws CanvasApiException
      *
@@ -580,7 +649,7 @@ class File extends AbstractBaseApi
     public static function fetchByContext(string $contextType, int $contextId, array $params = []): array
     {
         $endpoint = sprintf('%s/%d/files', $contextType, $contextId);
-        $paginatedResponse = self::getPaginatedResponse($endpoint, $params);
+        $paginatedResponse = self::getPaginatedResponse($endpoint, self::normalizeIncludeParam($params));
 
         $allData = [];
         do {
@@ -606,8 +675,21 @@ class File extends AbstractBaseApi
     /**
      * Fetch files for a course
      *
+     * @example
+     * ```php
+     * // Get uploader info alongside each file (copyright/ownership lookups)
+     * $files = File::fetchCourseFiles(456, ['include' => ['user']]);
+     * foreach ($files as $file) {
+     *     $uploader = $file->getUser();
+     *     if ($uploader !== null) {
+     *         echo "{$file->getDisplayName()} uploaded by {$uploader->displayName}\n";
+     *     }
+     * }
+     * ```
+     *
      * @param int $courseId
-     * @param mixed[] $params
+     * @param mixed[] $params Query parameters. Supports `['include' => ['user']]` to embed
+     *                        the uploader (accessible via `File::getUser()`)
      *
      * @throws CanvasApiException
      *
@@ -917,6 +999,29 @@ class File extends AbstractBaseApi
     public function setHidden(bool $hidden): void
     {
         $this->hidden = $hidden;
+    }
+
+    /**
+     * Get the user who uploaded the file.
+     *
+     * Only populated when the file was fetched with `include[]=user`
+     * (e.g. `$course->files(['include' => ['user']])`); returns null otherwise.
+     *
+     * @return UserDisplay|null
+     */
+    public function getUser(): ?UserDisplay
+    {
+        return $this->user;
+    }
+
+    /**
+     * Set the uploader of the file
+     *
+     * @param UserDisplay|null $user
+     */
+    public function setUser(?UserDisplay $user): void
+    {
+        $this->user = $user;
     }
 
     // Relationship Methods

--- a/src/Objects/UserDisplay.php
+++ b/src/Objects/UserDisplay.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CanvasLMS\Objects;
+
+/**
+ * Class UserDisplay
+ *
+ * Represents Canvas's abbreviated "UserDisplay" user representation. Canvas embeds this
+ * compact object (rather than a full User resource) on other objects when the API is asked
+ * to include user information alongside them, e.g. the uploader of a file when a course's
+ * file listing is requested with `include[]=user`.
+ *
+ * This is a read-only data object with no API endpoints of its own - it is only ever
+ * returned nested inside another resource's response.
+ *
+ * @see https://canvas.instructure.com/doc/api/all_resources.html#UserDisplay
+ *
+ * @package CanvasLMS\Objects
+ */
+class UserDisplay
+{
+    /**
+     * The user's ID
+     *
+     * @var int|null
+     */
+    public ?int $id = null;
+
+    /**
+     * A short name the user has selected, for use in conversations or other less formal
+     * contexts
+     *
+     * @var string|null
+     */
+    public ?string $displayName = null;
+
+    /**
+     * If avatars are enabled, this will be a URL to the user's avatar
+     *
+     * @var string|null
+     */
+    public ?string $avatarImageUrl = null;
+
+    /**
+     * URL to access user, either nested to a context or directly
+     *
+     * @var string|null
+     */
+    public ?string $htmlUrl = null;
+
+    /**
+     * Optional: This user's pronouns
+     *
+     * @var string|null
+     */
+    public ?string $pronouns = null;
+
+    /**
+     * Optional: This user's anonymous id, for use in an assignment with anonymous grading
+     * or peer review
+     *
+     * @var string|null
+     */
+    public ?string $anonymousId = null;
+
+    /**
+     * UserDisplay constructor.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $key => $value) {
+            $property = lcfirst(str_replace('_', '', ucwords($key, '_')));
+
+            if (property_exists($this, $property) && !is_null($value)) {
+                $this->{$property} = $value;
+            }
+        }
+    }
+}

--- a/tests/Api/Courses/CourseRelationshipTest.php
+++ b/tests/Api/Courses/CourseRelationshipTest.php
@@ -254,6 +254,71 @@ class CourseRelationshipTest extends TestCase
         $this->assertEquals(1, $files[0]->id);
     }
 
+    public function testFilesForwardsIncludeUserAsBracketedQueryParam(): void
+    {
+        $responseData = [
+            ['id' => 1, 'display_name' => 'file1.pdf', 'filename' => 'file1.pdf'],
+        ];
+
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => ['include[]' => ['user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        $files = $this->course->files(['include' => ['user']]);
+
+        $this->assertCount(1, $files);
+    }
+
+    public function testFilesExposesUploaderWhenIncludeUserRequested(): void
+    {
+        $responseData = [
+            [
+                'id' => 1,
+                'display_name' => 'infringing-material.pdf',
+                'filename' => 'infringing-material.pdf',
+                'user' => [
+                    'id' => 555,
+                    'display_name' => 'Jane Lecturer',
+                    'avatar_image_url' => 'https://canvas.example.com/avatars/555.png',
+                    'html_url' => 'https://canvas.example.com/users/555',
+                ],
+            ],
+        ];
+
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn($responseData);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->httpClient
+            ->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => ['include[]' => ['user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        $files = $this->course->files(['include' => ['user']]);
+
+        $uploader = $files[0]->getUser();
+        $this->assertNotNull($uploader);
+        $this->assertSame(555, $uploader->id);
+        $this->assertSame('Jane Lecturer', $uploader->displayName);
+        $this->assertSame('https://canvas.example.com/avatars/555.png', $uploader->avatarImageUrl);
+        $this->assertSame('https://canvas.example.com/users/555', $uploader->htmlUrl);
+    }
+
     public function testRubricsReturnsArrayOfRubrics(): void
     {
         $responseData = [

--- a/tests/Api/Files/FileContextTest.php
+++ b/tests/Api/Files/FileContextTest.php
@@ -124,6 +124,135 @@ class FileContextTest extends TestCase
         $this->assertEquals(789, $files[0]->getContextId());
     }
 
+    public function testFetchByContextForCourseForwardsIncludeUserAsBracketedParam(): void
+    {
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([
+                ['id' => 3, 'filename' => 'syllabus.pdf', 'display_name' => 'Course Syllabus'],
+            ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->mockClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => ['include[]' => ['user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        $files = File::fetchByContext('courses', 123, ['include' => ['user']]);
+
+        $this->assertCount(1, $files);
+    }
+
+    public function testFetchCourseFilesForwardsIncludeUserAsBracketedParam(): void
+    {
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([
+                ['id' => 5, 'filename' => 'lecture.pdf', 'display_name' => 'Lecture Notes'],
+            ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->mockClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/789/files', ['query' => ['include[]' => ['user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        File::fetchCourseFiles(789, ['include' => ['user']]);
+    }
+
+    public function testFetchByContextPreservesExistingBracketedIncludeParam(): void
+    {
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        // Callers may also use the SDK-wide 'include[]' literal-key convention directly
+        // (as documented on Course::enrollments()); it must pass through untouched and
+        // merge with any plain 'include' array given alongside it.
+        $this->mockClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => ['include[]' => ['usage_rights', 'user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        File::fetchByContext('courses', 123, [
+            'include[]' => ['usage_rights'],
+            'include' => ['user'],
+        ]);
+    }
+
+    public function testFileExposesUploaderWhenIncludeUserRequested(): void
+    {
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([
+                [
+                    'id' => 3,
+                    'filename' => 'infringing-material.pdf',
+                    'display_name' => 'Infringing Material',
+                    'user' => [
+                        'id' => 555,
+                        'display_name' => 'Jane Lecturer',
+                        'avatar_image_url' => 'https://canvas.example.com/avatars/555.png',
+                        'html_url' => 'https://canvas.example.com/users/555',
+                        'pronouns' => 'she/her',
+                        'anonymous_id' => 'xyz789',
+                    ],
+                ],
+            ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->mockClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => ['include[]' => ['user']]])
+            ->willReturn($mockPaginatedResponse);
+
+        $files = File::fetchByContext('courses', 123, ['include' => ['user']]);
+
+        $uploader = $files[0]->getUser();
+        $this->assertNotNull($uploader);
+        $this->assertSame(555, $uploader->id);
+        $this->assertSame('Jane Lecturer', $uploader->displayName);
+        $this->assertSame('https://canvas.example.com/avatars/555.png', $uploader->avatarImageUrl);
+        $this->assertSame('https://canvas.example.com/users/555', $uploader->htmlUrl);
+        $this->assertSame('she/her', $uploader->pronouns);
+        $this->assertSame('xyz789', $uploader->anonymousId);
+    }
+
+    public function testFileUserIsNullWithoutIncludeUser(): void
+    {
+        $mockPaginatedResponse = $this->createMock(\CanvasLMS\Pagination\PaginatedResponse::class);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getJsonData')
+            ->willReturn([
+                ['id' => 3, 'filename' => 'syllabus.pdf', 'display_name' => 'Course Syllabus'],
+            ]);
+        $mockPaginatedResponse->expects($this->once())
+            ->method('getNext')
+            ->willReturn(null);
+
+        $this->mockClient->expects($this->once())
+            ->method('getPaginated')
+            ->with('courses/123/files', ['query' => []])
+            ->willReturn($mockPaginatedResponse);
+
+        $files = File::fetchByContext('courses', 123);
+
+        $this->assertNull($files[0]->getUser());
+    }
+
     public function testUploadToContextForCourse(): void
     {
         // Create a temporary file

--- a/tests/Api/Files/FileTest.php
+++ b/tests/Api/Files/FileTest.php
@@ -618,6 +618,56 @@ class FileTest extends TestCase
         $this->assertFalse($file->isHidden());
     }
 
+    public function testConstructorHydratesNestedUserObject(): void
+    {
+        $file = new File([
+            'id' => 123,
+            'display_name' => 'Test File',
+            'user' => [
+                'id' => 555,
+                'display_name' => 'Jane Lecturer',
+                'avatar_image_url' => 'https://example.com/avatar.png',
+                'html_url' => 'https://example.com/users/555',
+                'pronouns' => 'she/her',
+                'anonymous_id' => 'xyz789',
+            ],
+        ]);
+
+        $uploader = $file->getUser();
+
+        $this->assertInstanceOf(\CanvasLMS\Objects\UserDisplay::class, $uploader);
+        $this->assertSame(555, $uploader->id);
+        $this->assertSame('Jane Lecturer', $uploader->displayName);
+        $this->assertSame('https://example.com/avatar.png', $uploader->avatarImageUrl);
+        $this->assertSame('https://example.com/users/555', $uploader->htmlUrl);
+        $this->assertSame('she/her', $uploader->pronouns);
+        $this->assertSame('xyz789', $uploader->anonymousId);
+    }
+
+    public function testGetUserReturnsNullWhenNotIncluded(): void
+    {
+        $file = new File([
+            'id' => 123,
+            'display_name' => 'Test File',
+        ]);
+
+        $this->assertNull($file->getUser());
+    }
+
+    public function testSetUser(): void
+    {
+        $file = new File(['id' => 123]);
+        $this->assertNull($file->getUser());
+
+        $uploader = new \CanvasLMS\Objects\UserDisplay(['id' => 42, 'display_name' => 'Manual Uploader']);
+        $file->setUser($uploader);
+
+        $this->assertSame($uploader, $file->getUser());
+
+        $file->setUser(null);
+        $this->assertNull($file->getUser());
+    }
+
     /**
      * Test file upload to S3 with external URLs
      */

--- a/tests/Objects/UserDisplayTest.php
+++ b/tests/Objects/UserDisplayTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Objects;
+
+use CanvasLMS\Objects\UserDisplay;
+use PHPUnit\Framework\TestCase;
+
+class UserDisplayTest extends TestCase
+{
+    public function testConstructorWithFullData(): void
+    {
+        $data = [
+            'id' => 42,
+            'display_name' => 'Jane Lecturer',
+            'avatar_image_url' => 'https://canvas.example.com/avatars/42.png',
+            'html_url' => 'https://canvas.example.com/users/42',
+            'pronouns' => 'she/her',
+            'anonymous_id' => 'abc123',
+        ];
+
+        $userDisplay = new UserDisplay($data);
+
+        $this->assertSame(42, $userDisplay->id);
+        $this->assertSame('Jane Lecturer', $userDisplay->displayName);
+        $this->assertSame('https://canvas.example.com/avatars/42.png', $userDisplay->avatarImageUrl);
+        $this->assertSame('https://canvas.example.com/users/42', $userDisplay->htmlUrl);
+        $this->assertSame('she/her', $userDisplay->pronouns);
+        $this->assertSame('abc123', $userDisplay->anonymousId);
+    }
+
+    public function testConstructorWithEmptyData(): void
+    {
+        $userDisplay = new UserDisplay();
+
+        $this->assertNull($userDisplay->id);
+        $this->assertNull($userDisplay->displayName);
+        $this->assertNull($userDisplay->avatarImageUrl);
+        $this->assertNull($userDisplay->htmlUrl);
+        $this->assertNull($userDisplay->pronouns);
+        $this->assertNull($userDisplay->anonymousId);
+    }
+
+    public function testConstructorIgnoresUnknownFields(): void
+    {
+        $userDisplay = new UserDisplay([
+            'id' => 7,
+            'display_name' => 'John Uploader',
+            'unknown_field' => 'ignored',
+        ]);
+
+        $this->assertSame(7, $userDisplay->id);
+        $this->assertSame('John Uploader', $userDisplay->displayName);
+        $this->assertFalse(property_exists($userDisplay, 'unknownField'));
+    }
+
+    public function testConstructorIgnoresNullValues(): void
+    {
+        $userDisplay = new UserDisplay([
+            'id' => 7,
+            'display_name' => null,
+        ]);
+
+        $this->assertSame(7, $userDisplay->id);
+        $this->assertNull($userDisplay->displayName);
+    }
+}


### PR DESCRIPTION
Fixes #171

## What

Canvas's `GET /courses/:id/files?include[]=user` endpoint embeds the uploader on each
file, but the SDK neither forwarded the `include` query param nor modeled the nested
`user` object, so the raw data wasn't reachable even though Canvas already returns it.

## Why

Requester's use case: copyright enforcement. When a file needs to come down, they need
to know who uploaded it so they can contact the lecturer directly - today there's no way
to get that from `$course->files()`.

## How

- `File::fetchByContext()` (and therefore `Course::files()`, `File::fetchCourseFiles()`,
  `fetchUserFiles()`, `fetchGroupFiles()`), plus `File::get()`/`paginate()`/`all()`, now
  normalize a caller-friendly `['include' => ['user']]` array into Canvas's bracketed
  `include[]=...` query form before it reaches the HTTP client. Guzzle's query builder
  repeats a given key verbatim for array values instead of appending `[]` automatically,
  so a plain `'include'` key alone would produce `include=user` (which Canvas/Rack
  doesn't parse as multi-value) - the fix rewrites it to `include[]=user`. The SDK-wide
  `'include[]'` literal-key convention (already used by e.g. `Course::enrollments()`)
  keeps working unchanged and merges with a plain `include` array if both are passed.
  This is generic to any Canvas file include, not just `user` (e.g. `usage_rights`).
- `File` now hydrates a nested `user` object into a new `CanvasLMS\Objects\UserDisplay`
  (Canvas's abbreviated user representation: `id`, `displayName`, `avatarImageUrl`,
  `htmlUrl`, `pronouns`, `anonymousId`), following the same "extract nested data before
  calling the parent constructor" pattern `GroupMembership` already uses for its own
  nested `user`/`group` objects. Exposed via `File::getUser()`/`setUser()`; `null` when
  the file wasn't fetched with `include[]=user`.
- Purely additive - no existing method signatures or the `File` shape changed.

## How to test

```php
use CanvasLMS\Api\Courses\Course;

$course = Course::find(123);
$files = $course->files(['include' => ['user']]);

foreach ($files as $file) {
    $uploader = $file->getUser(); // CanvasLMS\Objects\UserDisplay|null
    if ($uploader !== null) {
        echo "{$file->getDisplayName()} uploaded by {$uploader->displayName} ({$uploader->htmlUrl})\n";
    }
}
```

- [x] `docker compose exec php composer check` passes (PSR-12, PHP-CS-Fixer, PHPStan
      level 8, PHPUnit - 2510 tests / 21318 assertions, 0 failures)
- [x] New tests cover: `include=user` forwarded as `include[]=user` on the wire (both via
      `File::fetchByContext()`/`fetchCourseFiles()` and through `Course::files()`), a file
      with a nested `user` exposing it via `getUser()`, a file without `user` returning
      `null` (backward compat), and the existing bracketed `include[]` convention still
      passing through untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File listings can now include uploader details when requested.
  * Added access to uploader name, ID, avatar, profile link, and pronouns.
  * Include parameters now accept both user-friendly and Canvas query formats.
* **Documentation**
  * Added examples showing how to retrieve and display file uploader information.
* **Bug Fixes**
  * Preserved existing include options while adding new requested values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->