### PR TITLE
fix: Guzzle 8 support (allow ^8.0.0 + make code compatible)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "ext-json": "*",
         "ext-curl": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.4.5",
+        "guzzlehttp/guzzle": "^7.4.5 || ^8.0.0",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^3.0"
     },

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,3 +3,11 @@ parameters:
 	paths:
 		- src
 	tmpDir: tmp
+	ignoreErrors:
+		# GuzzleHttp\HandlerStack declares @template only on Guzzle 8, not on Guzzle 7.
+		# Annotating the generic would fail the lowest-deps (Guzzle 7) run, so we ignore
+		# the missing-type-params report and let it match only on the Guzzle 8 run.
+		-
+			message: '#with generic class GuzzleHttp\\HandlerStack does not specify its types#'
+			path: src/Http/HttpClient.php
+			reportUnmatched: false

--- a/src/Auth/OAuth.php
+++ b/src/Auth/OAuth.php
@@ -12,6 +12,7 @@ use CanvasLMS\Http\HttpClient;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Traits\ActivityLoggingTrait;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 
@@ -173,7 +174,7 @@ class OAuth
                 'error' => $e->getMessage(),
                 'code' => $e->getCode(),
             ]);
-            $response = $e->getResponse();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
             if ($response) {
                 $error = $response->getBody()->getContents();
             } else {
@@ -266,7 +267,7 @@ class OAuth
 
             return $data;
         } catch (RequestException $e) {
-            $response = $e->getResponse();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
             if ($response) {
                 $error = $response->getBody()->getContents();
             } else {
@@ -356,7 +357,7 @@ class OAuth
                 'error' => $e->getMessage(),
                 'code' => $e->getCode(),
             ]);
-            $response = $e->getResponse();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
             if ($response) {
                 $error = $response->getBody()->getContents();
             } else {
@@ -429,7 +430,7 @@ class OAuth
 
             return $data['session_url'];
         } catch (RequestException $e) {
-            $response = $e->getResponse();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
             if ($response) {
                 $error = $response->getBody()->getContents();
             } else {

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -14,6 +14,7 @@ use CanvasLMS\Http\Middleware\MiddlewareInterface;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Pagination\PaginatedResponse;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
@@ -328,8 +329,9 @@ class HttpClient implements HttpClientInterface
         } catch (RequestException $e) {
             $this->logger->error($e->getMessage());
             $errors = [];
-            if ($e->getResponse()) {
-                $body = $e->getResponse()->getBody()->getContents();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
+            if ($response !== null) {
+                $body = $response->getBody()->getContents();
                 if ($body) {
                     $decoded = json_decode($body, true);
                     if (is_array($decoded) && isset($decoded['errors'])) {
@@ -465,8 +467,9 @@ class HttpClient implements HttpClientInterface
         } catch (RequestException $e) {
             $this->logger->error($e->getMessage());
             $errors = [];
-            if ($e->getResponse()) {
-                $body = $e->getResponse()->getBody()->getContents();
+            $response = $e instanceof BadResponseException ? $e->getResponse() : null;
+            if ($response !== null) {
+                $body = $response->getBody()->getContents();
                 if ($body) {
                     $decoded = json_decode($body, true);
                     if (is_array($decoded) && isset($decoded['errors'])) {

--- a/src/Http/Middleware/LoggingMiddleware.php
+++ b/src/Http/Middleware/LoggingMiddleware.php
@@ -226,7 +226,7 @@ class LoggingMiddleware extends AbstractMiddleware
         }
 
         // Add response details if available
-        if ($reason instanceof \GuzzleHttp\Exception\RequestException && $reason->hasResponse()) {
+        if ($reason instanceof \GuzzleHttp\Exception\BadResponseException) {
             $response = $reason->getResponse();
             if ($response !== null) {
                 $context['status_code'] = $response->getStatusCode();

--- a/src/Http/Middleware/OAuth2RefreshMiddleware.php
+++ b/src/Http/Middleware/OAuth2RefreshMiddleware.php
@@ -6,6 +6,7 @@ namespace CanvasLMS\Http\Middleware;
 
 use CanvasLMS\Auth\OAuth;
 use CanvasLMS\Config;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -84,7 +85,7 @@ class OAuth2RefreshMiddleware extends AbstractMiddleware
                         },
                         function ($reason) use ($handler, $request, $options) {
                             if ($reason instanceof RequestException) {
-                                $response = $reason->getResponse();
+                                $response = $reason instanceof BadResponseException ? $reason->getResponse() : null;
                                 if ($response && $response->getStatusCode() === 401) {
                                     // Try refreshing token
                                     try {

--- a/src/Http/Middleware/RateLimitMiddleware.php
+++ b/src/Http/Middleware/RateLimitMiddleware.php
@@ -303,7 +303,7 @@ class RateLimitMiddleware extends AbstractMiddleware
     private function isRateLimitError($reason): bool
     {
         if ($reason instanceof \GuzzleHttp\Exception\RequestException) {
-            $response = $reason->getResponse();
+            $response = $reason instanceof \GuzzleHttp\Exception\BadResponseException ? $reason->getResponse() : null;
             if ($response && $response->getStatusCode() === 403) {
                 // Check for Canvas rate limit indicators
                 if ($response->hasHeader('X-Rate-Limit-Remaining')) {

--- a/src/Http/Middleware/RetryMiddleware.php
+++ b/src/Http/Middleware/RetryMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CanvasLMS\Http\Middleware;
 
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\Create;
@@ -105,7 +106,7 @@ class RetryMiddleware extends AbstractMiddleware
         }
 
         if ($reason instanceof RequestException) {
-            $response = $reason->getResponse();
+            $response = $reason instanceof BadResponseException ? $reason->getResponse() : null;
             if ($response !== null) {
                 return $this->shouldRetry($attempt, $response, null);
             }

--- a/tests/Http/HttpClientRawUrlTest.php
+++ b/tests/Http/HttpClientRawUrlTest.php
@@ -10,7 +10,7 @@ use CanvasLMS\Exceptions\MissingApiKeyException;
 use CanvasLMS\Exceptions\MissingBaseUrlException;
 use CanvasLMS\Http\HttpClient;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\BadResponseException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -268,7 +268,7 @@ class HttpClientRawUrlTest extends TestCase
         $mockErrorResponse->method('getBody')
             ->willReturn($mockErrorStream);
 
-        $exception = new RequestException(
+        $exception = new BadResponseException(
             'Not Found',
             $mockRequest,
             $mockErrorResponse

--- a/tests/Http/Middleware/OAuth2RefreshMiddlewareTest.php
+++ b/tests/Http/Middleware/OAuth2RefreshMiddlewareTest.php
@@ -7,6 +7,7 @@ namespace CanvasLMS\Tests\Http\Middleware;
 use CanvasLMS\Config;
 use CanvasLMS\Http\Middleware\OAuth2RefreshMiddleware;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -148,7 +149,7 @@ class OAuth2RefreshMiddlewareTest extends TestCase
 
         // First call 401s, the retried call succeeds
         $this->mockHandler->append(
-            new RequestException(
+            new BadResponseException(
                 'Unauthorized',
                 new Request('GET', '/api/v1/courses'),
                 new Response(401, [], json_encode(['errors' => [['message' => 'Invalid access token']]]))
@@ -196,7 +197,7 @@ class OAuth2RefreshMiddlewareTest extends TestCase
         \CanvasLMS\Auth\OAuth::setHttpClient($mockOAuthClient);
 
         $this->mockHandler->append(
-            new RequestException(
+            new BadResponseException(
                 'Unauthorized',
                 new Request('GET', '/api/v1/courses'),
                 new Response(401)
@@ -230,7 +231,7 @@ class OAuth2RefreshMiddlewareTest extends TestCase
         $this->middleware->configure(['retry_on_401' => false]);
 
         $this->mockHandler->append(
-            new RequestException(
+            new BadResponseException(
                 'Unauthorized',
                 new Request('GET', '/api/v1/courses'),
                 new Response(401)
@@ -316,7 +317,7 @@ class OAuth2RefreshMiddlewareTest extends TestCase
         Config::setOAuthToken('valid_token');
 
         $this->mockHandler->append(
-            new RequestException(
+            new BadResponseException(
                 'Server Error',
                 new Request('GET', '/api/v1/courses'),
                 new Response(500, [], json_encode(['error' => 'internal_server_error']))

--- a/tests/Pagination/EdgeCaseTest.php
+++ b/tests/Pagination/EdgeCaseTest.php
@@ -9,6 +9,7 @@ use CanvasLMS\Api\Enrollments\Enrollment;
 use CanvasLMS\Config;
 use CanvasLMS\Interfaces\HttpClientInterface;
 use CanvasLMS\Pagination\PaginatedResponse;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -125,7 +126,7 @@ class EdgeCaseTest extends TestCase
         $mockFirstResponse->method('getHeader')->with('Link')->willReturn([$linkHeader]);
 
         // Second call - rate limited (429)
-        $rateLimitException = new RequestException(
+        $rateLimitException = new BadResponseException(
             'Too Many Requests',
             new Request('GET', '/courses?page=2'),
             new Response(429, ['Retry-After' => '2'])
@@ -176,10 +177,7 @@ class EdgeCaseTest extends TestCase
         // Second page - timeout
         $timeoutException = new RequestException(
             'Connection timeout',
-            new Request('GET', '/courses/1/modules?page=2'),
-            null,
-            null,
-            ['errno' => CURLE_OPERATION_TIMEDOUT]
+            new Request('GET', '/courses/1/modules?page=2')
         );
 
         $this->mockHttpClient->expects($this->once())


### PR DESCRIPTION
Allows `guzzlehttp/guzzle: ^7.4.5 || ^8.0.0` (supersedes #182) and makes the code compatible with Guzzle 8.

**Why the code change:** Guzzle 8 removed `getResponse()`/`hasResponse()` from `RequestException`; the response now lives on `BadResponseException` (via `ResponseException`). Every response access is guarded with `instanceof BadResponseException`, which is correct on **both** Guzzle 7 and 8. Tests that build response-carrying exceptions now use `BadResponseException`. The `HandlerStack` generic (templated only on Guzzle 8) is ignored in phpstan config so the lowest-deps run stays green.

**Verified** replicating the CI matrix locally:
- PHPStan: green on Guzzle 7 and 8
- PHPUnit: 2510 tests pass on Guzzle 7 and 8
- phpcs PSR12 + php-cs-fixer: clean

Closes #182.